### PR TITLE
Emit ES6 & ES5 output also.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -94,6 +94,7 @@ module.exports = function() {
   var libTree = find(jsTree, {
     include: ['*/index.js', '*/lib/**/*.js']
   });
+  libTree = merge([libTree, HTMLTokenizer, handlebarsInlinedTrees.compiler]);
 
   var es6LibTree = mv(libTree, 'es6');
   libTree = transpile(libTree, 'ES5 Lib Tree');
@@ -117,11 +118,11 @@ module.exports = function() {
     find(libTree, {
       include: [
         'glimmer-syntax/**/*.js',
-        'glimmer-compiler/**/*.js'
+        'glimmer-compiler/**/*.js',
+        'simple-html-tokenizer/**/*.js',
+        'handlebars/**/*.js'
       ]
-    }),
-    HTMLTokenizer,
-    handlebarsInlinedTrees.compiler
+    })
   ]);
 
   var glimmerTests = merge([

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -95,6 +95,8 @@ module.exports = function() {
     include: ['*/index.js', '*/lib/**/*.js']
   });
 
+  var libOutputTree = mv(libTree, 'es6');
+
   var glimmerCommon = find(libTree, {
     include: [
       'glimmer/**/*.js',
@@ -195,7 +197,8 @@ module.exports = function() {
     glimmerCommon,
     glimmerCompiler,
     glimmerRuntime,
-    glimmerTests
+    glimmerTests,
+    libOutputTree
   ];
 
   if (hasBower) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -95,7 +95,9 @@ module.exports = function() {
     include: ['*/index.js', '*/lib/**/*.js']
   });
 
-  var libOutputTree = mv(libTree, 'es6');
+  var es6LibTree = mv(libTree, 'es6');
+  libTree = transpile(libTree, 'ES5 Lib Tree');
+  var es5LibTree = mv(libTree, 'named-amd');
 
   var glimmerCommon = find(libTree, {
     include: [
@@ -127,6 +129,8 @@ module.exports = function() {
     find(jsTree, { include: ['glimmer-test-helpers/**/*.js'] })
   ]);
 
+  glimmerTests = transpile(glimmerTests, 'glimmer-tests');
+
   // Test Assets
 
   var testHarnessTrees = [
@@ -145,11 +149,6 @@ module.exports = function() {
   }
 
   var testHarness = merge(testHarnessTrees);
-
-  glimmerCommon = transpile(glimmerCommon, 'glimmer-common');
-  glimmerCompiler = transpile(glimmerCompiler, 'glimmer-compiler');
-  glimmerRuntime = transpile(glimmerRuntime, 'glimmer-runtime');
-  glimmerTests = transpile(glimmerTests, 'glimmer-tests');
 
   glimmerCommon = concat(glimmerCommon, {
     inputFiles: ['**/*.js'],
@@ -198,7 +197,8 @@ module.exports = function() {
     glimmerCompiler,
     glimmerRuntime,
     glimmerTests,
-    libOutputTree
+    es5LibTree,
+    es6LibTree
   ];
 
   if (hasBower) {


### PR DESCRIPTION
Adds:

* dist/es6/
* dist/named-amd/

Ember will be updated to use named-amd (so that it can be more choosey with the files that it includes, to prevent duplication in the build output).