### PR TITLE
Better component layout builder API for Ember

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,43 @@ Ember CLI is a CI tool, so it will run tests as you change files.
 
 1. Run `npm start`.
 2. Visit <http://localhost:4200/tests/>.
+
+# TypeScript Notes
+
+## "Friend" Properties and Methods
+
+In TypeScript, `private` and `protected` refer to the class itself
+(and its subclasses).
+
+Sometimes, you want to add a property or method that shouldn't be
+considered part of the external API (for other packages or Ember)
+but is expected to be used as part of an internal protocol.
+
+In that case, it's ok to mark the property as `private` or
+`protected` and use `['property']` syntax to access the property
+inside of the same package.
+
+```js
+class Layout {
+  private template: Template;
+}
+
+function compile(layout: Layout, environment: Environment): CompiledBlock {
+  return layout['template'].compile(environment);
+}
+```
+
+The idea is that the `compile` function might as well be a private method
+on the class, but because the function leaks into untyped code, we want
+to be more careful and avoid exporting it.
+
+Other use-cases might include protocols where a cluster of classes is
+intended to work together internally, but it's difficult to describe
+as a single class hierarchy.
+
+This is a semi-blessed workflow according to the TypeScript team, and
+Visual Studio Code (and tsc) correctly type check uses of indexed
+properties, and provide autocompletion, etc.
+
+**You should not treat use of `['foo']` syntax as license to access
+private properties outside of the package.**

