### PR TITLE
Improve synthetic blocks in scanner

### DIFF
--- a/packages/node_modules/glimmer-runtime/lib/scanner.ts
+++ b/packages/node_modules/glimmer-runtime/lib/scanner.ts
@@ -2,7 +2,7 @@ import { Program, Statement as StatementSyntax } from './syntax';
 import buildStatement from './syntax/statements';
 import { TopLevelTemplate, EntryPoint, InlineBlock, Layout } from './compiled/blocks';
 import Environment from './environment';
-import { EMPTY_SLICE, LinkedList } from 'glimmer-util';
+import { EMPTY_SLICE, LinkedList, Stack } from 'glimmer-util';
 import { SerializedTemplate, SerializedBlock, Statement as SerializedStatement } from 'glimmer-wire-format';
 
 export default class Scanner {
@@ -62,29 +62,44 @@ const EMPTY_PROGRAM = {
 };
 
 export class BlockScanner {
-  public program = new LinkedList<StatementSyntax>();
-  public children: InlineBlock[] = [];
   public env: Environment;
+
+  private stack = new Stack<ChildBlockScanner>();
   private reader: SyntaxReader;
 
   constructor(statements: SerializedStatement[], blocks: InlineBlock[], env: Environment) {
+    this.stack.push(new ChildBlockScanner());
     this.reader = new SyntaxReader(statements, blocks);
     this.env = env;
   }
 
   scan(): ScanResults {
-    let { reader, program } = this;
     let statement: StatementSyntax;
 
-    while (statement = reader.next()) {
-      program.append(statement.scan(this));
+    while (statement = this.reader.next()) {
+      this.addStatement(statement.scan(this));
     }
 
-    return this;
+    return { program: this.stack.current.program, children: this.stack.current.children };
+  }
+
+  startBlock() {
+    this.stack.push(new ChildBlockScanner());
+  }
+
+  endBlock(): InlineBlock {
+    let { children, program } = this.stack.pop();
+    let block = new InlineBlock({ children, program, symbolTable: null, locals: [] });
+    this.addChild(block);
+    return block;
   }
 
   addChild(block: InlineBlock) {
-    this.children.push(block);
+    this.stack.current.addChild(block);
+  }
+
+  addStatement(statement: StatementSyntax) {
+    this.stack.current.addStatement(statement);
   }
 
   next(): StatementSyntax {
@@ -93,6 +108,19 @@ export class BlockScanner {
 
   unput(statement: StatementSyntax) {
     this.reader.unput(statement);
+  }
+}
+
+class ChildBlockScanner {
+  public children: InlineBlock[] = [];
+  public program = new LinkedList<StatementSyntax>();
+
+  addChild(block: InlineBlock) {
+    this.children.push(block);
+  }
+
+  addStatement(statement: StatementSyntax) {
+    this.program.append(statement);
   }
 }
 

--- a/packages/node_modules/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/node_modules/glimmer-runtime/lib/syntax/core.ts
@@ -63,9 +63,7 @@ import {
 import { Environment, Insertion, Helper as EnvHelper } from '../environment';
 
 import {
-  LinkedList,
   InternedString,
-  Slice,
   Dict,
   dict,
   intern,
@@ -543,12 +541,14 @@ export class OpenElement extends StatementSyntax {
     let { tag } = this;
 
     if (scanner.env.hasComponentDefinition([tag])) {
-      let attrs = this.attributes(scanner);
-      let contents = this.tagContents(scanner);
-      let template = new InlineBlock({ symbolTable: null, children: [], program: contents, locals: [] });
-      scanner.addChild(template);
+      let { args, attrs } = this.attributes(scanner);
+      scanner.startBlock();
+      this.tagContents(scanner);
+      let template = scanner.endBlock();
 
-      return new Component({ tag, attrs, template });
+      // let template = new InlineBlock({ symbolTable: null, children: [], program: contents, locals: [] });
+
+      return new Component({ tag, args, attrs, template });
     } else {
       return new OpenPrimitiveElement({ tag });
     }
@@ -568,24 +568,25 @@ export class OpenElement extends StatementSyntax {
     return new OpenPrimitiveElement({ tag });
   }
 
-  private attributes(scanner: BlockScanner): Slice<AttributeSyntax> {
+  private attributes(scanner: BlockScanner): { args: Args, attrs: InternedString[] } {
     let current = scanner.next();
-    let attrs = new LinkedList<AttributeSyntax>();
+    let args = dict<ExpressionSyntax>();
+    let attrs: InternedString[] = [];
 
     while (current[ATTRIBUTE_SYNTAX]) {
       let attr = <AttributeSyntax>current;
-      attrs.append(attr);
+      args[<string>attr.name] = attr.valueSyntax();
+      if (attr.isAttribute()) attrs.push(attr.name);
       current = scanner.next();
     }
 
     scanner.unput(current);
 
-    return attrs;
+    return { args: Args.fromNamedArgs(NamedArgs.build(args)), attrs };
   }
 
-  private tagContents(scanner: BlockScanner): Slice<StatementSyntax> {
+  private tagContents(scanner: BlockScanner) {
     let nesting = 1;
-    let list = new LinkedList<StatementSyntax>();
 
     while (true) {
       let current = scanner.next();
@@ -593,59 +594,46 @@ export class OpenElement extends StatementSyntax {
         break;
       }
 
-      list.append(current);
+      scanner.addStatement(current);
 
       if (current instanceof OpenElement || current instanceof OpenPrimitiveElement) {
         nesting++;
       }
     }
-
-    return list;
   }
+}
+
+interface ComponentOptions {
+  tag: InternedString;
+  attrs: InternedString[];
+  args: Args;
+  template: InlineBlock;
 }
 
 export class Component extends StatementSyntax {
   public type = 'component';
   public tag: InternedString;
-  public attrs: Slice<AttributeSyntax>;
+  public attrs: InternedString[];
+  public args: Args;
   public template: InlineBlock;
 
-  constructor({ tag, attrs, template }: { tag: InternedString, attrs: Slice<AttributeSyntax>, template: InlineBlock }) {
+  constructor({ tag, args, attrs, template }: ComponentOptions) {
     super();
     this.tag = tag;
+    this.args = args;
     this.attrs = attrs;
     this.template = template;
   }
 
   compile(list: CompileInto & SymbolLookup, env: Environment) {
     let definition = env.getComponentDefinition([this.tag]);
-    let args = Args.fromHash(attributesToNamedArgs(this.attrs)).compile(list, env);
-    let shadow = shadowList(this.attrs);
+    let args = this.args.compile(list as SymbolLookup, env);
+    let shadow = this.attrs;
     let templates = new Templates({ template: this.template, inverse: null });
 
     list.append(new OpenComponentOpcode({ definition, args, shadow, templates }));
     list.append(new CloseComponentOpcode());
   }
-}
-
-function shadowList(attrs: Slice<AttributeSyntax>) {
-  let list: InternedString[] = [];
-
-  attrs.forEachNode(node => {
-    if (node.isAttribute()) list.push(node.name);
-  });
-
-  return list;
-}
-
-function attributesToNamedArgs(attrs: Slice<AttributeSyntax>): NamedArgs {
-  let map = dict<ExpressionSyntax>();
-
-  attrs.forEachNode(a => {
-    map[<string>a.name] = a.valueSyntax();
-  });
-
-  return NamedArgs.build(map);
 }
 
 export class OpenPrimitiveElement extends StatementSyntax {
@@ -969,7 +957,7 @@ export class Args {
     return new Args({ positional, named: NamedArgs.empty() });
   }
 
-  static fromHash(named: NamedArgs): Args {
+  static fromNamedArgs(named: NamedArgs): Args {
     return new Args({ positional: PositionalArgs.empty(), named });
   }
 


### PR DESCRIPTION
This fixes some correctness bugs that “happened to work” but also prepares for `<some-component as |local|>`, which could not have worked with the current bugs.