### PR TITLE
Correct invalid import paths in `index.d.ts` files.

### DIFF
--- a/build-support/shims/index-aliases.js
+++ b/build-support/shims/index-aliases.js
@@ -1,0 +1,10 @@
+/* globals define */
+
+enifed('htmlbars', enifed.alias('htmlbars/index'));
+enifed('htmlbars-compiler', enifed.alias('htmlbars-compiler/index'));
+enifed('htmlbars-syntax', enifed.alias('htmlbars-syntax/index'));
+enifed('htmlbars-util', enifed.alias('htmlbars-util/index'));
+enifed('htmlbars-runtime', enifed.alias('htmlbars-runtime/index'));
+enifed('htmlbars-reference', enifed.alias('htmlbars-reference/index'));
+enifed('htmlbars-test-helpers', enifed.alias('htmlbars-test-helpers/index'));
+enifed('htmlbars-object', enifed.alias('htmlbars-object/index'));

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -50,19 +50,19 @@ module.exports = function() {
     include: ['*/index.d.ts'],
 
     getDestinationPath: function(relativePath) {
-      return relativePath.replace(/\/index\.d\.ts$/, '.js');
+      return relativePath.replace(/\.d\.ts$/, '.js');
     }
   });
 
   var tsTree = new Funnel('packages', {
     include: ["**/*.ts"],
-    exclude: ["**/*.d.ts"]
+    exclude: ['**/*.d.ts']
   });
 
   var jsTree = typescript(tsTree);
 
   var libTree = new Funnel(jsTree, {
-    include: ["*/lib/**/*.js"],
+    include: ["*/lib/**/*.js"]
   });
 
   var packagesTree = mergeTrees([DTSTree, libTree, HTMLTokenizer]);
@@ -98,17 +98,18 @@ module.exports = function() {
     destDir: '/tests'
   });
 
+  var shims = new Funnel('build-support/shims');
   var transpiledCompiler = transpile(compilerTree, 'transpiledLibs');
   var transpiledRuntime = transpile(runtimeTree, 'transpiledRuntime');
   var transpiledTests = transpile(testTree, 'transpiledTests');
 
-  var concatenatedCompiler = concatFiles(transpiledCompiler, {
+  var concatenatedCompiler = concatFiles(mergeTrees([transpiledCompiler, shims]), {
     inputFiles: ['**/*.js'],
     outputFile: '/amd/glimmer-compiler.amd.js',
     sourceMapConfig: { enabled: true }
   });
 
-  var concatenatedRuntime = concatFiles(transpiledRuntime, {
+  var concatenatedRuntime = concatFiles(mergeTrees([transpiledRuntime, shims]), {
     inputFiles: ['**/*.js'],
     outputFile: '/amd/glimmer-runtime.amd.js',
     sourceMapConfig: { enabled: true }

--- a/packages/htmlbars-syntax/tests/loc-node-test.ts
+++ b/packages/htmlbars-syntax/tests/loc-node-test.ts
@@ -1,4 +1,4 @@
-import { parse } from "../htmlbars-syntax";
+import { parse } from "../index";
 
 QUnit.module("[htmlbars-syntax] Parser - Location Info");
 

--- a/packages/htmlbars-syntax/tests/parser-node-test.ts
+++ b/packages/htmlbars-syntax/tests/parser-node-test.ts
@@ -1,6 +1,6 @@
-import { parse as handlebarsParse } from "../htmlbars-syntax/handlebars/compiler/base";
-import { parse } from "../htmlbars-syntax";
-import b from "../htmlbars-syntax/builders";
+import { parse as handlebarsParse } from "handlebars/compiler/base";
+import { parse } from "../index";
+import b from "../lib/builders";
 import { astEqual } from "./support";
 
 QUnit.module("[htmlbars-syntax] Parser - AST");

--- a/packages/htmlbars-syntax/tests/plugin-node-test.ts
+++ b/packages/htmlbars-syntax/tests/plugin-node-test.ts
@@ -1,4 +1,4 @@
-import { parse, Walker } from '../htmlbars-syntax';
+import { parse, Walker } from '../index';
 
 QUnit.module('[htmlbars-syntax] Plugins - AST Transforms');
 

--- a/packages/htmlbars-syntax/tests/support.ts
+++ b/packages/htmlbars-syntax/tests/support.ts
@@ -1,4 +1,4 @@
-import { parse } from '../htmlbars-syntax';
+import { parse } from '../index';
 
 function normalizeNode(obj) {
   if (obj && typeof obj === 'object') {

--- a/packages/htmlbars-syntax/tests/traversal/manipulating-node-test.ts
+++ b/packages/htmlbars-syntax/tests/traversal/manipulating-node-test.ts
@@ -7,7 +7,7 @@ import {
 import {
   cannotRemoveNode,
   cannotReplaceNode,
-} from 'htmlbars-syntax/traversal/errors';
+} from 'htmlbars-syntax/lib/traversal/errors';
 
 QUnit.module('[htmlbars-syntax] Traversal - manipulating');
 

--- a/packages/htmlbars-syntax/tests/traversal/visiting-keys-node-test.ts
+++ b/packages/htmlbars-syntax/tests/traversal/visiting-keys-node-test.ts
@@ -1,4 +1,4 @@
-import { parse, traverse } from '../../htmlbars-syntax';
+import { parse, traverse } from '../../index';
 
 function traversalEqual(node, expectedTraversal) {
   let actualTraversal = [];

--- a/packages/htmlbars-syntax/tests/traversal/visiting-node-test.ts
+++ b/packages/htmlbars-syntax/tests/traversal/visiting-node-test.ts
@@ -1,4 +1,4 @@
-import { parse, traverse } from '../../htmlbars-syntax';
+import { parse, traverse } from '../../index';
 
 function traversalEqual(node, expectedTraversal) {
   let actualTraversal = [];

--- a/packages/htmlbars-syntax/tests/traversal/walker-node-test.ts
+++ b/packages/htmlbars-syntax/tests/traversal/walker-node-test.ts
@@ -1,4 +1,4 @@
-import { parse, Walker } from '../../htmlbars-syntax';
+import { parse, Walker } from '../../index';
 
 function compareWalkedNodes(html, expected) {
   var ast = parse(html);

--- a/packages/htmlbars-util/tests/htmlbars-util-test.ts
+++ b/packages/htmlbars-util/tests/htmlbars-util-test.ts
@@ -1,4 +1,4 @@
-import {SafeString} from "../htmlbars-util";
+import {SafeString} from "htmlbars-util";
 
 QUnit.module('htmlbars-util');
 


### PR DESCRIPTION
Prior to this change, the `index.d.ts` files were moved up one directory (and named for their package) but the import paths were not being updated so that the resulting ES6 or AMD output referenced invalid paths.

This change adds define.alias shims for each of the packages, and leaves the `index.d.ts` files within the same level as they are on disk (therefore keeping the import paths correct).

In Ember we will need a little more work during integration (specifically the Ember loader will need to either gain aliases or support for `index` fallback).


Fixes #6.

---

Tested via:

```
ember test --server --no-launch
```

```
open http://localhost:7357/3586/tests/index.html?hidepassed&packages=htmlbars-runtime&module=HTMLBarsComponent%20-%20invocation
```