### PR TITLE
SVG: Bring back tests for basic behaviors

### DIFF
--- a/packages/node_modules/glimmer-compiler/lib/template-compiler.ts
+++ b/packages/node_modules/glimmer-compiler/lib/template-compiler.ts
@@ -83,6 +83,7 @@ export default class TemplateCompiler {
     if (isStatic) {
       this.opcode('staticAttr', action, name, namespace);
     } else if (action.value.type === 'MustacheStatement') {
+      assert(name.indexOf(':') === -1, `Namespaced attributes cannot be set as props. Perhaps you meant ${name}="{{title}}"`);
       this.opcode('dynamicProp', action, name);
     } else {
       this.opcode('dynamicAttr', action, name, namespace);

--- a/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/dom.ts
@@ -178,7 +178,11 @@ export class NamespacedAttribute implements ElementPatchOperation {
   }
 
   apply(dom: DOMHelper, element: Element, lastValue: string = null): any {
-    let { value: reference, namespace } = this;
+    let {
+      name,
+      value: reference,
+      namespace
+    } = this;
     let value = reference.value();
 
     if (value === lastValue) {

--- a/packages/node_modules/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/node_modules/glimmer-runtime/lib/syntax/core.ts
@@ -77,6 +77,7 @@ import {
   CloseElementOpcode,
   StaticAttrOpcode,
   DynamicAttrOpcode,
+  DynamicAttrNSOpcode,
   DynamicPropOpcode,
   CommentOpcode
 } from '../compiled/opcodes/dom';
@@ -417,8 +418,13 @@ export class DynamicAttr extends AttributeSyntax {
   }
 
   compile(compiler: CompileInto, env: Environment) {
-    compiler.append(new PutValueOpcode({ expression: this.value.compile(compiler, env) }));
-    compiler.append(new DynamicAttrOpcode(this));
+    let {namespace, value} = this;
+    compiler.append(new PutValueOpcode({ expression: value.compile(compiler, env) }));
+    if (namespace) {
+      compiler.append(new DynamicAttrNSOpcode(this));
+    } else {
+      compiler.append(new DynamicAttrOpcode(this));
+    }
   }
 
   valueSyntax(): ExpressionSyntax {

--- a/packages/node_modules/glimmer-runtime/tests/initial-render-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/initial-render-test.ts
@@ -39,23 +39,23 @@ function module(name: string) {
   });
 }
 
-module("Initial render - simple content");
+module("Initial render - Simple HTML, inline expressions");
 
-test("Simple content gets appended properly", function() {
+test("HTML text content", function() {
   let template = compile("content");
   render(template, {});
 
   equalTokens(root, "content");
 });
 
-test("Simple elements are created", function() {
+test("HTML tags", function() {
   let template = compile("<h1>hello!</h1><div>content</div>");
   render(template, {});
 
   equalTokens(root, "<h1>hello!</h1><div>content</div>");
 });
 
-test("Simple elements can be re-rendered", function() {
+test("HTML tags re-rendered", function() {
   let template = compile("<h1>hello!</h1><div>content</div>");
   let result = render(template, {});
 
@@ -67,42 +67,42 @@ test("Simple elements can be re-rendered", function() {
   equalTokens(root, "<h1>hello!</h1><div>content</div>");
 });
 
-test("Simple elements can have attributes", function() {
+test("HTML attributes", function() {
   let template = compile("<div class='foo' id='bar'>content</div>");
   render(template, {});
 
   equalTokens(root, '<div class="foo" id="bar">content</div>');
 });
 
-test("Simple elements can have an empty attribute", function() {
+test("HTML tag with empty attribute", function() {
   let template = compile("<div class=''>content</div>");
   render(template, {});
 
   equalTokens(root, '<div class="">content</div>');
 });
 
-test("presence of `disabled` attribute without value marks as disabled", function() {
+test("HTML boolean attribute 'disabled'", function() {
   let template = compile('<input disabled>');
   render(template, {});
 
   ok(root.firstChild['disabled'], 'disabled without value set as property is true');
 });
 
-test("Null quoted attribute value calls toString on the value", function() {
+test("Quoted attribute expression is coerced to a string", function() {
   let template = compile('<input disabled="{{isDisabled}}">');
   render(template, { isDisabled: null });
 
   ok(root.firstChild['disabled'], 'string of "null" set as property is true');
 });
 
-test("Null unquoted attribute value removes that attribute", function() {
+test("Unquoted attribute expression with null value is not coerced", function() {
   let template = compile('<input disabled={{isDisabled}}>');
   render(template, { isDisabled: null });
 
   equalTokens(root, '<input>');
 });
 
-test("unquoted attribute string is just that", function() {
+test("Unquoted attribute values", function() {
   let template = compile('<input value=funstuff>');
   render(template, {});
 
@@ -112,7 +112,7 @@ test("unquoted attribute string is just that", function() {
   equal(inputNode.value, 'funstuff', 'value is set as property');
 });
 
-test("unquoted attribute expression is string", function() {
+test("Unquoted attribute expression with string value is not coerced", function() {
   let template = compile('<input value={{funstuff}}>');
   render(template, {funstuff: "oh my"});
 
@@ -122,14 +122,14 @@ test("unquoted attribute expression is string", function() {
   equal(inputNode.value, 'oh my', 'string is set to property');
 });
 
-test("unquoted attribute expression works when followed by another attribute", function() {
+test("Attribute expression can be followed by another attribute", function() {
   let template = compile('<div foo="{{funstuff}}" name="Alice"></div>');
   render(template, {funstuff: "oh my"});
 
   equalTokens(root, '<div name="Alice" foo="oh my"></div>');
 });
 
-test("Unquoted attribute value with multiple nodes throws an exception", function () {
+test("Unquoted attribute with expression throws an exception", function () {
   expect(4);
 
   QUnit.throws(function() { compile('<img class=foo{{bar}}>'); }, expectedError(1));
@@ -146,13 +146,13 @@ test("Unquoted attribute value with multiple nodes throws an exception", functio
   }
 });
 
-test("Simple elements can have arbitrary attributes", function() {
+test("HTML tag with data- attribute", function() {
   let template = compile("<div data-some-data='foo'>content</div>");
   render(template, {});
   equalTokens(root, '<div data-some-data="foo">content</div>');
 });
 
-test("checked attribute and checked property are present after clone and hydrate", function() {
+test("<input> tag with 'checked' attribute", function() {
   let template = compile("<input checked=\"checked\">");
   render(template, {});
 

--- a/packages/node_modules/glimmer-runtime/tests/initial-render-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/initial-render-test.ts
@@ -850,16 +850,16 @@ test("error line numbers include multiple mustache lines", function() {
 
 if (document.createElement('div').namespaceURI) {
 
-module("Initial render (svg)");
+module("Initial render of namespaced HTML");
 
-test("Simple elements can have namespaced attributes", function() {
+test("Namespaced attribute", function() {
   compilesTo("<svg xlink:title='svg-title'>content</svg>");
   let svg = root.firstChild;
   equal(svg.namespaceURI, SVG_NAMESPACE);
   equal(svg.attributes[0].namespaceURI, XLINK_NAMESPACE);
 });
 
-test("Simple elements can have bound namespaced attributes", function() {
+test("Namespaced attribute with a quoted expression", function() {
   compilesTo(
     "<svg xlink:title='{{title}}'>content</svg>",
     "<svg xlink:title='svg-title'>content</svg>",
@@ -870,65 +870,77 @@ test("Simple elements can have bound namespaced attributes", function() {
   equal(svg.attributes[0].namespaceURI, XLINK_NAMESPACE);
 });
 
-test("Simple elements cannot have bound namespaced props", function() {
+test("Namespaced attribute with unquoted expression throws", function() {
   QUnit.throws(function() {
     compile("<svg xlink:title={{title}}>content</svg>");
   }, /Namespaced attributes cannot be set as props. Perhaps you meant xlink:title="{{title}}"/);
 });
 
-test("SVG element can have capitalized attributes", function() {
-  compilesTo("<svg viewBox=\"0 0 0 0\"></svg>");
+test("<svg> tag with case-sensitive attribute", function() {
+  let viewBox = '0 0 0 0';
+  compilesTo(`<svg viewBox="${viewBox}"></svg>`);
   let svg = root.firstChild;
   equal(svg.namespaceURI, SVG_NAMESPACE);
+  equal(svg.getAttribute('viewBox'), viewBox);
 });
 
-test("sets namespaces on nested namespaced elements", function() {
-  compilesTo('<svg><path stroke="black" d="M 0 0 L 100 100"></path></svg>');
+test("nested element in the SVG namespace", function() {
+  let d = 'M 0 0 L 100 100';
+  compilesTo(`<svg><path d="${d}"></path></svg>`);
   let svg = root.firstChild;
+  let path = svg.firstChild;
   equal(svg.namespaceURI, SVG_NAMESPACE);
-  equal(svg.firstChild.namespaceURI, SVG_NAMESPACE,
+  equal(path.namespaceURI, SVG_NAMESPACE,
         "creates the path element with a namespace");
+  equal(path.getAttribute('d'), d);
+});
 });
 
-test("sets a namespace on an HTML integration point", function() {
+test("<foreignObject> tag has an SVG namespace", function() {
   compilesTo('<svg><foreignObject>Hi</foreignObject></svg>');
   let svg = root.firstChild;
+  let foreignObject = svg.firstChild;
   equal(svg.namespaceURI, SVG_NAMESPACE);
-  equal(svg.firstChild.namespaceURI, SVG_NAMESPACE,
-        "creates the path element with a namespace");
+  equal(foreignObject.namespaceURI, SVG_NAMESPACE,
+        "creates the foreignObject element with a namespace");
 });
 
 QUnit.skip("does not set a namespace on an element inside an HTML integration point", function() {
   compilesTo('<svg><foreignObject><div></div></foreignObject></svg>');
   let svg = root.firstChild;
+  let foreignObject = svg.firstChild;
+  let div = foreignObject.firstChild;
   equal(svg.namespaceURI, SVG_NAMESPACE);
-  equal(svg.firstChild.namespaceURI, SVG_NAMESPACE,
-        "creates the path element with a namespace");
-  equal(svg.firstChild.firstChild.namespaceURI, XHTML_NAMESPACE,
+  equal(foreignObject.namespaceURI, SVG_NAMESPACE,
+        "creates the foreignObject element with a namespace");
+  equal(div.namespaceURI, XHTML_NAMESPACE,
         "creates the div inside the foreignObject without a namespace");
 });
 
-test("pops back to the correct namespace", function() {
+test("Namespaced and non-namespaced elements as siblings", function() {
   compilesTo('<svg></svg><svg></svg><div></div>');
-  equal(root.firstChild.namespaceURI, SVG_NAMESPACE,
+  let [first, second, third] = root.childNodes;
+  equal(first.namespaceURI, SVG_NAMESPACE,
         "creates the first svg element with a namespace");
-  equal(root.childNodes[1].namespaceURI, SVG_NAMESPACE,
+  equal(second.namespaceURI, SVG_NAMESPACE,
         "creates the second svg element with a namespace");
-  equal(root.lastChild.namespaceURI, XHTML_NAMESPACE,
+  equal(third.namespaceURI, XHTML_NAMESPACE,
         "creates the div element without a namespace");
 });
 
-test("pops back to the correct namespace even if exiting last child", function() {
+test("Namespaced and non-namespaced elements with nesting", function() {
   compilesTo('<div><svg></svg></div><div></div>');
-  equal(root.firstChild.namespaceURI, XHTML_NAMESPACE,
+  let [firstDiv, secondDiv] = root.childNodes;
+  let svg = firstDiv.firstChild;
+  equal(firstDiv.namespaceURI, XHTML_NAMESPACE,
         "first div's namespace is xhtmlNamespace");
-  equal(root.firstChild.firstChild.namespaceURI, SVG_NAMESPACE,
+  equal(svg.namespaceURI, SVG_NAMESPACE,
         "svg's namespace is svgNamespace");
-  equal(root.lastChild.namespaceURI, XHTML_NAMESPACE,
+  equal(secondDiv.namespaceURI, XHTML_NAMESPACE,
         "last div's namespace is xhtmlNamespace");
 });
 
-test("preserves capitalization of tags", function() {
+test("Case-sensitive tag has capitalization preserved", function() {
   compilesTo('<svg><linearGradient id="gradient"></linearGradient></svg>');
 });
 

--- a/packages/node_modules/glimmer-runtime/tests/initial-render-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/initial-render-test.ts
@@ -3,6 +3,10 @@ import { TestEnvironment, normalizeInnerHTML, getTextContent, equalTokens } from
 import { Template } from 'glimmer-runtime';
 import { UpdatableReference } from 'glimmer-reference';
 
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+const XLINK_NAMESPACE = 'http://www.w3.org/1999/xlink';
+const XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+
 let env: TestEnvironment, root: HTMLElement;
 
 function compile(template: string) {
@@ -846,103 +850,87 @@ test("error line numbers include multiple mustache lines", function() {
 
 if (document.createElement('div').namespaceURI) {
 
-// QUnit.module("Initial render (svg)", {
-//   setup: commonSetup
-// });
+module("Initial render (svg)");
 
-// QUnit.skip("Simple elements can have namespaced attributes", function() {
-//   let template = compile("<svg xlink:title='svg-title'>content</svg>");
-//   let svgNode = render(template, {}).fragment.firstChild;
+test("Simple elements can have namespaced attributes", function() {
+  compilesTo("<svg xlink:title='svg-title'>content</svg>");
+  let svg = root.firstChild;
+  equal(svg.namespaceURI, SVG_NAMESPACE);
+  equal(svg.attributes[0].namespaceURI, XLINK_NAMESPACE);
+});
 
-//   equalTokens(svgNode, '<svg xlink:title="svg-title">content</svg>');
-//   equal(svgNode.attributes[0].namespaceURI, 'http://www.w3.org/1999/xlink');
-// });
+test("Simple elements can have bound namespaced attributes", function() {
+  compilesTo(
+    "<svg xlink:title='{{title}}'>content</svg>",
+    "<svg xlink:title='svg-title'>content</svg>",
+    {title: 'svg-title'}
+  );
+  let svg = root.firstChild;
+  equal(svg.namespaceURI, SVG_NAMESPACE);
+  equal(svg.attributes[0].namespaceURI, XLINK_NAMESPACE);
+});
 
-// QUnit.skip("Simple elements can have bound namespaced attributes", function() {
-//   let template = compile("<svg xlink:title={{title}}>content</svg>");
-//   let svgNode = render(template, {title: 'svg-title'}, env).fragment.firstChild;
+test("Simple elements cannot have bound namespaced props", function() {
+  QUnit.throws(function() {
+    compile("<svg xlink:title={{title}}>content</svg>");
+  }, /Namespaced attributes cannot be set as props. Perhaps you meant xlink:title="{{title}}"/);
+});
 
-//   equalTokens(svgNode, '<svg xlink:title="svg-title">content</svg>');
-//   equal(svgNode.attributes[0].namespaceURI, 'http://www.w3.org/1999/xlink');
-// });
+test("SVG element can have capitalized attributes", function() {
+  compilesTo("<svg viewBox=\"0 0 0 0\"></svg>");
+  let svg = root.firstChild;
+  equal(svg.namespaceURI, SVG_NAMESPACE);
+});
 
-// QUnit.skip("SVG element can have capitalized attributes", function() {
-//   let template = compile("<svg viewBox=\"0 0 0 0\"></svg>");
-//   let svgNode = render(template, {}).fragment.firstChild;
-//   equalTokens(svgNode, '<svg viewBox=\"0 0 0 0\"></svg>');
-// });
+test("sets namespaces on nested namespaced elements", function() {
+  compilesTo('<svg><path stroke="black" d="M 0 0 L 100 100"></path></svg>');
+  let svg = root.firstChild;
+  equal(svg.namespaceURI, SVG_NAMESPACE);
+  equal(svg.firstChild.namespaceURI, SVG_NAMESPACE,
+        "creates the path element with a namespace");
+});
 
-// QUnit.skip("The compiler can handle namespaced elements", function() {
-//   let html = '<svg><path stroke="black" d="M 0 0 L 100 100"></path></svg>';
-//   let template = compile(html);
-//   let svgNode = render(template, {}).fragment.firstChild;
+test("sets a namespace on an HTML integration point", function() {
+  compilesTo('<svg><foreignObject>Hi</foreignObject></svg>');
+  let svg = root.firstChild;
+  equal(svg.namespaceURI, SVG_NAMESPACE);
+  equal(svg.firstChild.namespaceURI, SVG_NAMESPACE,
+        "creates the path element with a namespace");
+});
 
-//   equal(svgNode.namespaceURI, svgNamespace, "creates the svg element with a namespace");
-//   equalTokens(svgNode, html);
-// });
+QUnit.skip("does not set a namespace on an element inside an HTML integration point", function() {
+  compilesTo('<svg><foreignObject><div></div></foreignObject></svg>');
+  let svg = root.firstChild;
+  equal(svg.namespaceURI, SVG_NAMESPACE);
+  equal(svg.firstChild.namespaceURI, SVG_NAMESPACE,
+        "creates the path element with a namespace");
+  equal(svg.firstChild.firstChild.namespaceURI, XHTML_NAMESPACE,
+        "creates the div inside the foreignObject without a namespace");
+});
 
-// QUnit.skip("The compiler sets namespaces on nested namespaced elements", function() {
-//   let html = '<svg><path stroke="black" d="M 0 0 L 100 100"></path></svg>';
-//   let template = compile(html);
-//   let svgNode = render(template, {}).fragment.firstChild;
+test("pops back to the correct namespace", function() {
+  compilesTo('<svg></svg><svg></svg><div></div>');
+  equal(root.firstChild.namespaceURI, SVG_NAMESPACE,
+        "creates the first svg element with a namespace");
+  equal(root.childNodes[1].namespaceURI, SVG_NAMESPACE,
+        "creates the second svg element with a namespace");
+  equal(root.lastChild.namespaceURI, XHTML_NAMESPACE,
+        "creates the div element without a namespace");
+});
 
-//   equal( svgNode.childNodes[0].namespaceURI, svgNamespace,
-//          "creates the path element with a namespace" );
-//   equalTokens(svgNode, html);
-// });
+test("pops back to the correct namespace even if exiting last child", function() {
+  compilesTo('<div><svg></svg></div><div></div>');
+  equal(root.firstChild.namespaceURI, XHTML_NAMESPACE,
+        "first div's namespace is xhtmlNamespace");
+  equal(root.firstChild.firstChild.namespaceURI, SVG_NAMESPACE,
+        "svg's namespace is svgNamespace");
+  equal(root.lastChild.namespaceURI, XHTML_NAMESPACE,
+        "last div's namespace is xhtmlNamespace");
+});
 
-// QUnit.skip("The compiler sets a namespace on an HTML integration point", function() {
-//   let html = '<svg><foreignObject>Hi</foreignObject></svg>';
-//   let template = compile(html);
-//   let svgNode = render(template, {}).fragment.firstChild;
-
-//   equal( svgNode.namespaceURI, svgNamespace,
-//          "creates the svg element with a namespace" );
-//   equal( svgNode.childNodes[0].namespaceURI, svgNamespace,
-//          "creates the foreignObject element with a namespace" );
-//   equalTokens(svgNode, html);
-// });
-
-// QUnit.skip("The compiler does not set a namespace on an element inside an HTML integration point", function() {
-//   let html = '<svg><foreignObject><div></div></foreignObject></svg>';
-//   let template = compile(html);
-//   let svgNode = render(template, {}).fragment.firstChild;
-
-//   equal( svgNode.childNodes[0].childNodes[0].namespaceURI, xhtmlNamespace,
-//          "creates the div inside the foreignObject without a namespace" );
-//   equalTokens(svgNode, html);
-// });
-
-// QUnit.skip("The compiler pops back to the correct namespace", function() {
-//   let html = '<svg></svg><svg></svg><div></div>';
-//   let template = compile(html);
-//   let fragment = render(template, {}).fragment;
-
-//   equal( fragment.childNodes[0].namespaceURI, svgNamespace,
-//          "creates the first svg element with a namespace" );
-//   equal( fragment.childNodes[1].namespaceURI, svgNamespace,
-//          "creates the second svg element with a namespace" );
-//   equal( fragment.childNodes[2].namespaceURI, xhtmlNamespace,
-//          "creates the div element without a namespace" );
-//   equalTokens(fragment, html);
-// });
-
-// QUnit.skip("The compiler pops back to the correct namespace even if exiting last child", function () {
-//   let html = '<div><svg></svg></div><div></div>';
-//   let fragment = render(compile(html), {}).fragment;
-
-//   equal(fragment.firstChild.namespaceURI, xhtmlNamespace, "first div's namespace is xhtmlNamespace");
-//   equal(fragment.firstChild.firstChild.namespaceURI, svgNamespace, "svg's namespace is svgNamespace");
-//   equal(fragment.lastChild.namespaceURI, xhtmlNamespace, "last div's namespace is xhtmlNamespace");
-// });
-
-// QUnit.skip("The compiler preserves capitalization of tags", function() {
-//   let html = '<svg><linearGradient id="gradient"></linearGradient></svg>';
-//   let template = compile(html);
-//   let fragment = render(template, {}).fragment;
-
-//   equalTokens(fragment, html);
-// });
+test("preserves capitalization of tags", function() {
+  compilesTo('<svg><linearGradient id="gradient"></linearGradient></svg>');
+});
 
 // QUnit.skip("svg can live with hydration", function() {
 //   let template = compile('<svg></svg>{{name}}');


### PR DESCRIPTION
A first pass at ensuring proper SVG support. There seems to be an outstanding issue with nesting html content inside a `foreignObject` at the least.