### PR TITLE
Update license copyright date and link

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Tilde, Inc.
+Copyright (c) 2015 Tilde, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/glimmer/index.d.ts
+++ b/packages/glimmer/index.d.ts
@@ -1,8 +1,8 @@
 /*
  * @overview  Glimmer
- * @copyright Copyright 2011-2014 Tilde Inc. and contributors
+ * @copyright Copyright 2011-2015 Tilde Inc. and contributors
  * @license   Licensed under MIT license
- *            See https://raw.githubusercontent.com/tildeio/htmlbars/master/LICENSE
+ *            See https://raw.githubusercontent.com/tildeio/glimmer/master/LICENSE
  * @version   VERSION_STRING_PLACEHOLDER
  */
 


### PR DESCRIPTION
- Updates the copyright date to 2015
- Fixes link to license that pointed to LICENSE in tildeio/htmlbars