### PR TITLE
Add Conditional References

### DIFF
--- a/packages/node_modules/glimmer-runtime/index.ts
+++ b/packages/node_modules/glimmer-runtime/index.ts
@@ -12,6 +12,8 @@ export { default as Template } from './lib/template';
 
 export { default as SymbolTable } from './lib/symbol-table';
 
+export { ConditionalReference } from './lib/references';
+
 export {
   Templates,
   Append,

--- a/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -289,7 +289,7 @@ export class TestOpcode extends Opcode {
   public type = "test";
 
   evaluate(vm: VM) {
-    vm.frame.setCondition(vm.frame.getOperand());
+    vm.frame.setCondition(vm.env.toConditionalReference(vm.frame.getOperand()));
   }
 
   toJSON(): OpcodeJSON {
@@ -331,7 +331,7 @@ export class JumpIfOpcode extends JumpOpcode {
     let reference = vm.frame.getCondition();
     let value = reference.value();
 
-    if (value && !(Array.isArray(value) && value.length === 0)) {
+    if (value) {
       super.evaluate(vm);
       vm.updateWith(new Assert(reference));
     } else {
@@ -347,7 +347,7 @@ export class JumpUnlessOpcode extends JumpOpcode {
     let reference = vm.frame.getCondition();
     let value = reference.value();
 
-    if (value && !(Array.isArray(value) && value.length === 0)) {
+    if (value) {
       vm.updateWith(new Assert(reference));
     } else {
       super.evaluate(vm);

--- a/packages/node_modules/glimmer-runtime/lib/environment.ts
+++ b/packages/node_modules/glimmer-runtime/lib/environment.ts
@@ -2,8 +2,8 @@ import { Statement as StatementSyntax } from './syntax';
 import { Layout as CompiledLayout } from './compiled/blocks';
 
 import { DOMHelper } from './dom';
-
-import { NULL_REFERENCE } from './references';
+import { Reference } from 'glimmer-reference';
+import { NULL_REFERENCE, ConditionalReference } from './references';
 
 import {
   Component,
@@ -98,6 +98,10 @@ export abstract class Environment {
   constructor(dom: DOMHelper, meta: MetaLookup) {
     this.dom = dom;
     this.meta = meta;
+  }
+
+  toConditionalReference(reference: Reference): ConditionalReference {
+    return new ConditionalReference(reference);
   }
 
   getDOM(): DOMHelper { return this.dom; }

--- a/packages/node_modules/glimmer-runtime/lib/references.ts
+++ b/packages/node_modules/glimmer-runtime/lib/references.ts
@@ -1,9 +1,29 @@
-import { ConstReference, PathReference } from 'glimmer-reference';
+import { ConstReference, PathReference, Reference } from 'glimmer-reference';
 
 export class PrimitiveReference extends ConstReference<any> implements PathReference {
   get(): PathReference {
     return NULL_REFERENCE;
   }
+}
+
+export class ConditionalReference implements Reference {
+  private inner: Reference;
+
+  constructor(inner: Reference) {
+    this.inner = inner;
+  }
+
+  value() {
+    return this.toBool(this.inner.value());
+  }
+
+  protected toBool(value: any): boolean {
+    return !!value;
+  }
+
+  isDirty() { return this.inner.isDirty(); }
+
+  destroy() { return this.inner.destroy(); }
 }
 
 export const NULL_REFERENCE = new PrimitiveReference(null);

--- a/packages/node_modules/glimmer-runtime/tests/updating-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/updating-test.ts
@@ -120,6 +120,21 @@ test("a simple implementation of a dirtying rerender", function() {
   QUnit.notStrictEqual(root.firstChild.firstChild.firstChild, valueNode, "The text node was not blown away");
 });
 
+test('The if helper should consider an empty array falsy', function() {
+  let object: any = { condition: [], value: 'hello world' };
+  let template = compile('<div>{{#if condition}}<p>{{value}}</p>{{else}}<p>Nothing</p>{{/if}}</div>');
+  let result = render(template, object);
+
+  equalTokens(root, '<div><p>Nothing</p></div>');
+
+  object.condition.push('thing');
+  result.rerender();
+  equalTokens(root, '<div><p>hello world</p></div>', "Initial render");
+  object.condition.pop();
+  result.rerender();
+  equalTokens(root, '<div><p>Nothing</p></div>');
+});
+
 test("a simple implementation of a dirtying rerender without inverse", function() {
   let object = { condition: true, value: 'hello world' };
   let template = compile('<div>{{#if condition}}<p>{{value}}</p>{{/if}}</div>');
@@ -136,6 +151,54 @@ test("a simple implementation of a dirtying rerender without inverse", function(
 
   result.rerender();
   equalTokens(root, '<div><p>hello world</p></div>', "If the condition is true, the morph repopulates");
+});
+
+test('The unless helper without inverse', function() {
+  let object: any = { condition: true, value: 'hello world' };
+  let template = compile('<div>{{#unless condition}}<p>{{value}}</p>{{/unless}}</div>');
+  let result = render(template, object);
+
+  equalTokens(root, '<div><!----></div>', "Initial render");
+
+  object.condition = false;
+  result.rerender();
+  equalTokens(root, '<div><p>hello world</p></div>', "If the condition is false, the morph becomes populated");
+  object.condition = true;
+  result.rerender();
+  equalTokens(root, '<div><!----></div>', "If the condition is true, the morph unpopulated");
+});
+
+test('The unless helper with inverse', function() {
+  let object: any = { condition: true, value: 'hello world' };
+  let template = compile('<div>{{#unless condition}}<p>{{value}}</p>{{else}}<p>Nothing</p>{{/unless}}</div>');
+
+  let result = render(template, object);
+
+  equalTokens(root, '<div><p>Nothing</p></div>', "Initial render");
+
+  object.condition = false;
+  result.rerender();
+  equalTokens(root, '<div><p>hello world</p></div>', "If the condition is false, the default renders");
+  object.condition = true;
+  result.rerender();
+  equalTokens(root, '<div><p>Nothing</p></div>', "If the condition is true, the inverse renders");
+});
+
+test('The unless helper should consider an empty array falsy', function() {
+  let object: any = { condition: [], value: 'hello world' };
+  let template = compile('<div>{{#unless condition}}<p>{{value}}</p>{{else}}<p>Nothing</p>{{/unless}}</div>');
+
+  let result = render(template, object);
+
+  equalTokens(root, '<div><p>hello world</p></div>', "Initial render");
+
+  object.condition.push(1);
+  result.rerender();
+  equalTokens(root, '<div><p>Nothing</p></div>', "If the condition is true, the inverse renders");
+
+  object.condition.pop();
+  result.rerender();
+  equalTokens(root, '<div><p>hello world</p></div>', "If the condition is false, the default renders");
 });
 
 test("a conditional that is false on the first run", assert => {
@@ -182,6 +245,19 @@ test("block arguments (ensure balanced push/pop)", assert => {
   result.rerender();
 
   equalTokens(root, '<div>GodfreakOuter</div>', "After updating");
+});
+
+test("The with helper should consider an empty array falsy", assert => {
+  let object = { condition: [] };
+  let template = compile("<div>{{#with condition as |c|}}{{c.length}}{{/with}}</div>");
+  let result = render(template, object);
+
+  equalTokens(root, '<div><!----></div>', "Initial render");
+
+  object.condition.push(1);
+  result.rerender();
+
+  equalTokens(root, '<div>1</div>', "After updating");
 });
 
 test("block helpers whose template has a morph at the edge", function() {

--- a/packages/node_modules/glimmer-test-helpers/lib/environment.ts
+++ b/packages/node_modules/glimmer-test-helpers/lib/environment.ts
@@ -32,6 +32,7 @@ import {
   TestOpcode,
   JumpOpcode,
   JumpUnlessOpcode,
+  JumpIfOpcode,
   NextIterOpcode,
   OpenComponentOpcode,
   CloseComponentOpcode,
@@ -71,7 +72,8 @@ import {
   CompiledExpression,
 
   // References
-  ValueReference
+  ValueReference,
+  ConditionalReference
 } from "glimmer-runtime";
 
 import { compile as rawCompile, compileLayout as rawCompileLayout } from "./helpers";
@@ -79,7 +81,7 @@ import { FIXME, LinkedList, Slice, ListSlice, Dict, InternedString, assign, dict
 
 import GlimmerObject, { GlimmerObjectFactory } from "glimmer-object";
 
-import { Meta } from "glimmer-reference";
+import { Meta, Reference } from "glimmer-reference";
 
 export type Attrs = Dict<any>;
 type AttrsDiff = { oldAttrs: Attrs, newAttrs: Attrs };
@@ -241,6 +243,16 @@ class EmberishCurlyComponentManager implements ComponentManager<EmberishCurlyCom
 
 const EMBERISH_CURLY_COMPONENT_MANAGER = new EmberishCurlyComponentManager();
 
+class EmberishConditionalReference extends ConditionalReference {
+  protected toBool(value: any): boolean {
+    if (Array.isArray(value)) {
+      return value.length > 0;
+    } else {
+      return super.toBool(value);
+    }
+  }
+}
+
 export class TestEnvironment extends Environment {
   private helpers = {};
   private components = dict<ComponentDefinition<any>>();
@@ -274,6 +286,10 @@ export class TestEnvironment extends Environment {
   registerEmberishGlimmerComponent(name: string, Component: EmberishGlimmerComponentFactory, layout: string): ComponentDefinition<EmberishGlimmerComponentDefinition> {
     let definition = new EmberishGlimmerComponentDefinition(name, EMBERISH_GLIMMER_COMPONENT_MANAGER, Component, layout);
     return this.registerComponent(name, definition);
+  }
+
+  toConditionalReference(reference: Reference): ConditionalReference {
+    return new EmberishConditionalReference(reference);
   }
 
   statement<Options>(statement: StatementSyntax): StatementSyntax {
@@ -322,6 +338,8 @@ export class TestEnvironment extends Environment {
           return new IfSyntax({ args: block.args, templates: block.templates });
         case 'with':
           return new WithSyntax({ args: block.args, templates: block.templates });
+        case 'unless':
+          return new UnlessSyntax({ args: block.args, templates: block.templates })
       }
     }
 
@@ -684,6 +702,60 @@ class RenderInverseIdentitySyntax extends StatementSyntax {
 
   compile(compiler: CompileInto) {
     compiler.append(new EvaluateOpcode({ debug: "inverse", block: this.templates.inverse }));
+  }
+}
+
+class UnlessSyntax extends StatementSyntax {
+  type = "unless-statement";
+
+  public args: ArgsSyntax;
+  public templates: Templates;
+  public isStatic = false;
+
+  constructor({ args, templates }: { args: ArgsSyntax, templates: Templates }) {
+    super();
+    this.args = args;
+    this.templates = templates;
+  }
+
+  prettyPrint() {
+    return `#unless ${this.args.prettyPrint()}`;
+  }
+
+  compile(compiler: CompileInto, env: Environment) {
+    //        Enter(BEGIN, END)
+    // BEGIN: Noop
+    //        PutArgs
+    //        Test
+    //        JumpIf(ELSE)
+    //        Evaluate(default)
+    //        JumpOpcode(END)
+    // ELSE:  Noop
+    //        Evalulate(inverse)
+    // END:   Noop
+    //        Exit
+
+    let BEGIN = new LabelOpcode({ label: "BEGIN" });
+    let ELSE = new LabelOpcode({ label: "ELSE" });
+    let END = new LabelOpcode({ label: "END" });
+
+    compiler.append(new EnterOpcode({ begin: BEGIN, end: END }));
+    compiler.append(BEGIN);
+    compiler.append(new PutArgsOpcode({ args: this.args.compile(compiler, env) }));
+    compiler.append(new TestOpcode());
+    if (this.templates.inverse) {
+      compiler.append(new JumpIfOpcode({ target: ELSE }));
+      compiler.append(new EvaluateOpcode({ debug: "default", block: this.templates.default }));
+      compiler.append(new JumpOpcode({ target: END }));
+      compiler.append(ELSE);
+      compiler.append(new EvaluateOpcode({ debug: "inverse", block: this.templates.inverse }));
+    } else {
+      compiler.append(new JumpIfOpcode({ target: END }));
+      compiler.append(new EvaluateOpcode({ debug: "default", block: this.templates.default }));
+    }
+
+    compiler.append(END);
+    compiler.append(new ExitOpcode());
   }
 }
 


### PR DESCRIPTION
This introduces the concept of a conditional reference. This is needed to properly support an `EmberishConditionalReference`. An example of this would be that Ember considers empty arrays in `if` blocks as falsy. This also includes `{{#unless}}` syntax for testing.
Closes #38