### PR TITLE
Add builtin "with" syntax

### DIFF
--- a/packages/node_modules/glimmer-runtime/lib/environment.ts
+++ b/packages/node_modules/glimmer-runtime/lib/environment.ts
@@ -31,6 +31,7 @@ import * as Syntax from './syntax/core';
 
 import IfSyntax from './syntax/builtins/if';
 import UnlessSyntax from './syntax/builtins/unless';
+import WithSyntax from './syntax/builtins/with';
 
 type ScopeSlot = PathReference | InlineBlock;
 
@@ -158,8 +159,8 @@ export abstract class Environment {
         //   return new EachSyntax({ args: block.args, templates: block.templates });
         case 'if':
           return new IfSyntax({ args: block.args, templates: block.templates });
-        // case 'with':
-        //   return new WithSyntax({ args: block.args, templates: block.templates });
+        case 'with':
+          return new WithSyntax({ args: block.args, templates: block.templates });
         case 'unless':
           return new UnlessSyntax({ args: block.args, templates: block.templates });
       }

--- a/packages/node_modules/glimmer-runtime/lib/syntax/builtins/with.ts
+++ b/packages/node_modules/glimmer-runtime/lib/syntax/builtins/with.ts
@@ -1,0 +1,76 @@
+import {
+  CompileInto,
+  Statement as StatementSyntax
+} from '../../syntax';
+
+import {
+  LabelOpcode,
+  EnterOpcode,
+  PutArgsOpcode,
+  TestOpcode,
+  JumpUnlessOpcode,
+  JumpOpcode,
+  EvaluateOpcode,
+  ExitOpcode
+} from '../../compiled/opcodes/vm';
+
+import * as Syntax from '../core';
+import Environment from '../../environment';
+
+export default class WithSyntax extends StatementSyntax {
+  type = "with-statement";
+
+  public args: Syntax.Args;
+  public templates: Syntax.Templates;
+  public isStatic = false;
+
+  constructor({ args, templates }: { args: Syntax.Args, templates: Syntax.Templates }) {
+    super();
+    this.args = args;
+    this.templates = templates;
+  }
+
+  prettyPrint() {
+    return `#with ${this.args.prettyPrint()}`;
+  }
+
+  compile(compiler: CompileInto, env: Environment) {
+    //        Enter(BEGIN, END)
+    // BEGIN: Noop
+    //        PutArgs
+    //        Test
+    //        JumpUnless(ELSE)
+    //        Evaluate(default)
+    //        Jump(END)
+    // ELSE:  Noop
+    //        Evaluate(inverse)
+    // END:   Noop
+    //        Exit
+
+    let BEGIN = new LabelOpcode({ label: "BEGIN" });
+    let ELSE = new LabelOpcode({ label: "ELSE" });
+    let END = new LabelOpcode({ label: "END" });
+
+    compiler.append(new EnterOpcode({ begin: BEGIN, end: END }));
+    compiler.append(BEGIN);
+    compiler.append(new PutArgsOpcode({ args: this.args.compile(compiler, env) }));
+    compiler.append(new TestOpcode());
+
+    if (this.templates.inverse) {
+      compiler.append(new JumpUnlessOpcode({ target: ELSE }));
+    } else {
+      compiler.append(new JumpUnlessOpcode({ target: END }));
+    }
+
+    compiler.append(new EvaluateOpcode({ debug: "default", block: this.templates.default }));
+    compiler.append(new JumpOpcode({ target: END }));
+
+    if (this.templates.inverse) {
+      compiler.append(ELSE);
+      compiler.append(new EvaluateOpcode({ debug: "inverse", block: this.templates.inverse }));
+    }
+
+    compiler.append(END);
+    compiler.append(new ExitOpcode());
+  }
+}

--- a/packages/node_modules/glimmer-test-helpers/lib/environment.ts
+++ b/packages/node_modules/glimmer-test-helpers/lib/environment.ts
@@ -332,8 +332,6 @@ export class TestEnvironment extends Environment {
           return new RenderInverseIdentitySyntax({ args: block.args, templates: block.templates });
         case 'each':
           return new EachSyntax({ args: block.args, templates: block.templates });
-        case 'with':
-          return new WithSyntax({ args: block.args, templates: block.templates });
       }
     }
 
@@ -696,64 +694,6 @@ class RenderInverseIdentitySyntax extends StatementSyntax {
 
   compile(compiler: CompileInto) {
     compiler.append(new EvaluateOpcode({ debug: "inverse", block: this.templates.inverse }));
-  }
-}
-
-class WithSyntax extends StatementSyntax {
-  type = "with-statement";
-
-  public args: ArgsSyntax;
-  public templates: Templates;
-  public isStatic = false;
-
-  constructor({ args, templates }: { args: ArgsSyntax, templates: Templates }) {
-    super();
-    this.args = args;
-    this.templates = templates;
-  }
-
-  prettyPrint() {
-    return `#with ${this.args.prettyPrint()}`;
-  }
-
-  compile(compiler: CompileInto, env: Environment) {
-    //        Enter(BEGIN, END)
-    // BEGIN: Noop
-    //        PutArgs
-    //        Test
-    //        JumpUnless(ELSE)
-    //        Evaluate(default)
-    //        Jump(END)
-    // ELSE:  Noop
-    //        Evaluate(inverse)
-    // END:   Noop
-    //        Exit
-
-    let BEGIN = new LabelOpcode({ label: "BEGIN" });
-    let ELSE = new LabelOpcode({ label: "ELSE" });
-    let END = new LabelOpcode({ label: "END" });
-
-    compiler.append(new EnterOpcode({ begin: BEGIN, end: END }));
-    compiler.append(BEGIN);
-    compiler.append(new PutArgsOpcode({ args: this.args.compile(compiler, env) }));
-    compiler.append(new TestOpcode());
-
-    if (this.templates.inverse) {
-      compiler.append(new JumpUnlessOpcode({ target: ELSE }));
-    } else {
-      compiler.append(new JumpUnlessOpcode({ target: END }));
-    }
-
-    compiler.append(new EvaluateOpcode({ debug: "default", block: this.templates.default }));
-    compiler.append(new JumpOpcode({ target: END }));
-
-    if (this.templates.inverse) {
-      compiler.append(ELSE);
-      compiler.append(new EvaluateOpcode({ debug: "inverse", block: this.templates.inverse }));
-    }
-
-    compiler.append(END);
-    compiler.append(new ExitOpcode());
   }
 }
 


### PR DESCRIPTION
This adds builtin "with" syntax to the environment, however it's
becoming clear that there may be a possibility of creating an opcode
factory of some sort.

Some ideas an API could be something like:

```
appendPreamble('with', compiler);
appendDefault('with', compiler);
appendInverse('with', this.templates.inverse, compiler);
appendConclusion('with', compiler);
```
This can be done as a second pass once all of the builtin syntax has been committed.