### PR TITLE
Failing built-in #each test

### DIFF
--- a/packages/node_modules/glimmer-runtime/tests/updating-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/updating-test.ts
@@ -625,6 +625,14 @@ test("property nodes follow the normal dirtying rules", function() {
   strictEqual(root.firstChild['foo'], true, "Revalidating after dirtying");
 });
 
+test("should not loop over strings", assert => {
+  let template = compile("{{#each list as |item|}}{{item}}{{/each}}");
+  let object = { list: 'someString' };
+
+  render(template, object);
+  equalTokens(root, '');
+});
+
 test("top-level bounds are correct when swapping order", assert => {
   let template = compile("{{#each list key='key' as |item|}}{{item.name}}{{/each}}");
 


### PR DESCRIPTION
This doesn't seem to be solved by simply adding a `TestOpcode` to the syntax and I probably would need some guidance as to how to think about the problem in order to fix it.

<img width="708" alt="screen shot 2016-02-18 at 7 21 43 am" src="https://cloud.githubusercontent.com/assets/183799/13148024/5c3fc62a-d610-11e5-8e58-1bdfdd7a3f12.png">
