### PR TITLE
Make consumable from Ember without `npm link`.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,5 @@
 {
   "name": "htmlbars",
-  "dependencies": {
-    "simple-html-tokenizer": "tildeio/simple-html-tokenizer#v0.2.1"
-  },
   "devDependencies": {
     "loader.js": "~3.5.0",
     "qunit": "~1.20.0",

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,5 +1,7 @@
 /* globals __dirname */
 
+var path = require('path');
+var existsSync = require('exists-sync');
 var concat = require('broccoli-concat');
 var merge = require('broccoli-merge-trees');
 var typescript = require('broccoli-typescript-compiler');
@@ -17,6 +19,7 @@ function transpile(tree, label) {
 module.exports = function() {
   var packages = __dirname + '/packages/node_modules';
   var bower = __dirname + '/bower_components';
+  var hasBower = existsSync(bower);
 
   var tsOptions = {
     tsconfig: {
@@ -55,7 +58,7 @@ module.exports = function() {
     }
   });
 
-  var demos = merge([
+  var demoTrees = [
     demoConcat,
     find(__dirname + '/demos', {
       include: ['*.html'],
@@ -64,15 +67,20 @@ module.exports = function() {
     find(__dirname + '/bench', {
       include: ['*.html'],
       destDir: 'demos'
-    }),
-    find(__dirname + '/node_modules/benchmark', {
+    })
+  ];
+
+  var benchmarkPath = __dirname + '/node_modules/benchmark';
+  if (existsSync(benchmarkPath)) {
+    demoTrees.push(find(benchmarkPath, {
       include: ['benchmark.js'],
       destDir: 'demos'
-    })
-  ]);
+    }));
+  }
+  var demos = merge(demoTrees);
 
 
-  var tokenizerPath = path.join(require.resolve('simple-html-tokenizer'), '..', 'lib');
+  var tokenizerPath = path.join(require.resolve('simple-html-tokenizer'), '..', '..', 'lib');
   // TODO: WAT, why does { } change the output so much....
   var HTMLTokenizer = find(tokenizerPath, { });
 
@@ -119,19 +127,22 @@ module.exports = function() {
 
   // Test Assets
 
-  var testHarness = find(__dirname + '/tests', {
-    srcDir: '/',
-    files: [ 'index.html' ],
-    destDir: '/tests'
-  });
-
-  testHarness = merge([
-    testHarness,
-    find(bower, {
-      srcDir: '/qunit/qunit',
+  var testHarnessTrees = [
+    find(__dirname + '/tests', {
+      srcDir: '/',
+      files: [ 'index.html' ],
       destDir: '/tests'
     })
-  ]);
+  ];
+
+  if (hasBower) {
+    testHarnessTrees.push(find(bower, {
+      srcDir: '/qunit/qunit',
+      destDir: '/tests'
+    }));
+  }
+
+  var testHarness = merge(testHarnessTrees);
 
   glimmerCommon = transpile(glimmerCommon, 'glimmer-common');
   glimmerCompiler = transpile(glimmerCompiler, 'glimmer-compiler');
@@ -178,19 +189,24 @@ module.exports = function() {
     }
   });
 
-  var loader = find(bower, {
-    srcDir: '/loader.js',
-    files: [ 'loader.js' ],
-    destDir: '/assets'
-  });
-
-  return merge([
-    loader,
+  var finalTrees = [
     testHarness,
     demos,
     glimmerCommon,
     glimmerCompiler,
     glimmerRuntime,
     glimmerTests
-  ]);
+  ];
+
+  if (hasBower) {
+    var loader = find(bower, {
+      srcDir: '/loader.js',
+      files: [ 'loader.js' ],
+      destDir: '/assets'
+    });
+
+    finalTrees.push(loader);
+  }
+
+  return merge(finalTrees);
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -71,8 +71,10 @@ module.exports = function() {
     })
   ]);
 
+
+  var tokenizerPath = path.join(require.resolve('simple-html-tokenizer'), '..', 'lib');
   // TODO: WAT, why does { } change the output so much....
-  var HTMLTokenizer = find(bower + '/simple-html-tokenizer/lib/', { });
+  var HTMLTokenizer = find(tokenizerPath, { });
 
   var tsTree = find(packages, {
     include: ['**/*.ts'],

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "git-repo-version": "^0.1.2",
     "handlebars": "^3.0.2",
     "qunit": "^0.7.2",
+    "simple-html-tokenizer": "^0.2.1",
     "typescript": "next"
   },
   "devDependencies": {


### PR DESCRIPTION
Prior to these changes a few things were missing from a build when just `npm install`'ed (`benchmark` node library, all of bower components libs, etc). 

This PR changes things around so that if devDeps or bower components are missing the main package libs still build properly.