--- a/packages/node_modules/glimmer-runtime/index.ts
+++ b/packages/node_modules/glimmer-runtime/index.ts
@@ -37,18 +37,21 @@ export {
 
 export {
   default as Compiler,
-  CompileIntoList,
-  OpcodeBuilder
+  CompileIntoList
 } from './lib/compiler';
 
 export {
-  Block as CompiledBlock,
-  BlockOptions as CompiledBlockOptions,
-  Layout as CompiledLayout,
-  LayoutOptions as CompiledLayoutOptions,
-  InlineBlock as CompiledInlineBlock,
-  InlineBlockOptions as CompiledInlineBlockOptions,
-  EntryPoint as CompiledEntryPoint
+  default as OpcodeBuilder
+} from './lib/opcode-builder';
+
+export {
+  Block,
+  BlockOptions,
+  Layout,
+  LayoutOptions,
+  InlineBlock,
+  InlineBlockOptions,
+  EntryPoint
 } from './lib/compiled/blocks';
 
 export {
@@ -129,7 +132,7 @@ export {
   ComponentClass,
   ComponentManager,
   ComponentDefinition,
-  ComponentBuilder,
+  ComponentLayoutBuilder,
   ComponentAttrsBuilder,
   ComponentBodyBuilder
 } from './lib/component/interfaces';

--- a/packages/node_modules/glimmer-runtime/lib/compiled/blocks.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/blocks.ts
@@ -1,34 +1,37 @@
-import { LinkedList, InternedString } from 'glimmer-util';
-import { OpSeq, Opcode } from '../opcodes';
-import { OpenPrimitiveElementOpcode, CloseElementOpcode } from '../compiled/opcodes/dom';
-import { ShadowAttributesOpcode } from '../compiled/opcodes/component';
+import { InternedString } from 'glimmer-util';
+import { OpSeq } from '../opcodes';
 import { Program } from '../syntax';
 import { Environment } from '../environment';
-import { ComponentDefinition } from '../component/interfaces';
 import SymbolTable from '../symbol-table';
 
 import {
   EntryPointCompiler,
-  LayoutCompiler,
-  CompiledComponentParts,
   InlineBlockCompiler
 } from '../compiler';
 
 export interface BlockOptions {
   children: InlineBlock[];
   program: Program;
-  ops?: OpSeq;
-  symbolTable?: SymbolTable;
+  symbolTable: SymbolTable;
+}
+
+export class CompiledBlock {
+  public ops: OpSeq;
+  public symbols: number;
+
+  constructor(ops: OpSeq, symbols: number) {
+    this.ops = ops;
+    this.symbols = symbols;
+  }
 }
 
 export abstract class Block {
   public children: InlineBlock[];
-  public ops: OpSeq;
   public program: Program;
   public symbolTable: SymbolTable;
+  protected compiled: CompiledBlock = null;
 
   constructor(options: BlockOptions) {
-    this.ops = options.ops || null;
     this.symbolTable = options.symbolTable || null;
     this.children = options.children;
     this.program = options.program;
@@ -40,7 +43,7 @@ export interface InlineBlockOptions extends BlockOptions {
 }
 
 export class InlineBlock extends Block {
-  locals: InternedString[];
+  public locals: InternedString[];
 
   constructor(options: InlineBlockOptions) {
     super(options);
@@ -51,8 +54,12 @@ export class InlineBlock extends Block {
     return !!this.locals.length;
   }
 
-  compile(env: Environment) {
-    this.ops = this.ops || new InlineBlockCompiler(this, env).compile();
+  compile(env: Environment): CompiledBlock {
+    let compiled = this.compiled;
+    if (compiled) return compiled;
+
+    let ops = new InlineBlockCompiler(this, env).compile();
+    return this.compiled = new CompiledBlock(ops, this.symbolTable.size);
   }
 }
 
@@ -74,12 +81,15 @@ export class EntryPoint extends TopLevelTemplate {
   }
 
   compile(env: Environment) {
-    this.ops = this.ops || new EntryPointCompiler(this, env).compile();
+    let compiled = this.compiled;
+    if (compiled) return compiled;
+
+    let ops = new EntryPointCompiler(this, env).compile();
+    return this.compiled = new CompiledBlock(ops, this.symbolTable.size);
   }
 }
 
 export interface LayoutOptions extends BlockOptions {
-  parts?: CompiledComponentParts;
   named: InternedString[];
   yields: InternedString[];
   program: Program;
@@ -92,33 +102,18 @@ export class Layout extends TopLevelTemplate {
     return layout;
   }
 
-  private parts: CompiledComponentParts;
   public named: InternedString[];
   public yields: InternedString[];
 
-  constructor({ children, parts, named, yields, program }: LayoutOptions) {
-    super({ children, program });
-    this.parts = parts;
+  constructor(options: LayoutOptions) {
+    super(options);
+
+    let { named, yields } = options;
 
     // positional params in Ember may want this
     // this.locals = locals;
     this.named = named;
     this.yields = yields;
-  }
-
-  compile(definition: ComponentDefinition<any>, env: Environment) {
-    if (this.ops) return;
-
-    this.parts = this.parts || new LayoutCompiler(this, env, definition).compile();
-    let { tag, preamble, main } = this.parts;
-
-    let ops = new LinkedList<Opcode>();
-    ops.append(new OpenPrimitiveElementOpcode({ tag }));
-    ops.spliceList(preamble, null);
-    ops.append(new ShadowAttributesOpcode());
-    ops.spliceList(main, null);
-    ops.append(new CloseElementOpcode());
-    this.ops = ops;
   }
 
   hasNamedParameters(): boolean {

--- a/packages/node_modules/glimmer-runtime/lib/compiled/expressions/args.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/expressions/args.ts
@@ -1,7 +1,7 @@
 import { COMPILED_EMPTY_POSITIONAL_ARGS, EVALUATED_EMPTY_POSITIONAL_ARGS, CompiledPositionalArgs, EvaluatedPositionalArgs } from './positional-args';
 import { COMPILED_EMPTY_NAMED_ARGS, EVALUATED_EMPTY_NAMED_ARGS, CompiledNamedArgs, EvaluatedNamedArgs } from './named-args';
 import VM from '../../vm/append';
-import { Block as CompiledBlock } from '../blocks';
+import { Block  } from '../blocks';
 import { PathReference } from 'glimmer-reference';
 
 interface CompiledArgOptions {
@@ -77,7 +77,7 @@ export abstract class EvaluatedArgs {
   public type: string;
   public positional: EvaluatedPositionalArgs;
   public named: EvaluatedNamedArgs;
-  public blocks: CompiledBlock[];
+  public blocks: Block[];
   public internal: Object;
 }
 

--- a/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -3,6 +3,7 @@ import { Component, ComponentManager, ComponentDefinition } from '../../componen
 import { VM, UpdatingVM } from '../../vm';
 import { CompiledArgs, EvaluatedArgs } from '../../compiled/expressions/args';
 import { Templates } from '../../syntax/core';
+import { layoutFor } from '../../compiler';
 import { InternedString, dict } from 'glimmer-util';
 
 export interface OpenComponentOptions {
@@ -44,8 +45,10 @@ export class OpenComponentOpcode extends Opcode {
     args.internal['shadow'] = shadow;
     args.internal['definition'] = definition;
 
-    vm.pushRootScope(selfRef, definition.getLayout(vm.env).symbolTable.size);
-    vm.invokeLayout({ templates, args, shadow, definition, callerScope });
+    let layout = layoutFor(definition, vm.env);
+
+    vm.pushRootScope(selfRef, layout.symbols);
+    vm.invokeLayout({ templates, args, shadow, layout, callerScope });
     vm.env.didCreate(component, manager);
     vm.updateWith(new UpdateComponentOpcode({ name: definition.name, component, manager, args }));
   }

--- a/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/dom.ts
@@ -81,6 +81,7 @@ class ClassList extends PushPullReference {
     return null;
   }
 }
+
 export class CloseElementOpcode extends Opcode {
   public type = "close-element";
 
@@ -93,6 +94,11 @@ export class CloseElementOpcode extends Opcode {
     let flattened = dict<ElementOperation>();
     let flattenedKeys = [];
 
+    // This is a hardcoded merge strategy:
+    // 1. Classes are merged together split by whitespace
+    // 2. Other attributes are first-write-wins (which means invocation
+    //    wins over top-level element in components)
+
     for (let i = 0; i < groups.length; i++) {
       for (let j = 0; j < groups[i].length; j++) {
         let op = groups[i][j];
@@ -100,7 +106,7 @@ export class CloseElementOpcode extends Opcode {
         let value: PathReference = <FIXME> op['value'];
         if (name === 'class') {
           classes.append(value);
-        } else {
+        } else if (!flattened[name]) {
           flattenedKeys.push(name);
           flattened[name] = op;
         }

--- a/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -2,7 +2,7 @@ import { Opcode, OpcodeJSON, UpdatingOpcode } from '../../opcodes';
 import { CompiledExpression } from '../expressions';
 import { CompiledArgs } from '../expressions/args';
 import { VM, UpdatingVM } from '../../vm';
-import { Layout as CompiledLayout, InlineBlock as CompiledInlineBlock } from '../blocks';
+import { Layout, InlineBlock } from '../blocks';
 import { turbocharge } from '../../utils';
 import { NULL_REFERENCE } from '../../references';
 import { ListSlice, Slice, Dict, dict, assign } from 'glimmer-util';
@@ -108,7 +108,7 @@ export class BindPositionalArgsOpcode extends Opcode {
   private names: string[];
   private positional: number[];
 
-  constructor({ block }: { block: CompiledInlineBlock }) {
+  constructor({ block }: { block: InlineBlock }) {
     super();
 
     this.names = block.locals;
@@ -137,7 +137,7 @@ export class BindNamedArgsOpcode extends Opcode {
 
   public named: Dict<number>;
 
-  static create(layout: CompiledLayout) {
+  static create(layout: Layout) {
     let named = layout['named'].reduce(
       (obj, name) => assign(obj, { [<string>name]: layout.symbolTable.getNamed(name) }),
       dict<number>()
@@ -174,7 +174,7 @@ export class BindBlocksOpcode extends Opcode {
 
   public blocks: Dict<number>;
 
-  static create(template: CompiledLayout) {
+  static create(template: Layout) {
     let blocks = dict<number>();
     template['yields'].forEach(name => {
       blocks[<string>name] = template.symbolTable.getYield(name);
@@ -260,9 +260,9 @@ export class LabelOpcode extends Opcode {
 export class EvaluateOpcode extends Opcode {
   public type = "evaluate";
   public debug: string;
-  public block: CompiledInlineBlock;
+  public block: InlineBlock;
 
-  constructor({ debug, block }: { debug: string, block: CompiledInlineBlock }) {
+  constructor({ debug, block }: { debug: string, block: InlineBlock }) {
     super();
     this.debug = debug;
     this.block = block;

--- a/packages/node_modules/glimmer-runtime/lib/compiler.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiler.ts
@@ -1,21 +1,26 @@
 import { FIXME, Slice, LinkedList, InternedString } from 'glimmer-util';
 import { OpSeqBuilder, Opcode } from './opcodes';
-import { Layout as CompiledLayout } from './compiled/blocks';
+import { OpenPrimitiveElementOpcode, CloseElementOpcode } from './compiled/opcodes/dom';
+import { ShadowAttributesOpcode } from './compiled/opcodes/component';
 import { BindNamedArgsOpcode, BindBlocksOpcode, BindPositionalArgsOpcode } from './compiled/opcodes/vm';
 import * as Syntax from './syntax/core';
 import { Environment } from './environment';
 import SymbolTable from './symbol-table';
-import { Block, EntryPoint, InlineBlock, Layout } from './compiled/blocks';
-import { Args, Templates } from './syntax/core';
+import { Block, CompiledBlock, EntryPoint, InlineBlock, Layout } from './compiled/blocks';
+
 import {
   OpenComponentOpcode,
   CloseComponentOpcode
 } from './compiled/opcodes/component';
 
 import {
+  OpenComponentOptions
+} from './opcode-builder';
+
+import {
   Statement as StatementSyntax,
   Attribute as AttributeSyntax,
-  CompileInto
+  StatementCompilationBuffer
 } from './syntax';
 
 import {
@@ -23,11 +28,8 @@ import {
   default as makeFunctionExpression
 } from './compiled/expressions/function';
 
-import {
-  ComponentDefinition
-} from './component/interfaces';
-
 import * as Component from './component/interfaces';
+import { CACHED_LAYOUT } from './component/interfaces';
 
 abstract class Compiler {
   public env: Environment;
@@ -46,6 +48,10 @@ abstract class Compiler {
     this.env.statement(statement).compile(ops, this.env);
   }
 
+}
+
+function compileStatement(env: Environment, statement: StatementSyntax, ops: StatementCompilationBuffer) {
+  env.statement(statement).compile(ops, env);
 }
 
 export default Compiler;
@@ -133,145 +139,166 @@ export interface CompiledComponentParts {
   main: CompileIntoList;
 }
 
-class ComponentBuilder implements Component.ComponentBuilder {
-  private tagName: InternedString = null;
-  public body = new ComponentBodyBuilder();
-  public attrs = new ComponentAttrsBuilder();
+export function layoutFor(definition: Component.ComponentDefinition<any>, env: Environment): CompiledBlock {
+  let layout = definition[CACHED_LAYOUT];
+  if (layout) return layout;
 
-  tag(tagName: InternedString) {
-    this.tagName = tagName;
+  let builder = new ComponentLayoutBuilder(env);
+
+  definition['compile'](builder);
+
+  return definition[CACHED_LAYOUT] = builder.compile();
+}
+
+class ComponentLayoutBuilder implements Component.ComponentLayoutBuilder {
+  public env: Environment;
+
+  private inner: WrappedBuilder | UnwrappedBuilder;
+
+  constructor(env: Environment) {
+    this.env = env;
   }
 
-  toParts(): ComponentParts {
-    return {
-      tag: this.tagName,
-      attrs: this.attrs.asSlice(),
-      body: this.body.asSlice()
-    };
+  wrapLayout(layout: Layout) {
+    this.inner = new WrappedBuilder(this.env, layout);
+  }
+
+  fromLayout(layout: Layout) {
+    this.inner = new UnwrappedBuilder(this.env, layout);
+  }
+
+  compile(): CompiledBlock {
+    return this.inner.compile();
+  }
+
+  get tag(): Component.ComponentTagBuilder {
+    return this.inner.tag;
+  }
+
+  get attrs(): Component.ComponentAttrsBuilder {
+    return this.inner.attrs;
+  }
+}
+
+class WrappedBuilder {
+  private layout: Layout;
+  public env: Environment;
+
+  public tag = new ComponentTagBuilder();
+  public attrs = new ComponentAttrsBuilder();
+
+  constructor(env: Environment, layout: Layout) {
+    this.env = env;
+    this.layout = layout;
+  }
+
+  compile(): CompiledBlock {
+    let { env, layout } = this;
+
+    let list = new CompileIntoList(env, layout.symbolTable);
+
+    if (layout.hasNamedParameters()) {
+      list.append(BindNamedArgsOpcode.create(layout));
+    }
+
+    if (layout.hasYields()) {
+      list.append(BindBlocksOpcode.create(layout));
+    }
+
+    let tag = this.tag['tagName'];
+
+    list.append(new OpenPrimitiveElementOpcode({ tag }));
+
+    this.attrs['buffer'].forEach(statement => compileStatement(env, statement, list));
+
+    layout.program.forEachNode(statement => compileStatement(env, statement, list));
+
+    list.append(new CloseElementOpcode());
+
+    return new CompiledBlock(list, layout.symbolTable.size);
+  }
+}
+
+class UnwrappedBuilder {
+  private layout: Layout;
+  public env: Environment;
+
+  public attrs = new ComponentAttrsBuilder();
+
+  constructor(env: Environment, layout: Layout) {
+    this.env = env;
+    this.layout = layout;
+  }
+
+  get tag(): Component.ComponentTagBuilder {
+    throw new Error('BUG: Cannot call `tag` on an UnwrappedBuilder');
+  }
+
+  compile(): CompiledBlock {
+    let { env, layout } = this;
+
+    let list = new CompileIntoList(env, layout.symbolTable);
+
+    if (layout.hasNamedParameters()) {
+      list.append(BindNamedArgsOpcode.create(layout));
+    }
+
+    if (layout.hasYields()) {
+      list.append(BindBlocksOpcode.create(layout));
+    }
+
+    let attrs = this.attrs['buffer'];
+    let attrsInserted = false;
+
+    this.layout.program.forEachNode(statement => {
+      compileStatement(env, statement, list);
+
+      if (!attrsInserted && isOpenElement(statement)) {
+        list.append(new ShadowAttributesOpcode());
+        attrs.forEach(statement => compileStatement(env, statement, list));
+        attrsInserted = true;
+      }
+    });
+
+    return new CompiledBlock(list, layout.symbolTable.size);
+  }
+}
+
+type OpenElement = Syntax.OpenElement | Syntax.OpenPrimitiveElement;
+
+function isOpenElement(syntax: StatementSyntax): syntax is OpenElement {
+  return syntax instanceof Syntax.OpenElement || syntax instanceof Syntax.OpenPrimitiveElement;
+}
+
+class ComponentTagBuilder implements Component.ComponentTagBuilder {
+  private tagName: InternedString = null;
+
+  static(tagName: InternedString) {
+    this.tagName = tagName;
   }
 }
 
 class ComponentAttrsBuilder implements Component.ComponentAttrsBuilder {
-  private buffer: LinkedList<AttributeSyntax> = null;
-  private attrs: Slice<AttributeSyntax> = null;
+  private buffer: AttributeSyntax[] = [];
 
-  static({ name, value }: { name: string, value: string }) {
-    this.initBuffer('static').append(new Syntax.StaticAttr({ name: name as FIXME, value: value as FIXME }));
+  static(name: string, value: string) {
+    this.buffer.push(new Syntax.StaticAttr({ name: name as FIXME, value: value as FIXME }));
   }
 
-  dynamic({ name, value }: { name: string, value: FunctionExpression }) {
-    this.initBuffer('dynamic').append(new Syntax.DynamicAttr({ name: name as FIXME, value: makeFunctionExpression(value) }));
-  }
-
-  replace(attrs: Slice<AttributeSyntax>) {
-    if (this.buffer) {
-      throw new Error(`Cannot attrs.replace if you already did attrs.static or attrs.dynamic`);
-    }
-
-    this.attrs = attrs;
-  }
-
-  asSlice(): Slice<AttributeSyntax> {
-    return this.attrs || this.buffer;
-  }
-
-  private initBuffer(operation: string): LinkedList<AttributeSyntax> {
-    if (!this.buffer) {
-      if (this.attrs) {
-        this.buffer = LinkedList.fromSlice(this.attrs);
-        this.attrs = null;
-      } else {
-        this.buffer = new LinkedList<AttributeSyntax>();
-      }
-    }
-
-    return this.buffer;
+  dynamic(name: string, value: FunctionExpression) {
+    this.buffer.push(new Syntax.DynamicAttr({ name: name as FIXME, value: makeFunctionExpression(value) }));
   }
 }
 
 class ComponentBodyBuilder implements Component.ComponentBodyBuilder {
-  private program: Slice<StatementSyntax> = null;
+  private layout: Layout = null;
 
-  fromLayout(layout: CompiledLayout) {
-    this.program = layout.program;
-  }
-
-  replace(program: Slice<StatementSyntax>) {
-    this.program = program;
-  }
-
-  asSlice(): Slice<StatementSyntax> {
-    return this.program;
+  fromLayout(layout: Layout) {
+    this.layout = layout;
   }
 }
 
-export class LayoutCompiler extends Compiler {
-  private preamble: CompileIntoList;
-  private body: CompileIntoList;
-  private definition: ComponentDefinition<any>;
-  protected block: Layout;
-
-  constructor(layout: Layout, env: Environment, definition: ComponentDefinition<any>) {
-    super(layout, env);
-    this.definition = definition;
-  }
-
-  compile(): CompiledComponentParts {
-    let builder = new ComponentBuilder();
-
-    let { block: layout, env, symbolTable } = this;
-    this.definition.compile(builder, { env, symbolTable });
-
-    let { tag, attrs, body } = builder.toParts();
-
-    let preamble = this.preamble = new CompileIntoList(env, this.symbolTable);
-    let main = this.body = new CompileIntoList(env, this.symbolTable);
-
-    if (layout.hasNamedParameters()) {
-      preamble.append(BindNamedArgsOpcode.create(layout));
-    }
-
-    if (layout.hasYields()) {
-      preamble.append(BindBlocksOpcode.create(layout));
-    }
-
-    attrs.forEachNode(attr => {
-      this.compileStatement(attr, preamble);
-    });
-
-    body.forEachNode(statement => {
-      this.compileStatement(statement, main);
-    });
-
-    return { tag, preamble, main };
-  }
-
-  getLocalSymbol(name: InternedString): number {
-    return this.symbolTable.getLocal(name);
-  }
-
-  getNamedSymbol(name: InternedString): number {
-    return this.symbolTable.getNamed(name);
-  }
-
-  getBlockSymbol(name: InternedString): number {
-    return this.symbolTable.getYield(name);
-  }
-}
-
-interface OpenComponentOptions {
-  definition: ComponentDefinition<any>;
-  args: Args;
-  shadow: InternedString[];
-  templates: Templates;
-}
-
-export interface OpcodeBuilder {
-  openComponent(options: OpenComponentOptions);
-  closeComponent();
-}
-
-export class CompileIntoList extends LinkedList<Opcode> implements CompileInto, OpcodeBuilder {
+export class CompileIntoList extends LinkedList<Opcode> implements StatementCompilationBuffer {
   private env: Environment;
   private symbolTable: SymbolTable;
 

--- a/packages/node_modules/glimmer-runtime/lib/component/interfaces.ts
+++ b/packages/node_modules/glimmer-runtime/lib/component/interfaces.ts
@@ -1,14 +1,8 @@
 import { EvaluatedNamedArgs } from '../compiled/expressions/args';
 import { FunctionExpression } from '../compiled/expressions/function';
-
-import { Layout as CompiledLayout } from '../compiled/blocks';
+import { Layout, CompiledBlock } from '../compiled/blocks';
 
 import Environment from '../environment';
-import SymbolTable from '../symbol-table';
-
-import * as Syntax from '../syntax';
-
-import { Slice, InternedString } from 'glimmer-util';
 
 export interface Component {};
 export interface ComponentClass {};
@@ -23,28 +17,36 @@ export interface ComponentManager<T extends Component> {
   getSelf(component: T): any;
 }
 
-export interface ComponentBuilder {
-  body: ComponentBodyBuilder;
+export interface ComponentLayoutBuilder {
+  env: Environment;
+  tag: ComponentTagBuilder;
   attrs: ComponentAttrsBuilder;
 
-  tag(tagName: InternedString);
+  wrapLayout(layout: Layout);
+  fromLayout(layout: Layout);
+}
+
+export interface ComponentTagBuilder {
+  static(tagName: string);
 }
 
 export interface ComponentAttrsBuilder {
-  static(options: { name: string, value: string });
-  dynamic(options: { name: string, value: FunctionExpression });
-  replace(attrs: Slice<Syntax.Attribute>);
+  static(name: string, value: string);
+  dynamic(name: string, value: FunctionExpression);
 }
 
 export interface ComponentBodyBuilder {
-  fromLayout(layout: CompiledLayout);
-  replace(statements: Slice<Syntax.Statement>);
+  fromLayout(layout: Layout);
 }
+
+export const CACHED_LAYOUT = "CACHED_LAYOUT [d990e194-8529-4f3b-8ee9-11c58a70f7a4]";
 
 export abstract class ComponentDefinition<T extends Component> {
   public name: string; // for debugging
   public manager: ComponentManager<T>;
   public ComponentClass: ComponentClass;
+
+  private "CACHED_LAYOUT [d990e194-8529-4f3b-8ee9-11c58a70f7a4]": CompiledBlock = null;
 
   constructor(name: string, manager: ComponentManager<T>, ComponentClass: ComponentClass) {
     this.name = name;
@@ -52,7 +54,5 @@ export abstract class ComponentDefinition<T extends Component> {
     this.ComponentClass = ComponentClass;
   }
 
-  abstract getLayout(env: Environment): CompiledLayout;
-
-  abstract compile(builder: ComponentBuilder, options: { env: Environment, symbolTable: SymbolTable });
+  protected abstract compile(builder: ComponentLayoutBuilder);
 }

--- a/packages/node_modules/glimmer-runtime/lib/opcode-builder.ts
+++ b/packages/node_modules/glimmer-runtime/lib/opcode-builder.ts
@@ -1,0 +1,26 @@
+import {
+  ComponentDefinition
+} from './component/interfaces';
+
+import {
+  Args,
+  Templates
+} from './syntax/core';
+
+import {
+  InternedString
+} from 'glimmer-util';
+
+export interface OpenComponentOptions {
+  definition: ComponentDefinition<any>;
+  args: Args;
+  shadow: InternedString[];
+  templates: Templates;
+}
+
+interface OpcodeBuilder {
+  openComponent(options: OpenComponentOptions);
+  closeComponent();
+}
+
+export default OpcodeBuilder;

--- a/packages/node_modules/glimmer-runtime/lib/scanner.ts
+++ b/packages/node_modules/glimmer-runtime/lib/scanner.ts
@@ -16,14 +16,14 @@ export default class Scanner {
 
   scanEntryPoint(): EntryPoint {
     return this.scanTop<EntryPoint>(({ program, children }) => {
-      return EntryPoint.create({ children, ops: null, program });
+      return EntryPoint.create({ children, program, symbolTable: null });
     });
   }
 
   scanLayout(): Layout {
     return this.scanTop<Layout>(({ program, children }) => {
       let { named, yields } = this.spec;
-      return Layout.create({ children, program, named, yields });
+      return Layout.create({ children, program, named, yields, symbolTable: null });
     });
   }
 
@@ -42,7 +42,7 @@ export default class Scanner {
 
   private buildBlock(block: SerializedBlock, blocks: InlineBlock[]): InlineBlock{
     let { program, children } = this.buildStatements(block, blocks);
-    return new InlineBlock({ children, locals: block.locals, program });
+    return new InlineBlock({ children, locals: block.locals, program, symbolTable: null });
   }
 
   private buildStatements({ statements }: SerializedBlock, blocks: InlineBlock[]): ScanResults {

--- a/packages/node_modules/glimmer-runtime/lib/syntax.ts
+++ b/packages/node_modules/glimmer-runtime/lib/syntax.ts
@@ -5,9 +5,7 @@ import { CompiledExpression } from './compiled/expressions';
 import { Opcode } from './opcodes';
 import { InlineBlock } from './compiled/blocks';
 
-import {
-  OpcodeBuilder
-} from './compiler';
+import OpcodeBuilder from './opcode-builder';
 
 import {
   Statement as SerializedStatement,
@@ -67,7 +65,7 @@ export abstract class Statement implements LinkedListNode {
     return new (<new (any) => any>this.constructor)(this);
   }
 
-  abstract compile(opcodes: SymbolLookup & CompileInto & OpcodeBuilder, env: Environment);
+  abstract compile(opcodes: StatementCompilationBuffer, env: Environment);
 
   scan(scanner: BlockScanner): Statement {
     return this;
@@ -100,6 +98,10 @@ export interface SymbolLookup {
 
 export interface CompileInto {
   append(op: Opcode);
+}
+
+export interface StatementCompilationBuffer extends CompileInto, SymbolLookup, OpcodeBuilder {
+
 }
 
 export type Program = Slice<Statement>;

--- a/packages/node_modules/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/node_modules/glimmer-runtime/lib/syntax/core.ts
@@ -15,7 +15,7 @@ import {
 } from '../syntax';
 
 import {
-  InlineBlock as CompiledInlineBlock
+  InlineBlock
 } from '../compiled/blocks';
 
 import {
@@ -108,7 +108,7 @@ export interface BlockOptions {
 export class Block extends StatementSyntax {
   public type = "block";
 
-  static fromSpec(sexp: SerializedStatements.Block, children: CompiledInlineBlock[]): Block {
+  static fromSpec(sexp: SerializedStatements.Block, children: InlineBlock[]): Block {
     let [, path, params, hash, templateId, inverseId] = sexp;
 
     return new Block({
@@ -545,7 +545,10 @@ export class OpenElement extends StatementSyntax {
     if (scanner.env.hasComponentDefinition([tag])) {
       let attrs = this.attributes(scanner);
       let contents = this.tagContents(scanner);
-      return new Component({ tag, attrs, contents });
+      let template = new InlineBlock({ symbolTable: null, children: [], program: contents, locals: [] });
+      scanner.addChild(template);
+
+      return new Component({ tag, attrs, template });
     } else {
       return new OpenPrimitiveElement({ tag });
     }
@@ -605,21 +608,20 @@ export class Component extends StatementSyntax {
   public type = 'component';
   public tag: InternedString;
   public attrs: Slice<AttributeSyntax>;
-  public contents: Slice<StatementSyntax>;
+  public template: InlineBlock;
 
-  constructor({ tag, attrs, contents }: { tag: InternedString, attrs: Slice<AttributeSyntax>, contents: Slice<StatementSyntax> }) {
+  constructor({ tag, attrs, template }: { tag: InternedString, attrs: Slice<AttributeSyntax>, template: InlineBlock }) {
     super();
     this.tag = tag;
     this.attrs = attrs;
-    this.contents = contents;
+    this.template = template;
   }
 
   compile(list: CompileInto & SymbolLookup, env: Environment) {
     let definition = env.getComponentDefinition([this.tag]);
     let args = Args.fromHash(attributesToNamedArgs(this.attrs)).compile(list, env);
     let shadow = shadowList(this.attrs);
-    let block = new CompiledInlineBlock({ children: null, ops: null, locals: [], program: this.contents });
-    let templates = new Templates({ template: block, inverse: null });
+    let templates = new Templates({ template: this.template, inverse: null });
 
     list.append(new OpenComponentOpcode({ definition, args, shadow, templates }));
     list.append(new CloseComponentOpcode());
@@ -1112,7 +1114,7 @@ export class NamedArgs {
 export class Templates {
   public type = "templates";
 
-  static fromSpec([templateId, inverseId]: [number, number], children: CompiledInlineBlock[]): Templates {
+  static fromSpec([templateId, inverseId]: [number, number], children: InlineBlock[]): Templates {
     return new Templates({
       template: templateId === null ? null : children[templateId],
       inverse: inverseId === null ? null : children[inverseId],
@@ -1123,14 +1125,14 @@ export class Templates {
     return new Templates({ template: null, inverse: null });
   }
 
-  static build(template: CompiledInlineBlock, inverse: CompiledInlineBlock=null): Templates {
+  static build(template: InlineBlock, inverse: InlineBlock=null): Templates {
     return new this({ template, inverse });
   }
 
-  public default: CompiledInlineBlock;
-  public inverse: CompiledInlineBlock;
+  public default: InlineBlock;
+  public inverse: InlineBlock;
 
-  constructor(options: { template: CompiledInlineBlock, inverse: CompiledInlineBlock }) {
+  constructor(options: { template: InlineBlock, inverse: InlineBlock }) {
     this.default = options.template;
     this.inverse = options.inverse;
   }

--- a/packages/node_modules/glimmer-runtime/lib/syntax/statements.ts
+++ b/packages/node_modules/glimmer-runtime/lib/syntax/statements.ts
@@ -11,7 +11,7 @@ import {
   StaticAttr
 } from './core';
 
-import { InlineBlock as CompiledInlineBlock } from '../compiled/blocks';
+import { InlineBlock } from '../compiled/blocks';
 import { Statement as StatementSyntax } from '../syntax';
 import {
   Statements as SerializedStatements,
@@ -31,7 +31,7 @@ const {
   isStaticAttr
 } = SerializedStatements;
 
-export default function(sexp: SerializedStatement, blocks: CompiledInlineBlock[]): StatementSyntax {
+export default function(sexp: SerializedStatement, blocks: InlineBlock[]): StatementSyntax {
   if (isYield(sexp)) return Yield.fromSpec(sexp);
   if (isBlock(sexp)) return Block.fromSpec(sexp, blocks);
   if (isAppend(sexp)) return Append.fromSpec(sexp);

--- a/packages/node_modules/glimmer-runtime/lib/template.ts
+++ b/packages/node_modules/glimmer-runtime/lib/template.ts
@@ -44,9 +44,8 @@ export default class Template {
 
   render(self: PathReference, env: Environment, options: RenderOptions, blockArguments: any[]=null) {
     let elementStack = new ElementStack({ dom: env.getDOM(), parentNode: options.appendTo, nextSibling: null });
-    let vm = VM.initial(env, { self, elementStack, size: this.raw.symbolTable.size });
-
-    this.raw.compile(env);
-    return vm.execute(this.raw.ops);
+    let compiled = this.raw.compile(env);
+    let vm = VM.initial(env, { self, elementStack, size: compiled.symbols });
+    return vm.execute(compiled.ops);
   }
 }

--- a/packages/node_modules/glimmer-runtime/lib/vm/append.ts
+++ b/packages/node_modules/glimmer-runtime/lib/vm/append.ts
@@ -1,11 +1,10 @@
 import { Scope, Environment } from '../environment';
 import { ElementStack } from '../builder';
-import { ComponentDefinition } from '../component/interfaces';
 import { Dict, Stack, LinkedList, LOGGER, InternedString } from 'glimmer-util';
 import { ChainableReference, PathReference, ListManager, ListIterator } from 'glimmer-reference';
 import Template from '../template';
 import { Templates } from '../syntax/core';
-import { Block as CompiledBlock, InlineBlock as CompiledInlineBlock } from '../compiled/blocks';
+import { InlineBlock, CompiledBlock } from '../compiled/blocks';
 import { CompiledExpression } from '../compiled/expressions';
 import { CompiledArgs, EvaluatedArgs } from '../compiled/expressions/args';
 import { Opcode, OpSeq, UpdatingOpcode } from '../opcodes';
@@ -34,7 +33,7 @@ interface Registers {
 interface InvokeLayoutOptions {
   args: EvaluatedArgs;
   shadow: InternedString[];
-  definition: ComponentDefinition<any>;
+  layout: CompiledBlock;
   templates: Templates;
   callerScope: Scope;
 }
@@ -222,16 +221,12 @@ export default class VM {
 
   // Make sure you have opcodes that push and pop a scope around this opcode
   // if you need to change the scope.
-  invokeBlock(block: CompiledInlineBlock, args: EvaluatedArgs) {
-    block.compile(this.env);
-    this.pushFrame({ block, args });
+  invokeBlock(block: InlineBlock, args: EvaluatedArgs) {
+    let compiled = block.compile(this.env);
+    this.pushFrame({ block: compiled, args });
   }
 
-  invokeLayout({ args, definition, templates, callerScope }: InvokeLayoutOptions) {
-    let layout = definition.getLayout(this.env);
-
-    layout.compile(definition, this.env);
-
+  invokeLayout({ args, layout, templates, callerScope }: InvokeLayoutOptions) {
     this.pushFrame({ block: layout, blocks: templates, callerScope, args });
   }
 

--- a/packages/node_modules/glimmer-runtime/lib/vm/frame.ts
+++ b/packages/node_modules/glimmer-runtime/lib/vm/frame.ts
@@ -1,7 +1,7 @@
 import { Scope } from '../environment';
 import { InternedString } from 'glimmer-util';
 import { ChainableReference, PathReference, ListIterator } from 'glimmer-reference';
-import { InlineBlock as CompiledInlineBlock } from '../compiled/blocks';
+import { InlineBlock } from '../compiled/blocks';
 import { EvaluatedArgs } from '../compiled/expressions/args';
 import { Opcode, OpSeq } from '../opcodes';
 import { LabelOpcode } from '../compiled/opcodes/vm';
@@ -24,8 +24,8 @@ class Frame {
 }
 
 export interface Blocks {
-  default: CompiledInlineBlock;
-  inverse: CompiledInlineBlock;
+  default: InlineBlock;
+  inverse: InlineBlock;
 }
 
 export class FrameStack {

--- a/packages/node_modules/glimmer-test-helpers/lib/environment.ts
+++ b/packages/node_modules/glimmer-test-helpers/lib/environment.ts
@@ -2,14 +2,7 @@ import {
   // VM
   VM,
 
-  // Brands
-  isAttribute,
-
-  // Blocks
-  CompiledLayout,
-
   // Compiler
-  SymbolTable,
   CompileInto,
   OpcodeBuilder,
   SymbolLookup,
@@ -38,23 +31,16 @@ import {
   ComponentClass,
   ComponentManager,
   ComponentDefinition,
-  ComponentBuilder,
+  ComponentLayoutBuilder,
   EvaluatedNamedArgs,
 
   // Syntax Classes
   StatementSyntax,
-  ExpressionSyntax,
   AttributeSyntax,
 
   // Concrete Syntax
   Templates,
   ArgsSyntax,
-  OpenElement as OpenElementSyntax,
-  OpenPrimitiveElementSyntax,
-  CloseElementSyntax,
-
-  // Compiled Syntax
-  CompiledExpression,
 
   // References
   ValueReference,
@@ -65,7 +51,6 @@ import { compile as rawCompile, compileLayout as rawCompileLayout } from "./help
 
 import {
   Slice,
-  ListSlice,
   Dict,
   InternedString,
   assign,
@@ -390,75 +375,62 @@ interface BasicComponentFactory {
 }
 
 abstract class GenericComponentDefinition<T extends Component> extends ComponentDefinition<T> {
-  private compiledLayout : CompiledLayout;
-  private layout : string;
+  private layoutString : string;
 
-  constructor(name: string, manager: ComponentManager<any>, ComponentClass: ComponentClass, layout) {
+  constructor(name: string, manager: ComponentManager<any>, ComponentClass: ComponentClass, layout: string) {
     super(name, manager, ComponentClass);
-    this.layout = layout;
+    this.layoutString = layout;
   }
 
-  getLayout(env: Environment): CompiledLayout {
-    if (!this.compiledLayout) {
-      this.compiledLayout = rawCompileLayout(this.layout, { env });
-    }
-
-    return this.compiledLayout;
+  protected getLayout(options: { env: Environment }) {
+    return rawCompileLayout(this.layoutString, options);
   }
 
-  compile(builder: ComponentBuilder, { env }: { env: Environment, symbolTable: SymbolTable}) {
-    let { program } = this.getLayout(env);
+  // private extractComponent(builder: ComponentLayoutBuilder, head: OpenElementSyntax) {
+  //   builder.tag(head.tag);
 
-    let current = program.head();
+  //   let current = head.next;
 
-    while (current && current.type !== 'open-primitive-element') {
-      current = current.next;
-    }
+  //   let beginAttrs: AttributeSyntax = null;
+  //   let endAttrs: AttributeSyntax = null;
 
-    return this.extractComponent(builder, <any>current);
-  }
+  //   while (isAttribute(current)) {
+  //     beginAttrs = beginAttrs || <AttributeSyntax>current;
+  //     endAttrs = <AttributeSyntax>current;
+  //     current = current.next;
+  //   }
 
-  private extractComponent(builder: ComponentBuilder, head: OpenElementSyntax) {
-    builder.tag(head.tag);
+  //   builder.attrs.replace(new ListSlice(beginAttrs, endAttrs));
 
-    let current = head.next;
+  //   let beginBody: StatementSyntax = null;
+  //   let endBody: StatementSyntax = null;
+  //   let nesting = 1;
 
-    let beginAttrs: AttributeSyntax = null;
-    let endAttrs: AttributeSyntax = null;
+  //   while (true) {
+  //     if (current instanceof CloseElementSyntax && --nesting === 0) {
+  //       break;
+  //     }
 
-    while (isAttribute(current)) {
-      beginAttrs = beginAttrs || <AttributeSyntax>current;
-      endAttrs = <AttributeSyntax>current;
-      current = current.next;
-    }
+  //     beginBody = beginBody || current;
+  //     endBody = current;
 
-    builder.attrs.replace(new ListSlice(beginAttrs, endAttrs));
+  //     if (current instanceof OpenElementSyntax || current instanceof OpenPrimitiveElementSyntax) {
+  //       nesting++;
+  //     }
 
-    let beginBody: StatementSyntax = null;
-    let endBody: StatementSyntax = null;
-    let nesting = 1;
+  //     current = current.next;
+  //   }
 
-    while (true) {
-      if (current instanceof CloseElementSyntax && --nesting === 0) {
-        break;
-      }
-
-      beginBody = beginBody || current;
-      endBody = current;
-
-      if (current instanceof OpenElementSyntax || current instanceof OpenPrimitiveElementSyntax) {
-        nesting++;
-      }
-
-      current = current.next;
-    }
-
-    builder.body.replace(new ListSlice(beginBody, endBody));
-  }
+  //   builder.body.replace(new ListSlice(beginBody, endBody));
+  // }
 }
 
 class BasicComponentDefinition extends GenericComponentDefinition<BasicComponent> {
   public ComponentClass: BasicComponentFactory;
+
+  compile(builder: ComponentLayoutBuilder) {
+    builder.fromLayout(this.getLayout(builder));
+  }
 }
 
 interface EmberishCurlyComponentFactory {
@@ -472,11 +444,13 @@ function EmberID(vm: VM): PathReference {
 class EmberishCurlyComponentDefinition extends GenericComponentDefinition<EmberishCurlyComponent> {
   public ComponentClass: EmberishCurlyComponentFactory;
 
-  compile(builder: ComponentBuilder, { env } : { env: Environment }) {
-    builder.tag('div' as InternedString);
-    builder.body.fromLayout(this.getLayout(env));
-    builder.attrs.static({ name: 'class' as InternedString, value: 'ember-view' as InternedString });
-    builder.attrs.dynamic({ name: 'id' as InternedString, value: EmberID });
+  compile(builder: ComponentLayoutBuilder) {
+    let layout = this.getLayout(builder);
+
+    builder.wrapLayout(layout);
+    builder.tag.static('div');
+    builder.attrs.static('class', 'ember-view');
+    builder.attrs.dynamic('id', EmberID);
   }
 }
 
@@ -487,10 +461,10 @@ interface EmberishGlimmerComponentFactory {
 class EmberishGlimmerComponentDefinition extends GenericComponentDefinition<EmberishGlimmerComponent> {
   public ComponentClass: EmberishGlimmerComponentFactory;
 
-  compile(builder: ComponentBuilder, { env, symbolTable }: { env: Environment, symbolTable: SymbolTable }) {
-    super.compile(builder, { env, symbolTable });
-    builder.attrs.static({ name: 'class' as InternedString, value: 'ember-view' as InternedString });
-    builder.attrs.dynamic({ name: 'id' as InternedString, value: EmberID });
+  compile(builder: ComponentLayoutBuilder) {
+    builder.fromLayout(this.getLayout(builder));
+    builder.attrs.static('class', 'ember-view');
+    builder.attrs.dynamic('id', EmberID);
   }
 }
 

--- a/packages/node_modules/glimmer-test-helpers/lib/helpers.ts
+++ b/packages/node_modules/glimmer-test-helpers/lib/helpers.ts
@@ -1,7 +1,7 @@
 import { tokenize } from "simple-html-tokenizer";
 import { FIXME, forEach } from "glimmer-util";
 import { SerializedTemplate } from 'glimmer-wire-format';
-import { Environment, Template, CompiledLayout } from "glimmer-runtime";
+import { Environment, Template, Layout } from "glimmer-runtime";
 import { TemplateSpec, compileSpec } from "glimmer-compiler";
 
 interface CompileOptions {
@@ -45,7 +45,7 @@ export function compile(string: string, options: CompileOptions): Template {
   return Template.fromSpec(templateSpec, options.env);
 }
 
-export function compileLayout(string: string, options: CompileOptions): CompiledLayout {
+export function compileLayout(string: string, options: CompileOptions): Layout {
   let templateSpec = template(compileSpec(string, options));
   return Template.layoutFromSpec(templateSpec, options.env);
 }

--- a/packages/node_modules/glimmer-util/lib/platform-utils.ts
+++ b/packages/node_modules/glimmer-util/lib/platform-utils.ts
@@ -21,7 +21,7 @@ export function LITERAL(str: string): InternedString {
 
 let BASE_KEY = intern(`__glimmer{+ new Date()}`);
 
-export function symbol(debugName) {
+export function symbol(debugName): InternedString {
   let number = +(new Date());
   return intern(debugName + ' [id=' + BASE_KEY + Math.floor(Math.random() * number) + ']');
 }


### PR DESCRIPTION
This commit continues the process of exposing a minimal public API for
building component layouts outside of Glimmer.

We need to support using the layout as-is (“Glimmer components”) as well
as assembling the layout from dynamic information like tagName,
classNames, attributeBindings, etc.

Even for Glimmer components, we need a way to express adding additional
attributes (like id=“ember123” and class=“ember-view”).

The goal is to avoid leaking the statement syntax API or the appending
opcode API, which until now were necessary to construct a dynamic
layout.