### PR TITLE
Fix invalid import paths.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
   "name": "htmlbars",
   "dependencies": {
-    "simple-html-tokenizer": "tildeio/simple-html-tokenizer#1982c82fd42088657791ebc0ccb49114f14c5571"
+    "simple-html-tokenizer": "tildeio/simple-html-tokenizer#8b09fc2079877d3477f6a0f140f1bf04cf7e8c91"
   },
   "devDependencies": {
-    "loader.js": "tildeio/loader.js#node-style",
+    "loader.js": "~3.5.0",
     "qunit": "~1.20.0",
     "qunit-phantom-runner": "jonkemp/qunit-phantomjs-runner#7b2034a19a4a66ece427ec96826e34a0782634fa"
   },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -50,7 +50,7 @@ module.exports = function() {
     include: ['*/index.d.ts'],
 
     getDestinationPath: function(relativePath) {
-      return relativePath.replace(/\/index\.d\.ts$/, '.js');
+      return relativePath.replace(/\.d\.ts$/, '.js');
     }
   });
 
@@ -62,7 +62,7 @@ module.exports = function() {
   var jsTree = typescript(tsTree);
 
   var libTree = new Funnel(jsTree, {
-    include: ["*/lib/**/*.js"],
+    include: ["*/lib/**/*.js"]
   });
 
   var packagesTree = mergeTrees([DTSTree, libTree, HTMLTokenizer]);


### PR DESCRIPTION
Previously, the build would move `glimmer*/index.d.ts` to `glimmer*.ts` which made the relative import paths in those files incorrect.

This updates loader.js to include a node style fallback to `/index` if a given module is missing and stops the build tooling from moving the `.d.ts` files.

Also, updates simple-html-tokenizer to fix an invalid entry point module there.

---

Uses changes added in https://github.com/ember-cli/loader.js/pull/61 which adds the `/index` fallback to the loader (released as v3.5.0).

---

Fixes #6.