### PR TITLE
foreignObject support

### DIFF
--- a/packages/node_modules/glimmer-runtime/lib/dom.ts
+++ b/packages/node_modules/glimmer-runtime/lib/dom.ts
@@ -64,17 +64,18 @@ class DOMHelper {
   }
 
   createElement(tag: string, context: Element): Element {
-    if (context.namespaceURI === SVG_NAMESPACE || tag === 'svg') {
-      // Note: This does not properly handle <font> with color, face, or size attributes, which is also
-      // disallowed by the spec. We should fix this.
+    let isElementInSVGNamespace = context.namespaceURI === SVG_NAMESPACE || tag === 'svg';
+    let isHTMLIntegrationPoint = SVG_INTEGRATION_POINTS[context.tagName];
+    if (isElementInSVGNamespace && !isHTMLIntegrationPoint) {
+      // FIXME: This does not properly handle <font> with color, face, or
+      // size attributes, which is also disallowed by the spec. We should fix
+      // this.
       if (BLACKLIST_TABLE[tag]) {
         throw new Error(`Cannot create a ${tag} inside of a <${context.tagName}>, because it's inside an SVG context`);
       }
-
       return this.document.createElementNS(SVG_NAMESPACE, tag);
-    } else {
-      return this.document.createElement(tag);
     }
+    return this.document.createElement(tag);
   }
 
   insertHTMLBefore(parent: HTMLElement, nextSibling: Node, html: string): Bounds {

--- a/packages/node_modules/glimmer-runtime/tests/initial-render-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/initial-render-test.ts
@@ -906,18 +906,6 @@ test("<foreignObject> tag has an SVG namespace", function() {
         "creates the foreignObject element with a namespace");
 });
 
-test("elements nested inside <foreignObject> have an XHTML namespace", function() {
-  compilesTo('<svg><foreignObject><div></div></foreignObject></svg>');
-  let svg = root.firstChild;
-  let foreignObject = svg.firstChild;
-  let div = foreignObject.firstChild;
-  equal(svg.namespaceURI, SVG_NAMESPACE);
-  equal(foreignObject.namespaceURI, SVG_NAMESPACE,
-        "creates the foreignObject element with a namespace");
-  equal(div.namespaceURI, XHTML_NAMESPACE,
-        "creates the div inside the foreignObject without a namespace");
-});
-
 test("Namespaced and non-namespaced elements as siblings", function() {
   compilesTo('<svg></svg><svg></svg><div></div>');
   let [first, second, third] = root.childNodes;
@@ -1047,27 +1035,3 @@ test("Case-sensitive tag has capitalization preserved", function() {
 //   equal( svgNode.childNodes[0].namespaceURI, svgNamespace,
 //          "circle tag inside block inside svg has an svg namespace" );
 // });
-
-test("HTML namespace from root element is continued to child templates" function() {
-  compilesTo(
-    '<svg>{{#unless}}<circle />{{/unless}}</svg>',
-    "<svg><circle /></svg>"
-  );
-  let svg = root.firstChild;
-  let circle = svg.firstChild;
-  equal(svg.namespaceURI, SVG_NAMESPACE);
-  equal(circle.namespaceURI, SVG_NAMESPACE);
-});
-
-test("root <foreignObject> tag is SVG namespaced" function() {
-  let template = compile('<foreignObject>{{#unless}}<div></div>{{/unless}}</foreignObject>');
-  root = env.getDOM().createElement('svg', document.body) as HTMLDivElement;
-  render(template);
-  let foreignObject = root.firstChild;
-  let div = foreignObject.firstChild;
-  equal(foreignObject.tagName, 'foreignObject');
-  equal(foreignObject.namespaceURI, SVG_NAMESPACE);
-  equal(div.tagName, 'DIV');
-  equal(div.namespaceURI, XHTML_NAMESPACE);
-});
-}

--- a/packages/node_modules/glimmer-runtime/tests/initial-render-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/initial-render-test.ts
@@ -906,7 +906,7 @@ test("<foreignObject> tag has an SVG namespace", function() {
         "creates the foreignObject element with a namespace");
 });
 
-QUnit.skip("does not set a namespace on an element inside an HTML integration point", function() {
+test("elements nested inside <foreignObject> have an XHTML namespace", function() {
   compilesTo('<svg><foreignObject><div></div></foreignObject></svg>');
   let svg = root.firstChild;
   let foreignObject = svg.firstChild;
@@ -1048,15 +1048,26 @@ test("Case-sensitive tag has capitalization preserved", function() {
 //          "circle tag inside block inside svg has an svg namespace" );
 // });
 
-// QUnit.skip("Block helper with root foreignObject allows namespace to bleed through", function() {
-//   registerYieldingHelper('testing');
+test("HTML namespace from root element is continued to child templates" function() {
+  compilesTo(
+    '<svg>{{#unless}}<circle />{{/unless}}</svg>',
+    "<svg><circle /></svg>"
+  );
+  let svg = root.firstChild;
+  let circle = svg.firstChild;
+  equal(svg.namespaceURI, SVG_NAMESPACE);
+  equal(circle.namespaceURI, SVG_NAMESPACE);
+});
 
-//   let template = compile('<foreignObject>{{#testing}}<div></div>{{/testing}}</foreignObject>');
-
-//   let fragment = render(template, { isTrue: true }, env, { contextualElement: document.createElementNS(svgNamespace, 'svg') }).fragment;
-//   let svgNode = fragment.firstChild;
-//   equal( svgNode.namespaceURI, svgNamespace,
-//          "foreignObject tag has an svg namespace" );
-//   equal( svgNode.childNodes[0].namespaceURI, xhtmlNamespace,
-//          "div inside morph and foreignObject has xhtml namespace" );
-// });
+test("root <foreignObject> tag is SVG namespaced" function() {
+  let template = compile('<foreignObject>{{#unless}}<div></div>{{/unless}}</foreignObject>');
+  root = env.getDOM().createElement('svg', document.body) as HTMLDivElement;
+  render(template);
+  let foreignObject = root.firstChild;
+  let div = foreignObject.firstChild;
+  equal(foreignObject.tagName, 'foreignObject');
+  equal(foreignObject.namespaceURI, SVG_NAMESPACE);
+  equal(div.tagName, 'DIV');
+  equal(div.namespaceURI, XHTML_NAMESPACE);
+});
+}

--- a/packages/node_modules/glimmer-runtime/tests/updating-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/updating-test.ts
@@ -3,6 +3,9 @@ import { TestEnvironment, equalTokens, stripTight } from "glimmer-test-helpers";
 import { UpdatableReference } from "glimmer-reference";
 import { assign } from "glimmer-util";
 
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+const XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+
 /*
  * Phantom 1.9 does not serialize namespaced attributes correctly. The namespace
  * prefix is incorrectly stripped off.
@@ -984,3 +987,87 @@ QUnit.skip("Pruned lists invoke a cleanup hook on their subtrees when removing e
   strictEqual(destroyedRenderNodeCount, 6, "cleanup hook was invoked once for the wrapper morph and once for the {{item.word}}");
   strictEqual(destroyedRenderNode.lastValue, "hello", "The correct render node is passed in");
 });
+
+QUnit.module("Updating SVG", {
+  setup: commonSetup
+});
+
+test("HTML namespace from root element is continued to child templates", () => {
+  let object = { hasCircle: true };
+  let getSvg = () => root.firstChild;
+  let getCircle = () => getSvg().firstChild;
+  let template = compile('<svg>{{#if hasCircle}}<circle />{{/if}}</svg>');
+  render(template, object);
+
+  equalTokens(root, "<svg><circle /></svg>");
+  equal(getSvg().namespaceURI, SVG_NAMESPACE);
+  equal(getCircle().namespaceURI, SVG_NAMESPACE);
+
+  object.hasCircle = false;
+  rerender();
+
+  equalTokens(root, "<svg><!----></svg>");
+
+  object.hasCircle = true;
+  rerender();
+
+  equalTokens(root, "<svg><circle /></svg>");
+  equal(getSvg().namespaceURI, SVG_NAMESPACE);
+  equal(getCircle().namespaceURI, SVG_NAMESPACE);
+});
+
+test("root <foreignObject> tag is SVG namespaced" function() {
+  let object = { hasForeignObject: true };
+  let getForeignObject = () => root.firstChild;
+  let getDiv = () => getForeignObject().firstChild;
+  let template = compile('{{#if hasForeignObject}}<foreignObject><div></div></foreignObject>{{/if}}');
+  // Add an SVG node on the root that can be rendered into
+  root.appendChild(env.getDOM().createElement('svg', document.body));
+  root = root.firstChild;
+
+  render(template, object);
+
+  equalTokens(root.parentNode, "<svg><foreignObject><div></div></foreignObject></svg>");
+  equal(getForeignObject().namespaceURI, SVG_NAMESPACE);
+  equal(getDiv().namespaceURI, XHTML_NAMESPACE);
+
+  object.hasForeignObject = false;
+  rerender();
+
+  equalTokens(root.parentNode, "<svg><!----></svg>");
+
+  object.hasForeignObject = true;
+  rerender();
+
+  equalTokens(root.parentNode, "<svg><foreignObject><div></div></foreignObject></svg>");
+  equal(getForeignObject().namespaceURI, SVG_NAMESPACE);
+  equal(getDiv().namespaceURI, XHTML_NAMESPACE);
+});
+
+test("elements nested inside <foreignObject> have an XHTML namespace", function() {
+  let object = { hasDiv: true };
+  let getSvg = () => root.firstChild;
+  let getForeignObject = () => getSvg().firstChild;
+  let getDiv = () => getForeignObject().firstChild;
+  let template = compile('<svg><foreignObject>{{#if hasDiv}}<div></div>{{/if}}</foreignObject></svg>');
+  render(template, object);
+
+  equalTokens(root, "<svg><foreignObject><div></div></foreignObject></svg>");
+  equal(getSvg().namespaceURI, SVG_NAMESPACE);
+  equal(getForeignObject().namespaceURI, SVG_NAMESPACE);
+  equal(getDiv().namespaceURI, XHTML_NAMESPACE);
+
+  object.hasDiv = false;
+  rerender();
+
+  equalTokens(root, "<svg><foreignObject><!----></foreignObject></svg>");
+
+  object.hasDiv = true;
+  rerender();
+
+  equalTokens(root, "<svg><foreignObject><div></div></foreignObject></svg>");
+  equal(getSvg().namespaceURI, SVG_NAMESPACE);
+  equal(getForeignObject().namespaceURI, SVG_NAMESPACE);
+  equal(getDiv().namespaceURI, XHTML_NAMESPACE);
+});
+


### PR DESCRIPTION
TODO:

* This implements foreignObject at dom render time instead of at least partially at parsing time (for example I feel at least flagging what elements are integration points and open SVG namespaces should happen at compile time, no?)
* Consequently there are parser tests for [integration points](https://github.com/tildeio/glimmer/blob/master/packages/node_modules/glimmer-syntax/tests/parser-node-test.ts#L76) and [svg](https://github.com/tildeio/glimmer/blob/master/packages/node_modules/glimmer-syntax/tests/parser-node-test.ts#L51) that are pretty poor, because nothing special is being tested (namespaces are not currently represented on the AST).

Needs a quick discussion.