### PR TITLE
Disable failing tests in PhantomJS 1.9

### DIFF
--- a/packages/node_modules/glimmer-runtime/tests/updating-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/updating-test.ts
@@ -2,6 +2,18 @@ import { Template, RenderResult } from "glimmer-runtime";
 import { TestEnvironment, equalTokens, stripTight } from "glimmer-test-helpers";
 import { UpdatableReference } from "glimmer-reference";
 
+/*
+ * IE9 does not serialize namespaced attributes correctly. The namespace
+ * prefix is incorrectly stripped off.
+ */
+const serializesNSAttributesCorrectly = (function() {
+  let div = document.createElement('div');
+  let span = document.createElement('span');
+  span.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:lang', 'en-uk');
+  div.appendChild(span);
+  return div.innerHTML === '<span xml:lang="en-uk"></span>';
+})();
+
 let hooks, root: Element;
 let env: TestEnvironment;
 let self: UpdatableReference;
@@ -425,6 +437,7 @@ test("attribute nodes w/ concat follow the normal dirtying rules", function() {
   equalTokens(root, "<div data-value='hello world'>hello</div>");
 });
 
+if (serializesNSAttributesCorrectly) {
 test("namespaced attribute nodes follow the normal dirtying rules", function() {
   let template = compile("<div xml:lang='{{lang}}'>hello</div>");
   let object = { lang: "en-us" };
@@ -460,6 +473,7 @@ test("namespaced attribute nodes w/ concat follow the normal dirtying rules", fu
 
   equalTokens(root, "<div xml:lang='en-uk'>hello</div>", "Revalidating after dirtying");
 });
+}
 
 test("non-standard namespaced attribute nodes follow the normal dirtying rules", function() {
   let template = compile("<div epub:type='{{type}}'>hello</div>");


### PR DESCRIPTION
Is there a unified story around browser hacks like this?

Should fix the CI build for Ember.js which runs Phantom 1.9 /cc @rwjblue 

(branch is named IE9, which is just incorrect)