### PR TITLE
Types cleanup

### DIFF
--- a/demos/glimmer-demos/visualizer.ts
+++ b/demos/glimmer-demos/visualizer.ts
@@ -369,7 +369,7 @@ function renderContent() {
 
   function compileLayout(component) {
     let definition = env.getComponentDefinition([component]);
-    let compiled = layoutFor(definition, { env });
+    let compiled = layoutFor(definition, env);
     let children = definition.compileLayout(env).children;
 
     // Fake a Block

--- a/packages/node_modules/glimmer-object/lib/object.ts
+++ b/packages/node_modules/glimmer-object/lib/object.ts
@@ -47,13 +47,13 @@ export function turbocharge(obj) {
 }
 
 abstract class SealedMeta extends Meta {
-  addReferenceTypeFor(...args): InnerReferenceFactory {
+  addReferenceTypeFor(...args): InnerReferenceFactory<any> {
     throw new Error("Cannot modify reference types on a sealed meta");
   }
 }
 
 export class ClassMeta {
-  private referenceTypes = dict<InnerReferenceFactory>();
+  private referenceTypes = dict<InnerReferenceFactory<any>>();
   private propertyMetadata = dict<any>();
   private concatenatedProperties = dict<any[]>();
   private hasConcatenatedProperties = false;
@@ -156,7 +156,7 @@ export class ClassMeta {
     return this.propertyMetadata[<string>property];
   }
 
-  addReferenceTypeFor(property: InternedString, type: InnerReferenceFactory) {
+  addReferenceTypeFor(property: InternedString, type: InnerReferenceFactory<any>) {
     this.referenceTypes[<string>property] = type;
   }
 
@@ -216,7 +216,7 @@ export class ClassMeta {
     }
   }
 
-  getReferenceTypes(): Dict<InnerReferenceFactory> {
+  getReferenceTypes(): Dict<InnerReferenceFactory<any>> {
     return this.referenceTypes;
   }
 
@@ -225,7 +225,7 @@ export class ClassMeta {
   }
 
   reset(parent: ClassMeta) {
-    this.referenceTypes = dict<InnerReferenceFactory>();
+    this.referenceTypes = dict<InnerReferenceFactory<any>>();
     this.propertyMetadata = dict();
     this.concatenatedProperties = dict<any[]>();
     this.mergedProperties = dict<Object>();
@@ -257,7 +257,7 @@ export class ClassMeta {
   }
 
   seal() {
-    let referenceTypes: Dict<InnerReferenceFactory> = turbocharge(assign({}, this.referenceTypes));
+    let referenceTypes: Dict<InnerReferenceFactory<any>> = turbocharge(assign({}, this.referenceTypes));
     turbocharge(this.concatenatedProperties);
     turbocharge(this.mergedProperties);
 
@@ -277,13 +277,13 @@ export class ClassMeta {
 
     this.InstanceMetaConstructor = class extends SealedMeta {
       protected slots: Slots = new Slots();
-      public referenceTypes: Dict<InnerReferenceFactory> = referenceTypes;
+      public referenceTypes: Dict<InnerReferenceFactory<any>> = referenceTypes;
 
       getReferenceTypes() {
         return this.referenceTypes;
       }
 
-      referenceTypeFor(property: InternedString): InnerReferenceFactory {
+      referenceTypeFor(property: InternedString): InnerReferenceFactory<any> {
         return this.referenceTypes[<string>property] || PropertyReference;
       }
 

--- a/packages/node_modules/glimmer-object/tests/ember-metal-alias-test.ts
+++ b/packages/node_modules/glimmer-object/tests/ember-metal-alias-test.ts
@@ -15,11 +15,11 @@ QUnit.module('defineProperty - alias', {
   }
 });
 
-function shouldBeClean(reference: Reference, msg?: string) {
+function shouldBeClean(reference: Reference<any>, msg?: string) {
   // a "clean" reference is allowed to report dirty
 }
 
-function shouldBeDirty(reference: Reference, msg?: string) {
+function shouldBeDirty(reference: Reference<any>, msg?: string) {
   equal(reference.isDirty(), true, msg || `${reference} should be dirty`);
 }
 

--- a/packages/node_modules/glimmer-object/tests/object-test.ts
+++ b/packages/node_modules/glimmer-object/tests/object-test.ts
@@ -142,8 +142,8 @@ QUnit.test('the simple object model allows you to derive references', function()
   }
 });
 
-function root(obj): UpdatableReference {
-  return metaFor(obj).root() as UpdatableReference;
+function root<T>(obj: T): UpdatableReference<T> {
+  return metaFor(obj).root() as UpdatableReference<T>;
 }
 
 QUnit.test("Simple computed properties", function() {

--- a/packages/node_modules/glimmer-reference/lib/meta.ts
+++ b/packages/node_modules/glimmer-reference/lib/meta.ts
@@ -17,7 +17,7 @@ import { InnerReferenceFactory } from './references/descriptors';
 
 const NOOP_DESTROY = { destroy() {} };
 
-class ConstPath implements IPathReference {
+class ConstPath implements IPathReference<any> {
   private parent: any;
   private property: InternedString;
 
@@ -34,12 +34,12 @@ class ConstPath implements IPathReference {
     return this.parent[<string>this.property];
   }
 
-  get(prop: InternedString): IPathReference {
+  get(prop: InternedString): IPathReference<any> {
     return new ConstPath(this.parent[<string>this.property], prop);
   }
 }
 
-class ConstRoot implements IRootReference {
+class ConstRoot implements IRootReference<any> {
   private inner: any;
   private dirty = false;
 
@@ -62,15 +62,15 @@ class ConstRoot implements IRootReference {
     return this.inner;
   }
 
-  referenceFromParts(parts: InternedString[]): IPathReference {
+  referenceFromParts(parts: InternedString[]): IPathReference<any> {
     throw new Error("Not implemented");
   }
 
-  chainFor(prop: InternedString): IPathReference {
+  chainFor(prop: InternedString): IPathReference<any> {
     throw new Error("Not implemented");
   }
 
-  get(prop: InternedString): IPathReference {
+  get(prop: InternedString): IPathReference<any> {
     return new ConstPath(this.inner, prop);
   }
 }
@@ -82,7 +82,7 @@ class ConstMeta /*implements IMeta*/ {
     this.object = object;
   }
 
-  root(): IRootReference {
+  root(): ConstRoot {
     return new ConstRoot(this.object);
   }
 }
@@ -118,13 +118,13 @@ class Meta implements IMeta, HasGuid {
   }
 
   private object: any;
-  private RootReferenceFactory: RootReferenceFactory;
-  private DefaultPathReferenceFactory: InnerReferenceFactory;
-  private rootCache: IRootReference;
-  private references: Dict<DictSet<IPathReference & HasGuid>> = null;
+  private RootReferenceFactory: RootReferenceFactory<any>;
+  private DefaultPathReferenceFactory: InnerReferenceFactory<any>;
+  private rootCache: IRootReference<any>;
+  private references: Dict<DictSet<IPathReference<any> & HasGuid>> = null;
   public _guid;
   protected slots: Dict<any> = null;
-  protected referenceTypes: Dict<InnerReferenceFactory> = null;
+  protected referenceTypes: Dict<InnerReferenceFactory<any>> = null;
   protected propertyMetadata: Dict<any> = null;
 
   constructor(object: any, { RootReferenceFactory, DefaultPathReferenceFactory }: MetaOptions) {
@@ -133,34 +133,34 @@ class Meta implements IMeta, HasGuid {
     this.DefaultPathReferenceFactory = DefaultPathReferenceFactory || PropertyReference;
   }
 
-  addReference(property: InternedString, reference: IPathReference & HasGuid) {
-    let refs = this.references = this.references || dict<DictSet<IPathReference & HasGuid>>();
-    let set = refs[<string>property] = refs[<string>property] || new DictSet<IPathReference & HasGuid>();
+  addReference(property: InternedString, reference: IPathReference<any> & HasGuid) {
+    let refs = this.references = this.references || dict<DictSet<IPathReference<any> & HasGuid>>();
+    let set = refs[<string>property] = refs[<string>property] || new DictSet<IPathReference<any> & HasGuid>();
     set.add(reference);
   }
 
-  addReferenceTypeFor(property: InternedString, type: PathReferenceFactory) {
-    this.referenceTypes = this.referenceTypes || dict<PathReferenceFactory>();
+  addReferenceTypeFor(property: InternedString, type: PathReferenceFactory<any>) {
+    this.referenceTypes = this.referenceTypes || dict<PathReferenceFactory<any>>();
     this.referenceTypes[<string>property] = type;
   }
 
-  referenceTypeFor(property: InternedString): InnerReferenceFactory {
+  referenceTypeFor(property: InternedString): InnerReferenceFactory<any> {
     if (!this.referenceTypes) return PropertyReference;
     return this.referenceTypes[<string>property] || PropertyReference;
   }
 
-  removeReference(property: InternedString, reference: IPathReference & HasGuid) {
+  removeReference(property: InternedString, reference: IPathReference<any> & HasGuid) {
     if (!this.references) return;
     let set = this.references[<string>property];
     set.delete(reference);
   }
 
-  getReferenceTypes(): Dict<InnerReferenceFactory> {
-    this.referenceTypes = this.referenceTypes || dict<PathReferenceFactory>();
+  getReferenceTypes(): Dict<InnerReferenceFactory<any>> {
+    this.referenceTypes = this.referenceTypes || dict<PathReferenceFactory<any>>();
     return this.referenceTypes;
   }
 
-  referencesFor(property: InternedString): Set<IPathReference> {
+  referencesFor(property: InternedString): Set<IPathReference<any>> {
     if (!this.references) return;
     return this.references[<string>property];
   }
@@ -169,7 +169,7 @@ class Meta implements IMeta, HasGuid {
     return (this.slots = this.slots || dict());
   }
 
-  root(): IRootReference {
+  root(): IRootReference<any> {
     return (this.rootCache = this.rootCache || new this.RootReferenceFactory(this.object));
   }
 }

--- a/packages/node_modules/glimmer-reference/lib/references/const.ts
+++ b/packages/node_modules/glimmer-reference/lib/references/const.ts
@@ -1,6 +1,6 @@
-import { ChainableReference } from '../types';
+import { Reference } from '../types';
 
-export class ConstReference<T> implements ChainableReference {
+export class ConstReference<T> implements Reference<T> {
   protected inner: T;
 
   constructor(inner: T) {

--- a/packages/node_modules/glimmer-reference/lib/references/descriptors.ts
+++ b/packages/node_modules/glimmer-reference/lib/references/descriptors.ts
@@ -3,15 +3,15 @@ import { Reference, NotifiableReference } from 'glimmer-reference';
 import { InternedString } from 'glimmer-util';
 import PushPullReference from './push-pull';
 
-export interface InnerReferenceFactory {
-  new (object: any, property: InternedString, outer: NotifiableReference): Reference;
+export interface InnerReferenceFactory<T> {
+  new (object: any, property: InternedString, outer: NotifiableReference<any>): Reference<T>;
 }
 
-export class PropertyReference implements Reference {
+export class PropertyReference<T> implements Reference<T> {
   private object: any;
   private property: InternedString;
 
-  constructor(object: any, property: InternedString, outer: NotifiableReference) {
+  constructor(object: any, property: InternedString, outer: NotifiableReference<T>) {
     this.object = object;
     this.property = property;
   }
@@ -26,14 +26,14 @@ export class PropertyReference implements Reference {
 }
 
 export function ComputedReferenceBlueprint(property, dependencies) {
-  return class ComputedReference extends PushPullReference implements Reference {
+  return class ComputedReference<T> extends PushPullReference<T> implements Reference<T> {
     private object: any;
     private property: InternedString;
     private dependencies: InternedString[][];
-    private outer: NotifiableReference;
+    private outer: NotifiableReference<T>;
     private installed = false;
 
-    constructor(object: any, property: InternedString, outer: NotifiableReference) {
+    constructor(object: any, property: InternedString, outer: NotifiableReference<T>) {
       super();
       this.object = object;
       this.property = property;

--- a/packages/node_modules/glimmer-reference/lib/references/forked.ts
+++ b/packages/node_modules/glimmer-reference/lib/references/forked.ts
@@ -1,13 +1,13 @@
 import { ChainableReference, NotifiableReference } from 'glimmer-reference';
 import { HasGuid } from 'glimmer-util';
 
-export default class ForkedReference implements NotifiableReference, HasGuid {
-  private reference: ChainableReference;
+export default class ForkedReference<T> implements NotifiableReference<T>, HasGuid {
+  private reference: ChainableReference<T>;
   // private chain: Destroyable;
   public _guid: number = null;
   private dirty: boolean = true;
 
-  constructor(reference: ChainableReference) {
+  constructor(reference: ChainableReference<T>) {
     this.reference = reference;
     this._guid = null;
     this.dirty = true;
@@ -37,6 +37,6 @@ export default class ForkedReference implements NotifiableReference, HasGuid {
   }
 }
 
-export function fork(reference: ChainableReference): ForkedReference {
+export function fork<T>(reference: ChainableReference<T>): ForkedReference<T> {
   return new ForkedReference(reference);
 }

--- a/packages/node_modules/glimmer-reference/lib/references/iterable.ts
+++ b/packages/node_modules/glimmer-reference/lib/references/iterable.ts
@@ -1,42 +1,42 @@
 import { LinkedList, ListNode, InternedString, Dict, dict, intern, symbol } from 'glimmer-util';
-import { RootReference } from '../types';
+import { Reference, PathReference } from '../types';
 import UpdatableReference from './root';
 
 export const REFERENCE_ITERATOR: string = symbol("reference-iterator");
 
 export interface ListDelegate {
-  retain(key: InternedString, item: RootReference);
-  insert(key: InternedString, item: RootReference, before: InternedString);
-  move(key: InternedString, item: RootReference, before: InternedString);
+  retain(key: InternedString, item: PathReference<any>);
+  insert(key: InternedString, item: PathReference<any>, before: InternedString);
+  move(key: InternedString, item: PathReference<any>, before: InternedString);
   delete(key: InternedString);
   done();
 }
 
-class ListItem extends ListNode<UpdatableReference> {
+class ListItem<T> extends ListNode<UpdatableReference<T>> {
   public key: InternedString;
   public handled: boolean = true;
 
-  constructor(value: UpdatableReference, key: InternedString) {
+  constructor(value: UpdatableReference<T>, key: InternedString) {
     super(value);
     this.key = key;
   }
 
-  handle(value: any) {
+  handle(value: T) {
     this.handled = true;
     this.value.update(value);
   }
 }
 
 export class ListManager {
-  private array: RootReference;
+  private array: Reference<any[]>;
   private keyPath: InternedString;
 
   /* tslint:disable:no-unused-variable */
-  private map = dict<ListItem>();
-  private list = new LinkedList<ListItem>();
+  private map = dict<ListItem<any>>();
+  private list = new LinkedList<ListItem<any>>();
   /* tslint:enable:no-unused-variable */
 
-  constructor(array: RootReference, keyPath: InternedString) {
+  constructor(array: Reference<any[]>, keyPath: InternedString) {
     this.array = array;
     this.keyPath = keyPath;
   }
@@ -69,8 +69,8 @@ interface IteratorOptions {
   array: any[];
   keyFor: (obj: any, index: number) => InternedString;
   target: ListDelegate;
-  map: Dict<ListItem>;
-  list: LinkedList<ListItem>;
+  map: Dict<ListItem<any>>;
+  list: LinkedList<ListItem<any>>;
 }
 
 enum Phase {
@@ -82,17 +82,17 @@ enum Phase {
 
 export class ListIterator {
   /* tslint:disable:no-unused-variable */
-  private candidates = dict<ListItem>();
+  private candidates = dict<ListItem<any>>();
   /* tslint:enable:no-unused-variable*/
   private array: any[];
   private keyFor: (obj, index: number) => InternedString;
   private target: ListDelegate;
 
-  private map: Dict<ListItem>;
-  private list: LinkedList<ListItem>;
+  private map: Dict<ListItem<any>>;
+  private list: LinkedList<ListItem<any>>;
 
   private arrayPosition = 0;
-  private listPosition: ListItem;
+  private listPosition: ListItem<any>;
   private phase: Phase = Phase.Append;
 
   constructor({ array, keyFor, target, map, list }: IteratorOptions) {
@@ -182,13 +182,13 @@ export class ListIterator {
     }
   }
 
-  private nextRetain(current: ListItem, key: InternedString, item: any) {
+  private nextRetain(current: ListItem<any>, key: InternedString, item: any) {
     current.handle(item);
     this.listPosition = this.list.nextNode(current);
     this.target.retain(key, item);
   }
 
-  private nextMove(map: Dict<ListItem>, current: ListItem, key: InternedString, item: any) {
+  private nextMove(map: Dict<ListItem<any>>, current: ListItem<any>, key: InternedString, item: any) {
     let { candidates, list, target } = this;
     let found = map[<string>key];
     found.handle(item);
@@ -202,7 +202,7 @@ export class ListIterator {
     }
   }
 
-  private nextInsert(map: Dict<ListItem>, current: ListItem, key: InternedString, item: any) {
+  private nextInsert(map: Dict<ListItem<any>>, current: ListItem<any>, key: InternedString, item: any) {
     let { list, target } = this;
 
     let reference = new UpdatableReference(item);

--- a/packages/node_modules/glimmer-reference/lib/references/path.ts
+++ b/packages/node_modules/glimmer-reference/lib/references/path.ts
@@ -8,10 +8,10 @@ import { PathReference as IPathReference, Reference, Destroyable } from 'glimmer
 import { Dict, HasGuid } from 'glimmer-util';
 
 class UnchainFromPath {
-  private set: DictSet<PathReference & HasGuid>;
-  private child: PathReference & HasGuid;
+  private set: DictSet<PathReference<any> & HasGuid>;
+  private child: PathReference<any> & HasGuid;
 
-  constructor(set: DictSet<PathReference & HasGuid>, child: PathReference & HasGuid) {
+  constructor(set: DictSet<PathReference<any> & HasGuid>, child: PathReference<any> & HasGuid) {
     this.set = set;
     this.child = child;
   }
@@ -21,17 +21,17 @@ class UnchainFromPath {
   }
 }
 
-export class PathReference extends PushPullReference implements IPathReference, HasGuid {
-  private parent: IPathReference;
+export class PathReference<T> extends PushPullReference<T> implements IPathReference<T>, HasGuid {
+  private parent: IPathReference<any>;
   private property: InternedString;
   protected cache: any = EMPTY_CACHE;
-  private inner: Reference = null;
-  private chains: Dict<PathReference> = null;
-  private notifyChildren: DictSet<PathReference> = null;
+  private inner: Reference<T> = null;
+  private chains: Dict<PathReference<any>> = null;
+  private notifyChildren: DictSet<PathReference<any>> = null;
   private lastParentValue: any = EMPTY_CACHE;
   public _guid = null;
 
-  constructor(parent: IPathReference, property: InternedString) {
+  constructor(parent: IPathReference<T>, property: InternedString) {
     super();
     this.parent = parent;
     this.property = property;
@@ -67,19 +67,19 @@ export class PathReference extends PushPullReference implements IPathReference, 
     super.notify();
   }
 
-  get(prop: InternedString): IPathReference {
+  get(prop: InternedString): IPathReference<any> {
     let chains = this._getChains();
     if (<string>prop in chains) return chains[<string>prop];
     return (chains[<string>prop] = new PathReference(this, prop));
   }
 
-  chain(child: PathReference): Destroyable {
+  chain(child: PathReference<any>): Destroyable {
     let notifySet = this._getNotifyChildren();
     notifySet.add(child);
     return new UnchainFromPath(notifySet, child);
   }
 
-  fork(): Reference {
+  fork(): Reference<T> {
     return new ForkedReference(this);
   }
 
@@ -87,14 +87,14 @@ export class PathReference extends PushPullReference implements IPathReference, 
     return '[reference Direct]';
   }
 
-  private _getNotifyChildren(): DictSet<PathReference> {
+  private _getNotifyChildren(): DictSet<PathReference<any>> {
     if (this.notifyChildren) return this.notifyChildren;
-    return (this.notifyChildren = new DictSet<PathReference>());
+    return (this.notifyChildren = new DictSet<PathReference<any>>());
   }
 
-  private _getChains(): Dict<PathReference> {
+  private _getChains(): Dict<PathReference<any>> {
     if (this.chains) return this.chains;
-    return (this.chains = dict<PathReference>());
+    return (this.chains = dict<PathReference<any>>());
   }
 
   private _parentValue() {

--- a/packages/node_modules/glimmer-reference/lib/references/push-pull.ts
+++ b/packages/node_modules/glimmer-reference/lib/references/push-pull.ts
@@ -2,8 +2,8 @@ import { Destroyable, Reference, NotifiableReference, ChainableReference } from 
 import { HasGuid } from 'glimmer-util';
 
 class NotifyNode {
-  public parent: PushPullReference;
-  public child: NotifiableReference;
+  public parent: PushPullReference<any>;
+  public child: NotifiableReference<any>;
   public previousSibling: NotifyNode = null;
   public nextSibling: NotifyNode = null;
 
@@ -14,10 +14,10 @@ class NotifyNode {
 }
 
 class Unchain {
-  private reference: PushPullReference;
+  private reference: PushPullReference<any>;
   private notifyNode: NotifyNode;
 
-  constructor(reference: PushPullReference, notifyNode: NotifyNode) {
+  constructor(reference: PushPullReference<any>, notifyNode: NotifyNode) {
     this.reference = reference;
     this.notifyNode = notifyNode;
   }
@@ -33,7 +33,7 @@ class Unchain {
   }
 }
 
-export abstract class PushPullReference implements Reference, ChainableReference, NotifiableReference, HasGuid {
+export abstract class PushPullReference<T> implements Reference<T>, ChainableReference<T>, NotifiableReference<T>, HasGuid {
   protected dirty = true;
   public _notifyTail: NotifyNode = null;
   private sources: Destroyable[] = null;
@@ -41,7 +41,7 @@ export abstract class PushPullReference implements Reference, ChainableReference
 
   isDirty() { return true; }
 
-  chain(child: NotifiableReference): Destroyable {
+  chain(child: NotifiableReference<any>): Destroyable {
     // return this._append(child);
     return null;
   }
@@ -61,7 +61,7 @@ export abstract class PushPullReference implements Reference, ChainableReference
     this.sources.forEach(source => source.destroy());
   }
 
-  protected _addSource<T extends ChainableReference>(source: T): T {
+  protected _addSource<T extends ChainableReference<any>>(source: T): T {
     // this.sources = this.sources || [];
     // this.sources.push(source.chain(this));
     return source;

--- a/packages/node_modules/glimmer-reference/lib/references/root.ts
+++ b/packages/node_modules/glimmer-reference/lib/references/root.ts
@@ -3,31 +3,31 @@ import { PathReference } from './path';
 import { RootReference as IRootReference, PathReference as IPathReference } from 'glimmer-reference';
 import PushPullReference from './push-pull';
 
-export default class RootReference extends PushPullReference implements IRootReference, IPathReference {
-  private object: any;
-  private chains = dict<PathReference>();
+export default class RootReference<T> extends PushPullReference<T> implements IRootReference<T>, IPathReference<T> {
+  private object: T;
+  private chains = dict<PathReference<any>>();
 
-  constructor(object: any) {
+  constructor(object: T) {
     super();
     this.object = object;
   }
 
   isDirty() { return true; }
 
-  value() { return this.object; }
+  value(): T { return this.object; }
 
-  update(object: any) {
+  update(object: T) {
     this.object = object;
     // this.notify();
   }
 
-  get(prop: InternedString): IPathReference {
+  get<U>(prop: InternedString): IPathReference<U> {
     let chains = this.chains;
     if (<string>prop in chains) return chains[<string>prop];
     return (chains[<string>prop] = new PathReference(this, prop));
   }
 
-  chainFor(prop: InternedString): IPathReference {
+  chainFor<U>(prop: InternedString): IPathReference<U> {
     let chains = this.chains;
     if (<string>prop in chains) return chains[<string>prop];
     return null;
@@ -37,8 +37,8 @@ export default class RootReference extends PushPullReference implements IRootRef
     return string.split('.').reduce((ref, part) => ref.get(intern(part)), this);
   }
 
-  referenceFromParts(parts: InternedString[]): IPathReference {
-    return parts.reduce((ref, part) => ref.get(part), <IPathReference>this);
+  referenceFromParts(parts: InternedString[]): IPathReference<any> {
+    return parts.reduce((ref, part) => ref.get(part), <IPathReference<T>>this);
   }
 
   label() {
@@ -46,6 +46,6 @@ export default class RootReference extends PushPullReference implements IRootRef
   }
 }
 
-export function referenceFromParts(path: IPathReference, parts: InternedString[]): IPathReference {
+export function referenceFromParts<T>(path: IPathReference<T>, parts: InternedString[]): IPathReference<any> {
   return parts.reduce((ref, part) => ref.get(part), path);
 }

--- a/packages/node_modules/glimmer-reference/lib/types.ts
+++ b/packages/node_modules/glimmer-reference/lib/types.ts
@@ -4,29 +4,29 @@ export interface Destroyable {
   destroy();
 }
 
-export interface Reference extends Destroyable {
-  value(): any;
+export interface Reference<T> extends Destroyable {
+  value(): T;
   isDirty(): boolean;
 }
 
-export interface NotifiableReference extends Reference {
+export interface NotifiableReference<T> extends Reference<T> {
   // notify();
 }
 
-export interface ChainableReference extends Reference {
+export interface ChainableReference<T> extends Reference<T> {
   // chain(child: Reference): Destroyable;
 }
 
-export interface PathReferenceFactory {
-  new (object: any, property: InternedString): PathReference;
+export interface PathReferenceFactory<T> {
+  new (object: any, property: InternedString): PathReference<T>;
 }
 
-export interface PathReference extends ChainableReference, NotifiableReference {
-  get(key: InternedString): PathReference;
+export interface PathReference<T> extends ChainableReference<T>, NotifiableReference<T> {
+  get(key: InternedString): PathReference<any>;
 }
 
-export interface RootReferenceFactory {
-  new (parent: any): RootReference;
+export interface RootReferenceFactory<T> {
+  new (object: T): RootReference<T>;
 }
 
 export const CONST_REFERENCE = "503c5a44-e4a9-4bb5-85bc-102d35af6985";
@@ -35,30 +35,30 @@ export const CONST_REFERENCE = "503c5a44-e4a9-4bb5-85bc-102d35af6985";
 // the value() will always be `===` to the previous value. It can
 // be used to optimize code by replacing the reference with the
 // literal value and avoiding updating-related bookkeeping.
-export interface ConstReference extends PathReference {
+export interface ConstReference<T> extends PathReference<T> {
   "503c5a44-e4a9-4bb5-85bc-102d35af6985": boolean;
 }
 
-export interface RootReference extends PathReference {
-  update(value: any);
-  referenceFromParts(parts: InternedString[]): PathReference;
-  chainFor(prop: InternedString): PathReference;
+export interface RootReference<T> extends PathReference<T> {
+  update(value: T);
+  referenceFromParts(parts: InternedString[]): PathReference<T>;
+  chainFor(prop: InternedString): PathReference<T>;
 }
 
 import { InnerReferenceFactory } from './references/descriptors';
 
 export interface MetaOptions {
-  RootReferenceFactory?: RootReferenceFactory;
-  DefaultPathReferenceFactory?: InnerReferenceFactory;
+  RootReferenceFactory?: RootReferenceFactory<any>;
+  DefaultPathReferenceFactory?: InnerReferenceFactory<any>;
 }
 
 export interface Meta {
-  root(): RootReference;
-  referencesFor(property: InternedString): Set<PathReference>;
-  referenceTypeFor(property: InternedString): InnerReferenceFactory;
-  getReferenceTypes(): Dict<InnerReferenceFactory>;
-  addReference(property: InternedString, reference: PathReference);
-  removeReference(property: InternedString, reference: PathReference);
+  root(): RootReference<any>;
+  referencesFor(property: InternedString): Set<PathReference<any>>;
+  referenceTypeFor(property: InternedString): InnerReferenceFactory<any>;
+  getReferenceTypes(): Dict<InnerReferenceFactory<any>>;
+  addReference(property: InternedString, reference: PathReference<any>);
+  removeReference(property: InternedString, reference: PathReference<any>);
   getSlots(): Dict<any>;
 }
 

--- a/packages/node_modules/glimmer-reference/tests/iterable-test.ts
+++ b/packages/node_modules/glimmer-reference/tests/iterable-test.ts
@@ -4,19 +4,19 @@ import { LITERAL, LinkedList, ListNode, InternedString, dict } from 'glimmer-uti
 QUnit.module("Reference iterables");
 
 class Target implements ListDelegate {
-  private map = dict<ListNode<RootReference>>();
-  private list = new LinkedList<ListNode<RootReference>>();
+  private map = dict<ListNode<RootReference<any>>>();
+  private list = new LinkedList<ListNode<RootReference<any>>>();
 
   retain() {}
   done() {}
 
-  insert(key: InternedString, item: RootReference, before: InternedString) {
+  insert(key: InternedString, item: RootReference<any>, before: InternedString) {
     let referenceNode = before ? this.map[<string>before] : null;
     let node = this.map[<string>key] = new ListNode(item);
     this.list.insertBefore(node, referenceNode);
   }
 
-  move(key: InternedString, item: RootReference, before: InternedString) {
+  move(key: InternedString, item: RootReference<any>, before: InternedString) {
     let referenceNode = before ? this.map[<string>before] : null;
     let node = this.map[<string>key];
     this.list.remove(node);
@@ -35,7 +35,7 @@ class Target implements ListDelegate {
 }
 
 function toValues(target: Target): any[] {
-  let refs: Reference[] = target.toArray();
+  let refs: Reference<any>[] = target.toArray();
   return refs.map(ref => ref.value());
 }
 

--- a/packages/node_modules/glimmer-runtime/index.ts
+++ b/packages/node_modules/glimmer-runtime/index.ts
@@ -138,8 +138,7 @@ export {
   ComponentManager,
   ComponentDefinition,
   ComponentLayoutBuilder,
-  ComponentAttrsBuilder,
-  ComponentBodyBuilder
+  ComponentAttrsBuilder
 } from './lib/component/interfaces';
 
 export { default as DOMHelper, DOMHelper as IDOMHepler, isWhitespace } from './lib/dom';

--- a/packages/node_modules/glimmer-runtime/lib/builder.ts
+++ b/packages/node_modules/glimmer-runtime/lib/builder.ts
@@ -76,15 +76,15 @@ class GroupedElementOperations {
     this.groups.push(group);
   }
 
-  addAttribute(name: InternedString, value: PathReference) {
+  addAttribute(name: InternedString, value: PathReference<string>) {
     this.group.push(new NonNamespacedAttribute(name, value));
   }
 
-  addAttributeNS(name: InternedString, value: PathReference, namespace: InternedString) {
+  addAttributeNS(name: InternedString, value: PathReference<string>, namespace: InternedString) {
     this.group.push(new NamespacedAttribute(name, value, namespace));
   }
 
-  addProperty(name: InternedString, value: PathReference) {
+  addProperty(name: InternedString, value: PathReference<any>) {
     this.group.push(new Property(name, value));
   }
 }
@@ -223,15 +223,15 @@ export class ElementStack {
   //   this.dom.setAttributeNS(this.element, name, value, namespace);
   // }
 
-  setAttribute(name: InternedString, value: PathReference) {
+  setAttribute(name: InternedString, value: PathReference<string>) {
     this.elementOperations.addAttribute(name, value);
   }
 
-  setAttributeNS(name: InternedString, value: PathReference, namespace: InternedString) {
+  setAttributeNS(name: InternedString, value: PathReference<string>, namespace: InternedString) {
     this.elementOperations.addAttributeNS(name, value, namespace);
   }
 
-  setProperty(name: InternedString, value: PathReference) {
+  setProperty(name: InternedString, value: PathReference<any>) {
     this.elementOperations.addProperty(name, value);
   }
 

--- a/packages/node_modules/glimmer-runtime/lib/compiled/expressions.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/expressions.ts
@@ -1,9 +1,9 @@
 import VM from '../vm/append';
 import { PathReference } from 'glimmer-reference';
 
-export abstract class CompiledExpression {
+export abstract class CompiledExpression<T> {
   type: string;
-  abstract evaluate(vm: VM): PathReference;
+  abstract evaluate(vm: VM): PathReference<T>;
 
   toJSON(): string {
     return `UNIMPL: ${this.type.toUpperCase()}`;

--- a/packages/node_modules/glimmer-runtime/lib/compiled/expressions/args.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/expressions/args.ts
@@ -70,7 +70,7 @@ export abstract class EvaluatedArgs {
     return new NonEmptyEvaluatedArgs(options);
   }
 
-  static positional(values: PathReference[]): EvaluatedArgs {
+  static positional(values: PathReference<any>[]): EvaluatedArgs {
     return new NonEmptyEvaluatedArgs({ positional: EvaluatedPositionalArgs.create({ values }), named: EvaluatedNamedArgs.empty() });
   }
 

--- a/packages/node_modules/glimmer-runtime/lib/compiled/expressions/concat.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/expressions/concat.ts
@@ -1,17 +1,18 @@
 import { CompiledExpression } from '../expressions';
 import VM from '../../vm/append';
-import { PathReference, ChainableReference } from 'glimmer-reference';
+import { PathReference, Reference } from 'glimmer-reference';
+import { Opaque, FIXME } from 'glimmer-util';
 
 export default class CompiledConcat {
   public type = "concat";
-  public parts: CompiledExpression[];
+  public parts: CompiledExpression<Opaque>[];
 
-  constructor({ parts }: { parts: CompiledExpression[] }) {
+  constructor({ parts }: { parts: CompiledExpression<Opaque>[] }) {
     this.parts = parts;
   }
 
   evaluate(vm: VM): ConcatReference {
-    let parts = new Array(this.parts.length);
+    let parts: PathReference<Opaque>[] = new Array(this.parts.length);
     for (let i = 0; i < this.parts.length; i++) {
       parts[i] = this.parts[i].evaluate(vm);
     }
@@ -23,10 +24,10 @@ export default class CompiledConcat {
   }
 }
 
-class ConcatReference implements ChainableReference {
-  private parts: PathReference[];
+class ConcatReference implements Reference<string> {
+  private parts: PathReference<Opaque>[];
 
-  constructor(parts: PathReference[]) {
+  constructor(parts: PathReference<Opaque>[]) {
     this.parts = parts;
   }
 
@@ -34,10 +35,10 @@ class ConcatReference implements ChainableReference {
     return true;
   }
 
-  value() {
-    let parts = new Array(this.parts.length);
+  value(): string {
+    let parts = new Array<string>(this.parts.length);
     for (let i = 0; i < this.parts.length; i++) {
-      parts[i] = this.parts[i].value();
+      parts[i] = this.parts[i].value() as FIXME<'convert opaque to str'>;
     }
     return parts.join('');
   }

--- a/packages/node_modules/glimmer-runtime/lib/compiled/expressions/function.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/expressions/function.ts
@@ -3,36 +3,36 @@ import { Expression as ExpressionSyntax } from '../../syntax';
 import { CompiledExpression } from '../expressions';
 import { PublicVM as VM } from '../../vm';
 
-export type FunctionExpression = (VM) => PathReference;
+export type FunctionExpression<T> = (VM) => PathReference<T>;
 
-export default function make(func: FunctionExpression): ExpressionSyntax {
+export default function make<T>(func: FunctionExpression<T>): ExpressionSyntax<T> {
   return new FunctionExpressionSyntax(func);
 }
 
-class FunctionExpressionSyntax extends ExpressionSyntax {
-  private func: FunctionExpression;
+class FunctionExpressionSyntax<T> extends ExpressionSyntax<T> {
+  private func: FunctionExpression<T>;
 
-  constructor(func: FunctionExpression) {
+  constructor(func: FunctionExpression<T>) {
     super();
     this.func = func;
   }
 
-  compile(): CompiledExpression {
+  compile(): CompiledExpression<T> {
     return new CompiledFunctionExpression(this.func);
   }
 }
 
-class CompiledFunctionExpression extends CompiledExpression {
+class CompiledFunctionExpression<T> extends CompiledExpression<T> {
   type = "function";
 
-  private func: FunctionExpression;
+  private func: FunctionExpression<T>;
 
-  constructor(func: FunctionExpression) {
+  constructor(func: FunctionExpression<T>) {
     super();
     this.func = func;
   }
 
-  evaluate(vm: VM) {
+  evaluate(vm: VM): PathReference<T> {
     return this.func.call(undefined, vm);
   }
 

--- a/packages/node_modules/glimmer-runtime/lib/compiled/expressions/helper.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/expressions/helper.ts
@@ -4,7 +4,7 @@ import VM from '../../vm/append';
 import { Helper } from '../../environment';
 import { PathReference } from 'glimmer-reference';
 
-export default class CompiledHelper extends CompiledExpression {
+export default class CompiledHelper<T> extends CompiledExpression<T> {
   public type = "helper";
   public helper: Helper;
   public args: CompiledArgs;
@@ -15,12 +15,12 @@ export default class CompiledHelper extends CompiledExpression {
     this.args = args;
   }
 
-  evaluate(vm: VM): PathReference {
+  evaluate(vm: VM): PathReference<T> {
     return new HelperInvocationReference(this.helper, this.args.evaluate(vm));
   }
 }
 
-class HelperInvocationReference implements PathReference {
+class HelperInvocationReference<T> implements PathReference<T> {
   private helper: Helper;
   private args: EvaluatedArgs;
 
@@ -29,7 +29,7 @@ class HelperInvocationReference implements PathReference {
     this.args = args;
   }
 
-  get(): PathReference {
+  get(): PathReference<T> {
     throw new Error("Unimplemented: Yielding the result of a helper call.");
   }
 

--- a/packages/node_modules/glimmer-runtime/lib/compiled/expressions/named-args.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/expressions/named-args.ts
@@ -5,7 +5,7 @@ import { PathReference } from 'glimmer-reference';
 import { InternedString, Dict, dict } from 'glimmer-util';
 
 export abstract class CompiledNamedArgs {
-  static create({ map }: { map: Dict<CompiledExpression> }): CompiledNamedArgs {
+  static create({ map }: { map: Dict<CompiledExpression<any>> }): CompiledNamedArgs {
     if (Object.keys(map).length) {
       return new CompiledNonEmptyNamedArgs({ map });
     } else {
@@ -14,16 +14,16 @@ export abstract class CompiledNamedArgs {
   }
 
   public type: string;
-  public map: Dict<CompiledExpression>;
+  public map: Dict<CompiledExpression<any>>;
   abstract evaluate(vm: VM): EvaluatedNamedArgs;
   abstract toJSON(): string;
 }
 
 class CompiledNonEmptyNamedArgs extends CompiledNamedArgs {
   public type = "named-args";
-  public map: Dict<CompiledExpression>;
+  public map: Dict<CompiledExpression<any>>;
 
-  constructor({ map }: { map: Dict<CompiledExpression> }) {
+  constructor({ map }: { map: Dict<CompiledExpression<any>> }) {
     super();
     this.map = map;
   }
@@ -31,7 +31,7 @@ class CompiledNonEmptyNamedArgs extends CompiledNamedArgs {
   evaluate(vm: VM): EvaluatedNamedArgs {
     let { map } = this;
 
-    let compiledMap = dict<PathReference>();
+    let compiledMap = dict<PathReference<any>>();
     let compiledKeys = Object.keys(map);
 
     for (let i = 0; i < compiledKeys.length; i++) {
@@ -51,7 +51,7 @@ class CompiledNonEmptyNamedArgs extends CompiledNamedArgs {
 
 export const COMPILED_EMPTY_NAMED_ARGS = new (class extends CompiledNamedArgs {
   public type = "empty-named-args";
-  public map = dict<CompiledExpression>();
+  public map = dict<CompiledExpression<any>>();
 
   evaluate(vm): EvaluatedNamedArgs {
     return EvaluatedNamedArgs.empty();
@@ -67,14 +67,14 @@ export abstract class EvaluatedNamedArgs {
     return EVALUATED_EMPTY_NAMED_ARGS;
   }
 
-  static create({ map }: { map: Dict<PathReference> }) {
+  static create({ map }: { map: Dict<PathReference<any>> }) {
     return new NonEmptyEvaluatedNamedArgs({ map });
   }
 
   public type: string;
-  public map: Dict<PathReference>;
+  public map: Dict<PathReference<any>>;
 
-  forEach(callback: (key: InternedString, value: PathReference) => void) {
+  forEach(callback: (key: InternedString, value: PathReference<any>) => void) {
     let { map } = this;
     let mapKeys = Object.keys(map);
 
@@ -84,23 +84,23 @@ export abstract class EvaluatedNamedArgs {
     }
   }
 
-  abstract get(key: InternedString): PathReference;
+  abstract get(key: InternedString): PathReference<any>;
   abstract has(key: InternedString): boolean;
   abstract value(): Dict<any>;
 }
 
 class NonEmptyEvaluatedNamedArgs extends EvaluatedNamedArgs {
-  public values: PathReference[];
+  public values: PathReference<any>[];
   public keys: InternedString[];
-  public map: Dict<PathReference>;
+  public map: Dict<PathReference<any>>;
 
-  constructor({ map }: { map: Dict<PathReference> }) {
+  constructor({ map }: { map: Dict<PathReference<any>> }) {
     super();
 
     this.map = map;
   }
 
-  get(key: InternedString): PathReference {
+  get(key: InternedString): PathReference<any> {
     return this.map[<string>key];
   }
 
@@ -124,7 +124,7 @@ class NonEmptyEvaluatedNamedArgs extends EvaluatedNamedArgs {
 }
 
 export const EVALUATED_EMPTY_NAMED_ARGS = new (class extends EvaluatedNamedArgs {
-  get(): PathReference {
+  get(): PathReference<any> {
     return NULL_REFERENCE;
   }
 

--- a/packages/node_modules/glimmer-runtime/lib/compiled/expressions/positional-args.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/expressions/positional-args.ts
@@ -4,7 +4,7 @@ import VM from '../../vm/append';
 import { PathReference } from 'glimmer-reference';
 
 export abstract class CompiledPositionalArgs {
-  static create({ values }: { values: CompiledExpression[] }): CompiledPositionalArgs {
+  static create({ values }: { values: CompiledExpression<any>[] }): CompiledPositionalArgs {
     if (values.length) {
       return new CompiledNonEmptyPositionalArgs({ values });
     } else {
@@ -19,19 +19,19 @@ export abstract class CompiledPositionalArgs {
 
 class CompiledNonEmptyPositionalArgs extends CompiledPositionalArgs {
   public type = "positional-args";
-  public values: CompiledExpression[];
+  public values: CompiledExpression<any>[];
 
-  constructor({ values }: { values: CompiledExpression[] }) {
+  constructor({ values }: { values: CompiledExpression<any>[] }) {
     super();
     this.values = values;
   }
 
   evaluate(vm: VM): EvaluatedPositionalArgs {
     let { values } = this;
-    let valueReferences = new Array(values.length);
+    let valueReferences = new Array<any>(values.length);
 
     for (let i = 0; i < values.length; i++) {
-      valueReferences[i] = <PathReference>values[i].evaluate(vm);
+      valueReferences[i] = <PathReference<any>>values[i].evaluate(vm);
     }
 
     return EvaluatedPositionalArgs.create({ values: valueReferences });
@@ -59,33 +59,33 @@ export abstract class EvaluatedPositionalArgs {
     return EVALUATED_EMPTY_POSITIONAL_ARGS;
   }
 
-  static create({ values }: { values: PathReference[] }) {
+  static create({ values }: { values: PathReference<any>[] }) {
     return new NonEmptyEvaluatedPositionalArgs({ values });
   }
 
   public type: string;
-  public values: PathReference[];
+  public values: PathReference<any>[];
 
-  forEach(callback: (value: PathReference) => void) {
+  forEach(callback: (value: PathReference<any>) => void) {
     let values = this.values;
     for (let i = 0; i < values.length; i++) {
       callback(values[i]);
     }
   }
 
-  abstract at(index: number): PathReference;
+  abstract at(index: number): PathReference<any>;
   abstract value(): any[];
 }
 
 class NonEmptyEvaluatedPositionalArgs extends EvaluatedPositionalArgs {
-  public values: PathReference[];
+  public values: PathReference<any>[];
 
-  constructor({ values }: { values: PathReference[] }) {
+  constructor({ values }: { values: PathReference<any>[] }) {
     super();
     this.values = values;
   }
 
-  at(index: number): PathReference {
+  at(index: number): PathReference<any> {
     return this.values[index];
   }
 
@@ -100,7 +100,7 @@ class NonEmptyEvaluatedPositionalArgs extends EvaluatedPositionalArgs {
 }
 
 export const EVALUATED_EMPTY_POSITIONAL_ARGS = new (class extends EvaluatedPositionalArgs {
-  at(): PathReference {
+  at(): PathReference<any> {
     return NULL_REFERENCE;
   }
 

--- a/packages/node_modules/glimmer-runtime/lib/compiled/expressions/ref.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/expressions/ref.ts
@@ -3,7 +3,7 @@ import VM from '../../vm/append';
 import { InternedString } from 'glimmer-util';
 import { PathReference, referenceFromParts } from 'glimmer-reference';
 
-export abstract class CompiledSymbolRef extends CompiledExpression {
+export abstract class CompiledSymbolRef extends CompiledExpression<any> {
   protected debug: string;
   protected symbol: number;
   protected path: InternedString[];
@@ -15,12 +15,12 @@ export abstract class CompiledSymbolRef extends CompiledExpression {
     this.path = path;
   }
 
-  evaluate(vm: VM): PathReference {
+  evaluate(vm: VM): PathReference<any> {
     let base = this.referenceForSymbol(vm);
     return referenceFromParts(base, this.path);
   }
 
-  protected abstract referenceForSymbol(vm: VM): PathReference;
+  protected abstract referenceForSymbol(vm: VM): PathReference<any>;
 
   toJSON(): string {
     let { debug, symbol, path } = this;
@@ -36,7 +36,7 @@ export abstract class CompiledSymbolRef extends CompiledExpression {
 export class CompiledKeywordRef extends CompiledSymbolRef {
   public type = "keyword-ref";
 
-  referenceForSymbol(vm: VM): PathReference {
+  referenceForSymbol(vm: VM): PathReference<any> {
     return vm.referenceForKeyword(this.symbol);
   }
 }
@@ -44,12 +44,12 @@ export class CompiledKeywordRef extends CompiledSymbolRef {
 export class CompiledLocalRef extends CompiledSymbolRef {
   public type = "local-ref";
 
-  referenceForSymbol(vm: VM): PathReference {
+  referenceForSymbol(vm: VM): PathReference<any> {
     return vm.referenceForSymbol(this.symbol);
   }
 }
 
-export class CompiledSelfRef extends CompiledExpression {
+export class CompiledSelfRef extends CompiledExpression<any> {
   public type = "self-ref";
   private parts: InternedString[];
 
@@ -58,7 +58,7 @@ export class CompiledSelfRef extends CompiledExpression {
     this.parts = parts;
   }
 
-  evaluate(vm: VM): PathReference {
+  evaluate(vm: VM): PathReference<any> {
     return referenceFromParts(vm.getSelf(), this.parts);
   }
 

--- a/packages/node_modules/glimmer-runtime/lib/compiled/expressions/value.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/expressions/value.ts
@@ -3,16 +3,16 @@ import { CompiledExpression } from '../expressions';
 import { ConstReference, PathReference } from 'glimmer-reference';
 import { InternedString, dict } from 'glimmer-util';
 
-export default class CompiledValue extends CompiledExpression {
+export default class CompiledValue<T> extends CompiledExpression<T> {
   public type = "value";
-  private reference: ValueReference;
+  private reference: ValueReference<T>;
 
   constructor({ value }: { value: any }) {
     super();
     this.reference = new ValueReference(value);
   }
 
-  evaluate(vm: VM): PathReference {
+  evaluate(vm: VM): PathReference<T> {
     return this.reference;
   }
 
@@ -21,9 +21,9 @@ export default class CompiledValue extends CompiledExpression {
   }
 }
 
-export class ValueReference extends ConstReference<any> implements PathReference {
-  protected inner: any;
-  protected children = dict<ValueReference>();
+export class ValueReference<T> extends ConstReference<T> implements PathReference<T> {
+  protected inner: T;
+  protected children = dict<ValueReference<any>>();
 
   get(key: InternedString) {
     let { children } = this;

--- a/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -24,7 +24,7 @@ class Keywords implements IKeywords {
     this.scope = scope;
   }
 
-  get(name: InternedString): PathReference {
+  get(name: InternedString): PathReference<any> {
     let symbol = this.names.indexOf(name);
     return this.scope.getSymbol(symbol);
   }

--- a/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/content.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/content.ts
@@ -34,11 +34,11 @@ export class AppendOpcode extends Opcode {
 export class UpdateAppendOpcode extends UpdatingContentOpcode {
   type = 'update-append';
 
-  private reference: PathReference;
+  private reference: PathReference<string>;
   private lastValue: string;
   private textNode: Text;
 
-  constructor(reference: PathReference, lastValue: string, textNode: Text) {
+  constructor(reference: PathReference<string>, lastValue: string, textNode: Text) {
     super();
     this.reference = reference;
     this.lastValue = lastValue;
@@ -79,11 +79,11 @@ export class TrustingAppendOpcode extends Opcode {
 export class UpdateTrustingAppendOpcode extends UpdatingContentOpcode {
   type = 'update-trusting-append';
 
-  private reference: PathReference;
+  private reference: PathReference<string>;
   private lastValue: string;
   private bounds: Bounds;
 
-  constructor(reference: PathReference, lastValue: string, bounds: Bounds) {
+  constructor(reference: PathReference<string>, lastValue: string, bounds: Bounds) {
     super();
     this.reference = reference;
     this.lastValue = lastValue;

--- a/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/dom.ts
@@ -1,7 +1,7 @@
 import { Opcode, OpcodeJSON, UpdatingOpcode } from '../../opcodes';
 import { VM, UpdatingVM } from '../../vm';
 import { FIXME, InternedString, dict } from 'glimmer-util';
-import { PathReference, PushPullReference } from 'glimmer-reference';
+import { PathReference, Reference } from 'glimmer-reference';
 import { DOMHelper } from '../../dom';
 import { ValueReference } from '../../compiled/expressions/value';
 
@@ -57,14 +57,17 @@ export class OpenPrimitiveElementOpcode extends Opcode {
   }
 }
 
-class ClassList extends PushPullReference {
-  private list: PathReference[] = [];
+class ClassList implements Reference<string> {
+  private list: PathReference<string>[] = [];
 
   isEmpty() {
     return this.list.length === 0;
   }
 
-  append(reference: PathReference) {
+  destroy() {}
+  isDirty() { return true; }
+
+  append(reference: PathReference<string>) {
     this.list.push(reference);
   }
 
@@ -75,10 +78,6 @@ class ClassList extends PushPullReference {
       ret[i] = this.list[i].value();
     }
     return ret.join(' ');
-  }
-
-  get(): FIXME {
-    return null;
   }
 }
 
@@ -102,8 +101,8 @@ export class CloseElementOpcode extends Opcode {
     for (let i = 0; i < groups.length; i++) {
       for (let j = 0; j < groups[i].length; j++) {
         let op = groups[i][j];
-        let name: string = <FIXME> op['name'];
-        let value: PathReference = <FIXME> op['value'];
+        let name = op['name'] as FIXME<string>;
+        let value = op['value'] as FIXME<PathReference<string>>;
         if (name === 'class') {
           classes.append(value);
         } else if (!flattened[name]) {
@@ -128,7 +127,7 @@ export class CloseElementOpcode extends Opcode {
 export class StaticAttrOpcode extends Opcode {
   public type = "static-attr";
   public name: InternedString;
-  public value: ValueReference;
+  public value: ValueReference<string>;
   public namespace: InternedString;
 
   constructor({ name, value, namespace }: { name: InternedString, value: InternedString, namespace: InternedString }) {
@@ -175,10 +174,10 @@ interface ElementPatchOperation extends ElementOperation {
 
 export class NamespacedAttribute implements ElementPatchOperation {
   name: InternedString;
-  value: PathReference;
+  value: PathReference<string>;
   namespace: InternedString;
 
-  constructor(name: InternedString, value: PathReference, namespace: InternedString) {
+  constructor(name: InternedString, value: PathReference<string>, namespace: InternedString) {
     this.name = name;
     this.value = value;
     this.namespace = namespace;
@@ -212,9 +211,9 @@ export class NamespacedAttribute implements ElementPatchOperation {
 
 export class NonNamespacedAttribute implements ElementPatchOperation {
   name: InternedString;
-  value: PathReference;
+  value: Reference<string>;
 
-  constructor(name: InternedString, value: PathReference) {
+  constructor(name: InternedString, value: Reference<string>) {
     this.name = name;
     this.value = value;
   }
@@ -243,9 +242,9 @@ export class NonNamespacedAttribute implements ElementPatchOperation {
 
 export class Property implements ElementPatchOperation {
   name: InternedString;
-  value: PathReference;
+  value: PathReference<any>;
 
-  constructor(name: InternedString, value: PathReference) {
+  constructor(name: InternedString, value: PathReference<any>) {
     this.name = name;
     this.value = value;
   }

--- a/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/lists.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/lists.ts
@@ -3,7 +3,7 @@ import { VM, UpdatingVM } from '../../vm';
 import { LabelOpcode } from '../../compiled/opcodes/vm';
 import { EvaluatedArgs } from '../expressions/args';
 import { LITERAL, ListSlice, Slice, InternedString, assert } from 'glimmer-util';
-import { RootReference, ConstReference, ListManager, ListDelegate } from 'glimmer-reference';
+import { PathReference, ConstReference, ListManager, ListDelegate } from 'glimmer-reference';
 
 abstract class ListUpdatingOpcode extends UpdatingOpcode {
   public type: string;
@@ -27,7 +27,7 @@ export class EnterListOpcode extends Opcode {
     let listRef = vm.frame.getOperand();
     let keyPath = vm.frame.getArgs().named.get(LITERAL("key")).value();
 
-    let manager =  new ListManager(<RootReference>listRef /* WTF */, keyPath);
+    let manager =  new ListManager(listRef, keyPath);
     let delegate = new IterateDelegate(vm);
 
     vm.frame.setIterator(manager.iterator(delegate));
@@ -101,7 +101,7 @@ class IterateDelegate implements ListDelegate {
     this.vm = vm;
   }
 
-  insert(key: InternedString, item: RootReference, before: InternedString) {
+  insert(key: InternedString, item: PathReference<any>, before: InternedString) {
     let { vm } = this;
 
     assert(!before, "Insertion should be append-only on initial render");
@@ -112,11 +112,11 @@ class IterateDelegate implements ListDelegate {
     vm.frame.setKey(key);
   }
 
-  retain(key: InternedString, item: RootReference) {
+  retain(key: InternedString, item: PathReference<any>) {
     assert(false, "Insertion should be append-only on initial render");
   }
 
-  move(key: InternedString, item: RootReference, before: InternedString) {
+  move(key: InternedString, item: PathReference<any>, before: InternedString) {
     assert(false, "Insertion should be append-only on initial render");
   }
 

--- a/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -7,7 +7,7 @@ import { turbocharge } from '../../utils';
 import { NULL_REFERENCE } from '../../references';
 import { InternedString, ListSlice, Slice, Dict, dict, assign } from 'glimmer-util';
 import { SymbolLookup } from '../../syntax';
-import { ChainableReference } from 'glimmer-reference';
+import { Reference } from 'glimmer-reference';
 
 abstract class VMUpdatingOpcode extends UpdatingOpcode {
   public type: string;
@@ -73,9 +73,9 @@ export class PutNullOpcode extends Opcode {
 
 export class PutValueOpcode extends Opcode {
   public type = "put-value";
-  private expression: CompiledExpression;
+  private expression: CompiledExpression<any>;
 
-  constructor({ expression }: { expression: CompiledExpression }) {
+  constructor({ expression }: { expression: CompiledExpression<any> }) {
     super();
     this.expression = expression;
   }
@@ -213,22 +213,22 @@ export class BindBlocksOpcode extends Opcode {
 export class BindKeywordsOpcode extends Opcode {
   public type = "bind-keywords";
 
-  public keywords: [number, CompiledExpression][];
+  public keywords: [number, CompiledExpression<any>][];
 
-  static create(lookup: SymbolLookup, keywords: Dict<CompiledExpression>) {
+  static create(lookup: SymbolLookup, keywords: Dict<CompiledExpression<any>>) {
     let toBind = Object.keys(keywords);
 
     let tuples = toBind.map(name => {
       let symbol = lookup.getKeywordSymbol(name as InternedString);
       let expr = keywords[name];
 
-      return [symbol, expr] as [number, CompiledExpression];
+      return [symbol, expr] as [number, CompiledExpression<any>];
     });
 
     return new BindKeywordsOpcode({ keywords: tuples });
   }
 
-  constructor({ keywords }: { keywords: [number, CompiledExpression][] }) {
+  constructor({ keywords }: { keywords: [number, CompiledExpression<any>][] }) {
     super();
     this.keywords = keywords;
   }
@@ -400,9 +400,9 @@ export class JumpUnlessOpcode extends JumpOpcode {
 export class Assert extends VMUpdatingOpcode {
   public type = "assert";
 
-  private reference: ChainableReference;
+  private reference: Reference<boolean>;
 
-  constructor(reference: ChainableReference) {
+  constructor(reference: Reference<boolean>) {
     super();
     this.reference = reference;
   }
@@ -417,9 +417,9 @@ export class Assert extends VMUpdatingOpcode {
 export class AssertFalse extends VMUpdatingOpcode {
   public type = "assert-false";
 
-  private reference: ChainableReference;
+  private reference: Reference<boolean>;
 
-  constructor(reference: ChainableReference) {
+  constructor(reference: Reference<boolean>) {
     super();
     this.reference = reference;
   }

--- a/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -238,7 +238,6 @@ export class BindKeywordsOpcode extends Opcode {
   }
 }
 
-
 export class EnterOpcode extends Opcode {
   public type = "enter";
   private slice: Slice<Opcode>;

--- a/packages/node_modules/glimmer-runtime/lib/compiler.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiler.ts
@@ -5,7 +5,7 @@ import { OpenPrimitiveElementOpcode, CloseElementOpcode } from './compiled/opcod
 import { PushDynamicScopeOpcode, PopDynamicScopeOpcode, BindKeywordsOpcode } from './compiled/opcodes/vm';
 import { DidCreateElementOpcode, ShadowAttributesOpcode } from './compiled/opcodes/component';
 import { BindNamedArgsOpcode, BindBlocksOpcode, BindPositionalArgsOpcode } from './compiled/opcodes/vm';
-import { Expression, SymbolLookup } from './syntax';
+import { SymbolLookup } from './syntax';
 import * as Syntax from './syntax/core';
 import { Environment } from './environment';
 import SymbolTable from './symbol-table';

--- a/packages/node_modules/glimmer-runtime/lib/compiler.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiler.ts
@@ -1,4 +1,4 @@
-import { FIXME, Slice, LinkedList, InternedString, Dict, dict } from 'glimmer-util';
+import { FIXME, Opaque, Slice, LinkedList, InternedString, Dict, dict } from 'glimmer-util';
 import { OpSeq, Opcode } from './opcodes';
 import { CompiledExpression } from './compiled/expressions';
 import { OpenPrimitiveElementOpcode, CloseElementOpcode } from './compiled/opcodes/dom';
@@ -131,7 +131,7 @@ export class InlineBlockCompiler extends Compiler {
 
 export interface ComponentParts {
   tag: InternedString;
-  attrs: Slice<AttributeSyntax>;
+  attrs: Slice<AttributeSyntax<Opaque>>;
   body: Slice<StatementSyntax>;
 }
 
@@ -156,7 +156,7 @@ class ComponentLayoutBuilder implements Component.ComponentLayoutBuilder {
   public env: Environment;
 
   private inner: WrappedBuilder | UnwrappedBuilder;
-  private keywords: Dict<FunctionExpression> = null;
+  private keywords: Dict<FunctionExpression<any>> = null;
 
   constructor(env: Environment) {
     this.env = env;
@@ -170,7 +170,7 @@ class ComponentLayoutBuilder implements Component.ComponentLayoutBuilder {
     this.inner = new UnwrappedBuilder(this.env, layout);
   }
 
-  bindKeywords(keywords: Dict<FunctionExpression>) {
+  bindKeywords(keywords: Dict<FunctionExpression<any>>) {
     this.keywords = keywords;
   }
 
@@ -199,7 +199,7 @@ class WrappedBuilder {
     this.layout = layout;
   }
 
-  compile(keywords: Dict<FunctionExpression>): CompiledBlock {
+  compile(keywords: Dict<FunctionExpression<any>>): CompiledBlock {
     let { env, layout } = this;
 
     let list = new CompileIntoList(env, layout.symbolTable);
@@ -252,7 +252,7 @@ class UnwrappedBuilder {
     throw new Error('BUG: Cannot call `tag` on an UnwrappedBuilder');
   }
 
-  compile(keywords: Dict<FunctionExpression>): CompiledBlock {
+  compile(keywords: Dict<FunctionExpression<any>>): CompiledBlock {
     let { env, layout } = this;
 
     let list = new CompileIntoList(env, layout.symbolTable);
@@ -292,8 +292,8 @@ class UnwrappedBuilder {
   }
 }
 
-function compileKeywords(lookup: SymbolLookup, env: Environment, keywords: Dict<FunctionExpression>): Dict<CompiledExpression> {
-  let compiledKeywords = dict<CompiledExpression>();
+function compileKeywords(lookup: SymbolLookup, env: Environment, keywords: Dict<FunctionExpression<any>>): Dict<CompiledExpression<any>> {
+  let compiledKeywords = dict<CompiledExpression<any>>();
 
   Object.keys(keywords).forEach(k => {
     compiledKeywords[k] = makeFunctionExpression(keywords[k]).compile(lookup, env);
@@ -317,22 +317,14 @@ class ComponentTagBuilder implements Component.ComponentTagBuilder {
 }
 
 class ComponentAttrsBuilder implements Component.ComponentAttrsBuilder {
-  private buffer: AttributeSyntax[] = [];
+  private buffer: AttributeSyntax<string>[] = [];
 
   static(name: string, value: string) {
-    this.buffer.push(new Syntax.StaticAttr({ name: name as FIXME, value: value as FIXME }));
+    this.buffer.push(new Syntax.StaticAttr({ name: name as FIXME<'intern'>, value: value as FIXME<'intern'> }));
   }
 
-  dynamic(name: string, value: FunctionExpression) {
-    this.buffer.push(new Syntax.DynamicAttr({ name: name as FIXME, value: makeFunctionExpression(value) }));
-  }
-}
-
-class ComponentBodyBuilder implements Component.ComponentBodyBuilder {
-  private layout: Layout = null;
-
-  fromLayout(layout: Layout) {
-    this.layout = layout;
+  dynamic(name: string, value: FunctionExpression<string>) {
+    this.buffer.push(new Syntax.DynamicAttr({ name: name as FIXME<'intern'>, value: makeFunctionExpression(value) }));
   }
 }
 

--- a/packages/node_modules/glimmer-runtime/lib/component/interfaces.ts
+++ b/packages/node_modules/glimmer-runtime/lib/component/interfaces.ts
@@ -4,17 +4,17 @@ import { Layout, CompiledBlock } from '../compiled/blocks';
 
 import Environment from '../environment';
 
-import { Dict, InternedString } from 'glimmer-util';
+import { Opaque, Dict, InternedString } from 'glimmer-util';
 import { PathReference } from 'glimmer-reference';
 
-export interface Component {};
-export interface ComponentClass {};
+export type Component = Opaque;
+export type ComponentClass = any;
 
 export interface Keywords {
-  get(name: InternedString): PathReference;
+  get(name: InternedString): PathReference<any>;
 }
 
-export interface ComponentManager<T extends Component> {
+export interface ComponentManager<T> {
   // First, the component manager is asked to create a bucket of state for
   // the supplied attributes. From the perspective of Glimmer, this is
   // an opaque token, but in practice it is probably a component object.
@@ -47,7 +47,7 @@ export interface ComponentLayoutBuilder {
   tag: ComponentTagBuilder;
   attrs: ComponentAttrsBuilder;
 
-  bindKeywords(keywords: Dict<FunctionExpression>);
+  bindKeywords(keywords: Dict<FunctionExpression<any>>);
   wrapLayout(layout: Layout);
   fromLayout(layout: Layout);
 }
@@ -58,16 +58,12 @@ export interface ComponentTagBuilder {
 
 export interface ComponentAttrsBuilder {
   static(name: string, value: string);
-  dynamic(name: string, value: FunctionExpression);
-}
-
-export interface ComponentBodyBuilder {
-  fromLayout(layout: Layout);
+  dynamic(name: string, value: FunctionExpression<string>);
 }
 
 export const CACHED_LAYOUT = "CACHED_LAYOUT [d990e194-8529-4f3b-8ee9-11c58a70f7a4]";
 
-export abstract class ComponentDefinition<T extends Component> {
+export abstract class ComponentDefinition<T> {
   public name: string; // for debugging
   public manager: ComponentManager<T>;
   public ComponentClass: ComponentClass;

--- a/packages/node_modules/glimmer-runtime/lib/environment.ts
+++ b/packages/node_modules/glimmer-runtime/lib/environment.ts
@@ -24,7 +24,7 @@ import {
 
 import { InlineBlock } from './compiled/blocks';
 
-import { Dict } from 'glimmer-util';
+import { Dict, Opaque } from 'glimmer-util';
 
 import * as Syntax from './syntax/core';
 
@@ -33,11 +33,11 @@ import UnlessSyntax from './syntax/builtins/unless';
 import WithSyntax from './syntax/builtins/with';
 import EachSyntax from './syntax/builtins/each';
 
-type ScopeSlot = PathReference | InlineBlock;
+type ScopeSlot = PathReference<Opaque> | InlineBlock;
 
 export class DynamicScope {
   static root(size: number) {
-    let refs: PathReference[] = new Array(size);
+    let refs: PathReference<Opaque>[] = new Array(size);
 
     for (let i = 0; i < size; i++) {
       refs[i] = NULL_REFERENCE;
@@ -52,11 +52,11 @@ export class DynamicScope {
     this.slots = references;
   }
 
-  getSymbol(symbol: number): PathReference {
-    return this.slots[symbol] as PathReference;
+  getSymbol(symbol: number): PathReference<Opaque> {
+    return this.slots[symbol] as PathReference<Opaque>;
   }
 
-  bindSymbol(symbol: number, value: PathReference) {
+  bindSymbol(symbol: number, value: PathReference<Opaque>) {
     this.slots[symbol] = value;
   }
 
@@ -66,8 +66,8 @@ export class DynamicScope {
 }
 
 export class Scope {
-  static root(self: PathReference, size = 0) {
-    let refs: PathReference[] = new Array(size + 1);
+  static root(self: PathReference<Opaque>, size = 0) {
+    let refs: PathReference<Opaque>[] = new Array(size + 1);
 
     for (let i = 0; i <= size; i++) {
       refs[i] = NULL_REFERENCE;
@@ -84,24 +84,24 @@ export class Scope {
     this.slots = references;
   }
 
-  init({ self }: { self: PathReference }): this {
+  init({ self }: { self: PathReference<Opaque> }): this {
     this.slots[0] = self;
     return this;
   }
 
-  getSelf(): PathReference {
-    return this.slots[0] as PathReference;
+  getSelf(): PathReference<Opaque> {
+    return this.slots[0] as PathReference<Opaque>;
   }
 
-  getSymbol(symbol: number): PathReference {
-    return this.slots[symbol] as PathReference;
+  getSymbol(symbol: number): PathReference<Opaque> {
+    return this.slots[symbol] as PathReference<Opaque>;
   }
 
   getBlock(symbol: number): InlineBlock {
     return this.slots[symbol] as InlineBlock;
   }
 
-  bindSymbol(symbol: number, value: PathReference) {
+  bindSymbol(symbol: number, value: PathReference<Opaque>) {
     this.slots[symbol] = value;
   }
 
@@ -117,7 +117,7 @@ export class Scope {
     return this.callerScope;
   }
 
-  child() {
+  child(): Scope {
     return new Scope(this.slots.slice());
   }
 }
@@ -125,15 +125,15 @@ export class Scope {
 export abstract class Environment {
   protected dom: DOMHelper;
   private createdComponents: Component[] = [];
-  private createdManagers: ComponentManager<any>[] = [];
+  private createdManagers: ComponentManager<Component>[] = [];
   private updatedComponents: Component[] = [];
-  private updatedManagers: ComponentManager<any>[] = [];
+  private updatedManagers: ComponentManager<Component>[] = [];
 
   constructor(dom: DOMHelper) {
     this.dom = dom;
   }
 
-  toConditionalReference(reference: Reference): ConditionalReference {
+  toConditionalReference(reference: Reference<Opaque>): ConditionalReference {
     return new ConditionalReference(reference);
   }
 
@@ -177,14 +177,14 @@ export abstract class Environment {
     this.updatedManagers = [];
   }
 
-  didCreate<T extends Component>(component: T, manager: ComponentManager<T>) {
-    this.createdComponents.push(component);
-    this.createdManagers.push(manager);
+  didCreate<T>(component: T, manager: ComponentManager<T>) {
+    this.createdComponents.push(component as any);
+    this.createdManagers.push(manager as any);
   }
 
-  didUpdate<T extends Component>(component: T, manager: ComponentManager<T>) {
-    this.updatedComponents.push(component);
-    this.updatedManagers.push(manager);
+  didUpdate<T>(component: T, manager: ComponentManager<T>) {
+    this.updatedComponents.push(component as any);
+    this.updatedManagers.push(manager as any);
   }
 
   commit() {
@@ -201,7 +201,7 @@ export abstract class Environment {
     }
   }
 
-  iteratorFor(iterable: PathReference) {
+  iteratorFor(iterable: PathReference<Opaque[]>) {
     let position = 0;
     let len = iterable.value().length;
 
@@ -219,11 +219,11 @@ export abstract class Environment {
     };
   }
 
-  abstract rootReferenceFor(obj: any): PathReference;
+  abstract rootReferenceFor<T>(obj: T): PathReference<T>;
   abstract hasHelper(helperName: InternedString[]): boolean;
   abstract lookupHelper(helperName: InternedString[]): Helper;
   abstract hasComponentDefinition(tagName: InternedString[]): boolean;
-  abstract getComponentDefinition(tagName: InternedString[]): ComponentDefinition<any>;
+  abstract getComponentDefinition(tagName: InternedString[]): ComponentDefinition<Opaque>;
   abstract getKeywords(): InternedString[];
 }
 
@@ -239,8 +239,8 @@ interface SafeString {
 
 export type Insertion = string | SafeString | Node;
 
-type PositionalArguments = any[];
-type KeywordArguments = Dict<any>;
+type PositionalArguments = Opaque[];
+type KeywordArguments = Dict<Opaque>;
 
 export interface Helper {
   (positional: PositionalArguments, named: KeywordArguments, options: Object): Insertion;

--- a/packages/node_modules/glimmer-runtime/lib/references.ts
+++ b/packages/node_modules/glimmer-runtime/lib/references.ts
@@ -1,19 +1,21 @@
 import { ConstReference, PathReference, Reference } from 'glimmer-reference';
 
-export class PrimitiveReference extends ConstReference<any> implements PathReference {
-  get(): PathReference {
+type Primitive = string | number | boolean;
+
+export class PrimitiveReference extends ConstReference<any> implements PathReference<Primitive> {
+  get(): PrimitiveReference {
     return NULL_REFERENCE;
   }
 }
 
-export class ConditionalReference implements Reference {
-  private inner: Reference;
+export class ConditionalReference implements Reference<boolean> {
+  private inner: Reference<any>;
 
-  constructor(inner: Reference) {
+  constructor(inner: Reference<any>) {
     this.inner = inner;
   }
 
-  value() {
+  value(): boolean {
     return this.toBool(this.inner.value());
   }
 

--- a/packages/node_modules/glimmer-runtime/lib/syntax.ts
+++ b/packages/node_modules/glimmer-runtime/lib/syntax.ts
@@ -72,12 +72,12 @@ export abstract class Statement implements LinkedListNode {
   }
 }
 
-interface ExpressionClass<T extends SerializedExpression, U extends Expression> {
+interface ExpressionClass<T extends SerializedExpression, U extends Expression<T>> {
   fromSpec(spec: T, blocks?: InlineBlock[]): U;
 }
 
-export abstract class Expression {
-  static fromSpec<T extends SerializedExpression, U extends Expression>(spec: T, blocks?: InlineBlock[]): U {
+export abstract class Expression<T> {
+  static fromSpec<T extends SerializedExpression, U extends Expression<T>>(spec: T, blocks?: InlineBlock[]): U {
     throw new Error(`You need to implement fromSpec on ${this}`);
   }
 
@@ -87,7 +87,7 @@ export abstract class Expression {
     return `${this.type}`;
   }
 
-  abstract compile(compiler: SymbolLookup, env: Environment): CompiledExpression;
+  abstract compile(compiler: SymbolLookup, env: Environment): CompiledExpression<T>;
 }
 
 export interface SymbolLookup {
@@ -113,15 +113,15 @@ export type Program = Slice<Statement>;
 
 export const ATTRIBUTE = "e1185d30-7cac-4b12-b26a-35327d905d92";
 
-export abstract class Attribute extends Statement {
+export abstract class Attribute<T> extends Statement {
   "e1185d30-7cac-4b12-b26a-35327d905d92" = true;
   name: InternedString;
   namespace: InternedString;
 
-  abstract valueSyntax(): Expression;
+  abstract valueSyntax(): Expression<T>;
   abstract isAttribute(): boolean;
 }
 
-export function isAttribute(value: Statement): value is Attribute {
+export function isAttribute(value: Statement): value is Attribute<any> {
   return value && value[ATTRIBUTE] === true;
 }

--- a/packages/node_modules/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/node_modules/glimmer-runtime/lib/syntax/core.ts
@@ -57,13 +57,14 @@ import {
 } from '../compiled/expressions';
 
 import {
-  PushPullReference,
-  PathReference
+  PathReference,
+  Reference
 } from 'glimmer-reference';
 
 import { Environment, Insertion, Helper as EnvHelper } from '../environment';
 
 import {
+  Opaque,
   InternedString,
   Dict,
   dict,
@@ -97,8 +98,6 @@ interface Bounds {
   firstNode(): Node;
   lastNode(): Node;
 }
-
-interface Reference {}
 
 export interface BlockOptions {
 
@@ -154,7 +153,7 @@ export class Block extends StatementSyntax {
   }
 }
 
-export class Unknown extends ExpressionSyntax {
+export class Unknown extends ExpressionSyntax<any> {
   public type = "unknown";
 
   static fromSpec(sexp: SerializedExpressions.Unknown): Unknown {
@@ -176,7 +175,7 @@ export class Unknown extends ExpressionSyntax {
     this.trustingMorph = !!options.unsafe;
   }
 
-  compile(compiler: SymbolLookup, env: Environment): CompiledExpression {
+  compile(compiler: SymbolLookup, env: Environment): CompiledExpression<any> {
     let { ref } = this;
 
     if (env.hasHelper(ref.parts)) {
@@ -200,14 +199,14 @@ export class Append extends StatementSyntax {
     return new Append({ value: buildExpression(value), trustingMorph });
   }
 
-  static build(value: ExpressionSyntax, trustingMorph: boolean) {
+  static build(value: ExpressionSyntax<any>, trustingMorph: boolean) {
     return new this({ value, trustingMorph });
   }
 
-  value: ExpressionSyntax;
+  value: ExpressionSyntax<any>;
   trustingMorph: boolean;
 
-  constructor({ value, trustingMorph }: { value: ExpressionSyntax, trustingMorph: boolean }) {
+  constructor({ value, trustingMorph }: { value: ExpressionSyntax<any>, trustingMorph: boolean }) {
     super();
     this.value = value;
     this.trustingMorph = trustingMorph;
@@ -229,17 +228,22 @@ export class Append extends StatementSyntax {
   }
 }
 
-class HelperInvocationReference extends PushPullReference implements PathReference {
+class HelperInvocationReference implements Reference<Insertion> {
   private helper: EnvHelper;
   private args: EvaluatedArgs;
 
   constructor(helper: EnvHelper, args: EvaluatedArgs) {
-    super();
     this.helper = helper;
     this.args = args;
   }
 
-  get(): PathReference {
+  isDirty() {
+    return true;
+  }
+
+  destroy() {}
+
+  get(): PathReference<Opaque> {
     throw new Error("Unimplemented: Yielding the result of a helper call.");
   }
 
@@ -281,7 +285,7 @@ export class Modifier implements StatementSyntax {
 }
 */
 
-export class DynamicProp extends AttributeSyntax {
+export class DynamicProp extends AttributeSyntax<Opaque> {
   "e1185d30-7cac-4b12-b26a-35327d905d92" = true;
   type = "dynamic-prop";
 
@@ -299,9 +303,9 @@ export class DynamicProp extends AttributeSyntax {
   }
 
   public name: InternedString;
-  public value: ExpressionSyntax;
+  public value: ExpressionSyntax<Opaque>;
 
-  constructor(options: { name: InternedString, value: ExpressionSyntax }) {
+  constructor(options: { name: InternedString, value: ExpressionSyntax<Opaque> }) {
     super();
     this.name = options.name;
     this.value = options.value;
@@ -318,7 +322,7 @@ export class DynamicProp extends AttributeSyntax {
     compiler.append(new DynamicPropOpcode(this));
   }
 
-  valueSyntax(): ExpressionSyntax {
+  valueSyntax(): ExpressionSyntax<Opaque> {
     return this.value;
   }
 
@@ -327,7 +331,7 @@ export class DynamicProp extends AttributeSyntax {
   }
 }
 
-export class StaticAttr extends AttributeSyntax {
+export class StaticAttr extends AttributeSyntax<string> {
   "e1185d30-7cac-4b12-b26a-35327d905d92" = true;
   type = "static-attr";
 
@@ -366,8 +370,8 @@ export class StaticAttr extends AttributeSyntax {
     compiler.append(new StaticAttrOpcode(this));
   }
 
-  valueSyntax(): ExpressionSyntax {
-    return Value.build(this.value);
+  valueSyntax(): ExpressionSyntax<string> {
+    return Value.build(this.value as string);
   }
 
   isAttribute(): boolean {
@@ -375,7 +379,7 @@ export class StaticAttr extends AttributeSyntax {
   }
 }
 
-export class DynamicAttr extends AttributeSyntax {
+export class DynamicAttr extends AttributeSyntax<string> {
   "e1185d30-7cac-4b12-b26a-35327d905d92" = true;
   type = "dynamic-attr";
 
@@ -389,17 +393,17 @@ export class DynamicAttr extends AttributeSyntax {
     });
   }
 
-  static build(_name: string, value: ExpressionSyntax, _namespace: string=null): DynamicAttr {
+  static build(_name: string, value: ExpressionSyntax<string>, _namespace: string=null): DynamicAttr {
     let name = intern(_name);
     let namespace = _namespace ? intern(_namespace) : null;
     return new this({ name, value, namespace });
   }
 
   name: InternedString;
-  value: ExpressionSyntax;
+  value: ExpressionSyntax<string>;
   namespace: InternedString;
 
-  constructor({ name, value, namespace = null }: { name: InternedString, value: ExpressionSyntax, namespace?: InternedString }) {
+  constructor({ name, value, namespace = null }: { name: InternedString, value: ExpressionSyntax<string>, namespace?: InternedString }) {
     super();
     this.name = name;
     this.value = value;
@@ -426,7 +430,7 @@ export class DynamicAttr extends AttributeSyntax {
     }
   }
 
-  valueSyntax(): ExpressionSyntax {
+  valueSyntax(): ExpressionSyntax<string> {
     return this.value;
   }
 
@@ -571,11 +575,11 @@ export class OpenElement extends StatementSyntax {
 
   private attributes(scanner: BlockScanner): { args: Args, attrs: InternedString[] } {
     let current = scanner.next();
-    let args = dict<ExpressionSyntax>();
+    let args = dict<ExpressionSyntax<Opaque>>();
     let attrs: InternedString[] = [];
 
     while (current[ATTRIBUTE_SYNTAX]) {
-      let attr = <AttributeSyntax>current;
+      let attr = <AttributeSyntax<Opaque>>current;
       args[<string>attr.name] = attr.valueSyntax();
       if (attr.isAttribute()) attrs.push(attr.name);
       current = scanner.next();
@@ -669,7 +673,7 @@ export class Yield extends StatementSyntax {
     return new Yield({ to: to as InternedString, args });
   }
 
-  static build(params: ExpressionSyntax[], to: string): Yield {
+  static build(params: ExpressionSyntax<Opaque>[], to: string): Yield {
     let args = Args.fromPositionalArgs(PositionalArgs.build(params));
     return new this({ to: intern(to), args });
   }
@@ -724,20 +728,20 @@ export class CloseBlockOpcode extends Opcode {
   }
 }
 
-export class Value extends ExpressionSyntax {
+export class Value<T extends SerializedExpressions.Value> extends ExpressionSyntax<T> {
   type = "value";
 
-  static fromSpec(value: SerializedExpressions.Value): Value {
+  static fromSpec<U extends SerializedExpressions.Value>(value: U): Value<U> {
     return new Value(value);
   }
 
-  static build(value) {
+  static build<U extends SerializedExpressions.Value>(value: U): Value<U> {
     return new this(value);
   }
 
-  public value: boolean | string | number;
+  public value: T;
 
-  constructor(value) {
+  constructor(value: T) {
     super();
     this.value = value;
   }
@@ -746,16 +750,16 @@ export class Value extends ExpressionSyntax {
     return String(this.value);
   }
 
-  inner() {
+  inner(): T {
     return this.value;
   }
 
-  compile(compiler: SymbolLookup): CompiledExpression {
-    return new CompiledValue(this);
+  compile(compiler: SymbolLookup): CompiledExpression<T> {
+    return new CompiledValue<T>(this);
   }
 }
 
-export class Get extends ExpressionSyntax {
+export class Get extends ExpressionSyntax<Opaque> {
   type = "get";
 
   static fromSpec(sexp: SerializedExpressions.Get): Get {
@@ -779,22 +783,22 @@ export class Get extends ExpressionSyntax {
     return new PrettyPrint('expr', 'get', [this.ref.prettyPrint()], null);
   }
 
-  compile(compiler: SymbolLookup): CompiledExpression {
+  compile(compiler: SymbolLookup): CompiledExpression<Opaque> {
     return this.ref.compile(compiler);
   }
 }
 
-export class GetNamedParameter extends ExpressionSyntax {
+export class GetNamedParameter<T> extends ExpressionSyntax<T> {
   type = "get-named-parameter";
 
-  static fromSpec(sexp: SerializedExpressions.Attr): GetNamedParameter {
+  static fromSpec(sexp: SerializedExpressions.Attr): GetNamedParameter<Opaque> {
     let [, parts] = sexp;
 
-    return new GetNamedParameter({ parts: parts as InternedString[] });
+    return new GetNamedParameter<Opaque>({ parts: parts as InternedString[] });
   }
 
-  static build(path: string): GetNamedParameter {
-    return new this({ parts: path.split('.').map(intern) });
+  static build(path: string): GetNamedParameter<Opaque> {
+    return new this<Opaque>({ parts: path.split('.').map(intern) });
   }
 
   public parts: InternedString[];
@@ -808,7 +812,7 @@ export class GetNamedParameter extends ExpressionSyntax {
     return new PrettyPrint('expr', 'get-named', [this.parts.join('.')], null);
   }
 
-  compile(lookup: SymbolLookup): CompiledExpression {
+  compile(lookup: SymbolLookup): CompiledExpression<T> {
     let { parts } = this;
     let head = parts[0];
     let symbol = lookup.getNamedSymbol(head);
@@ -825,7 +829,7 @@ function internPath(path: string): InternedString[] {
 
 // this is separated out from Get because Unknown also has a ref, but it
 // may turn out to be a helper
-export class Ref extends ExpressionSyntax {
+export class Ref extends ExpressionSyntax<Opaque> {
   type = "ref";
 
   static build(path: string): Ref {
@@ -843,7 +847,7 @@ export class Ref extends ExpressionSyntax {
     return this.parts.join('.');
   }
 
-  compile(lookup: SymbolLookup): CompiledExpression {
+  compile(lookup: SymbolLookup): CompiledExpression<Opaque> {
     let { parts } = this;
     let head = parts[0];
     let path = parts.slice(1);
@@ -870,7 +874,7 @@ export class Ref extends ExpressionSyntax {
   }
 }
 
-export class Helper extends ExpressionSyntax {
+export class Helper extends ExpressionSyntax<Opaque> {
   type = "helper";
 
   static fromSpec(sexp: SerializedExpressions.Helper): Helper {
@@ -901,10 +905,10 @@ export class Helper extends ExpressionSyntax {
     return new PrettyPrint('expr', this.ref.prettyPrint(), params, hash);
   }
 
-  compile(compiler: SymbolLookup, env: Environment): CompiledExpression {
+  compile(compiler: SymbolLookup, env: Environment): CompiledExpression<Opaque> {
     if (env.hasHelper(this.ref.parts)) {
       let { args, ref } = this;
-      return new CompiledHelper({ helper: env.lookupHelper(ref.parts), args: args.compile(compiler, env) });
+      return new CompiledHelper<Opaque>({ helper: env.lookupHelper(ref.parts), args: args.compile(compiler, env) });
     } else {
       throw new Error(`Compile Error: ${this.ref.prettyPrint()} is not a helper`);
     }
@@ -929,9 +933,9 @@ export class Concat {
   }
 
   isStatic = false;
-  parts: ExpressionSyntax[];
+  parts: ExpressionSyntax<Opaque>[];
 
-  constructor({ parts }: { parts: ExpressionSyntax[] }) {
+  constructor({ parts }: { parts: ExpressionSyntax<Opaque>[] }) {
     this.parts = parts;
   }
 
@@ -997,7 +1001,7 @@ export class PositionalArgs {
     return new PositionalArgs(sexp.map(buildExpression));
   }
 
-  static build(exprs: ExpressionSyntax[]): PositionalArgs {
+  static build(exprs: ExpressionSyntax<Opaque>[]): PositionalArgs {
     return new this(exprs);
   }
 
@@ -1007,21 +1011,21 @@ export class PositionalArgs {
     return (this._empty = this._empty || new PositionalArgs([]));
   }
 
-  values: ExpressionSyntax[];
+  values: ExpressionSyntax<Opaque>[];
   length: number;
   isStatic = false;
 
-  constructor(exprs: ExpressionSyntax[]) {
+  constructor(exprs: ExpressionSyntax<Opaque>[]) {
     this.values = exprs;
     this.length = exprs.length;
   }
 
-  push(expr: ExpressionSyntax) {
+  push(expr: ExpressionSyntax<Opaque>) {
     this.values.push(expr);
     this.length = this.values.length;
   }
 
-  at(index: number): ExpressionSyntax {
+  at(index: number): ExpressionSyntax<Opaque> {
     return this.values[index];
   }
 
@@ -1037,7 +1041,7 @@ export class NamedArgs {
     if (sexp === null || sexp === undefined) { return NamedArgs.empty(); }
     let keys: InternedString[] = [];
     let values = [];
-    let map = dict<ExpressionSyntax>();
+    let map = dict<ExpressionSyntax<Opaque>>();
 
     Object.keys(sexp).forEach(key => {
       keys.push(key as InternedString);
@@ -1048,7 +1052,7 @@ export class NamedArgs {
     return new this({ map });
   }
 
-  static build(map: Dict<ExpressionSyntax>): NamedArgs {
+  static build(map: Dict<ExpressionSyntax<Opaque>>): NamedArgs {
     let keys = [];
     let values = [];
 
@@ -1064,13 +1068,13 @@ export class NamedArgs {
   static _empty;
 
   static empty(): NamedArgs {
-    return (this._empty = this._empty || new NamedArgs({ map: dict<ExpressionSyntax>() }));
+    return (this._empty = this._empty || new NamedArgs({ map: dict<ExpressionSyntax<Opaque>>() }));
   }
 
-  public map: Dict<ExpressionSyntax>;
+  public map: Dict<ExpressionSyntax<Opaque>>;
   public isStatic = false;
 
-  constructor({ map }: { map: Dict<ExpressionSyntax> }) {
+  constructor({ map }: { map: Dict<ExpressionSyntax<Opaque>> }) {
     this.map = map;
   }
 
@@ -1078,11 +1082,11 @@ export class NamedArgs {
     return JSON.stringify(this.map);
   }
 
-  add(key: InternedString, value: ExpressionSyntax) {
+  add(key: InternedString, value: ExpressionSyntax<Opaque>) {
     this.map[<string>key] = value;
   }
 
-  at(key: InternedString): ExpressionSyntax {
+  at(key: InternedString): ExpressionSyntax<Opaque> {
     return this.map[<string>key];
   }
 
@@ -1093,7 +1097,7 @@ export class NamedArgs {
   compile(compiler: SymbolLookup, env: Environment): CompiledNamedArgs {
     let { map } = this;
 
-    let compiledMap = dict<CompiledExpression>();
+    let compiledMap = dict<CompiledExpression<Opaque>>();
 
     Object.keys(map).forEach(key => {
       compiledMap[key] = map[key].compile(compiler, env);
@@ -1127,23 +1131,5 @@ export class Templates {
   constructor(options: { template: InlineBlock, inverse: InlineBlock }) {
     this.default = options.template;
     this.inverse = options.inverse;
-  }
-
-  prettyPrint(): string {
-    // let { default: _default, inverse } = this;
-
-    // return JSON.stringify({
-    //   // default: _default && _default.position,
-    //   // inverse: inverse && inverse.position
-    // });
-    return "";
-  }
-
-  compile(compiler: SymbolLookup) {
-    return this;
-  }
-
-  evaluate(vm: VM): PathReference {
-    throw new Error("unimplemented evaluate for ExpressionSyntax");
   }
 }

--- a/packages/node_modules/glimmer-runtime/lib/template.ts
+++ b/packages/node_modules/glimmer-runtime/lib/template.ts
@@ -1,4 +1,4 @@
-import { InternedString, Dict } from 'glimmer-util';
+import { InternedString, Opaque, Dict } from 'glimmer-util';
 import { SerializedTemplate } from 'glimmer-wire-format';
 import { PathReference } from 'glimmer-reference';
 import { EntryPoint, Layout } from './compiled/blocks';
@@ -13,7 +13,7 @@ interface TemplateOptions {
 
 interface RenderOptions {
   hostOptions?: Object;
-  keywords?: Dict<PathReference>;
+  keywords?: Dict<PathReference<Opaque>>;
   appendTo: Element;
 }
 
@@ -41,7 +41,7 @@ export default class Template {
     this.raw = raw;
   }
 
-  render(self: PathReference, env: Environment, { keywords, appendTo }: RenderOptions, blockArguments: any[]=null) {
+  render(self: PathReference<any>, env: Environment, { keywords, appendTo }: RenderOptions, blockArguments: any[]=null) {
     let elementStack = new ElementStack({ dom: env.getDOM(), parentNode: appendTo, nextSibling: null });
     let compiled = this.raw.compile(env);
     let vm = VM.initial(env, { self, elementStack, size: compiled.symbols });
@@ -54,7 +54,7 @@ export default class Template {
   }
 }
 
-function bindSymbols(scope: DynamicScope, env: Environment, dict: Dict<PathReference>) {
+function bindSymbols(scope: DynamicScope, env: Environment, dict: Dict<PathReference<Opaque>>) {
   let toBind = Object.keys(dict);
   let keywords = env.getKeywords();
 

--- a/packages/node_modules/glimmer-runtime/lib/vm/append.ts
+++ b/packages/node_modules/glimmer-runtime/lib/vm/append.ts
@@ -1,6 +1,6 @@
 import { Scope, DynamicScope, Environment } from '../environment';
 import { ElementStack } from '../builder';
-import { Dict, Stack, LinkedList, LOGGER, InternedString } from 'glimmer-util';
+import { Dict, Stack, LinkedList, LOGGER, InternedString, Opaque } from 'glimmer-util';
 import { ChainableReference, PathReference, ListManager, ListIterator } from 'glimmer-reference';
 import Template from '../template';
 import { Templates } from '../syntax/core';
@@ -16,7 +16,7 @@ import RenderResult from './render-result';
 import { FrameStack, Blocks } from './frame';
 
 interface VMInitialOptions {
-  self: PathReference;
+  self: PathReference<Opaque>;
   elementStack: ElementStack;
   size: number;
 }
@@ -29,9 +29,9 @@ interface VMConstructorOptions {
 }
 
 interface Registers {
-  operand: PathReference;
+  operand: PathReference<any>;
   args: EvaluatedArgs;
-  condition: ChainableReference;
+  condition: PathReference<boolean>;
   iterator: ListIterator;
   key: InternedString;
   templates: Dict<Template>;
@@ -54,7 +54,7 @@ interface PushFrameOptions {
 
 export interface PublicVM {
   env: Environment;
-  getSelf(): PathReference;
+  getSelf(): PathReference<any>;
   referenceForSymbol(symbol: number);
 }
 
@@ -180,7 +180,7 @@ export default class VM {
     this.dynamicScopeStack.push(this.dynamicScopeStack.current.child());
   }
 
-  pushRootScope(self: PathReference, size: number): Scope {
+  pushRootScope(self: PathReference<any>, size: number): Scope {
     let scope = Scope.root(self, size);
     this.scopeStack.push(scope);
     return scope;
@@ -196,15 +196,15 @@ export default class VM {
 
   /// SCOPE HELPERS
 
-  getSelf(): PathReference {
+  getSelf(): PathReference<any> {
     return this.scope().getSelf();
   }
 
-  referenceForSymbol(symbol: number): PathReference {
+  referenceForSymbol(symbol: number): PathReference<any> {
     return this.scope().getSymbol(symbol);
   }
 
-  referenceForKeyword(symbol: number): PathReference {
+  referenceForKeyword(symbol: number): PathReference<any> {
     return this.dynamicScope().getSymbol(symbol);
   }
 
@@ -256,7 +256,7 @@ export default class VM {
     this.pushFrame({ block: layout, blocks: templates, callerScope, args });
   }
 
-  evaluateOperand(expr: CompiledExpression) {
+  evaluateOperand(expr: CompiledExpression<any>) {
     this.frame.setOperand(expr.evaluate(this));
   }
 
@@ -305,7 +305,7 @@ export default class VM {
     });
   }
 
-  bindKeywords(entries: [number, CompiledExpression][]) {
+  bindKeywords(entries: [number, CompiledExpression<any>][]) {
     let scope = this.dynamicScope();
 
     entries.forEach(([symbol, expr]) => {

--- a/packages/node_modules/glimmer-runtime/lib/vm/append.ts
+++ b/packages/node_modules/glimmer-runtime/lib/vm/append.ts
@@ -1,6 +1,6 @@
 import { Scope, DynamicScope, Environment } from '../environment';
 import { ElementStack } from '../builder';
-import { Dict, DictWithNumberKeys, Stack, LinkedList, LOGGER, InternedString } from 'glimmer-util';
+import { Dict, Stack, LinkedList, LOGGER, InternedString } from 'glimmer-util';
 import { ChainableReference, PathReference, ListManager, ListIterator } from 'glimmer-reference';
 import Template from '../template';
 import { Templates } from '../syntax/core';

--- a/packages/node_modules/glimmer-runtime/lib/vm/frame.ts
+++ b/packages/node_modules/glimmer-runtime/lib/vm/frame.ts
@@ -1,6 +1,6 @@
 import { Scope } from '../environment';
 import { InternedString } from 'glimmer-util';
-import { ChainableReference, PathReference, ListIterator } from 'glimmer-reference';
+import { Reference, PathReference, ListIterator } from 'glimmer-reference';
 import { InlineBlock } from '../compiled/blocks';
 import { EvaluatedArgs } from '../compiled/expressions/args';
 import { Opcode, OpSeq } from '../opcodes';
@@ -9,11 +9,11 @@ import { LabelOpcode } from '../compiled/opcodes/vm';
 class Frame {
   ops: OpSeq;
   op: Opcode;
-  operand: PathReference = null;
+  operand: PathReference<any> = null;
   args: EvaluatedArgs = null;
   callerScope: Scope = null;
   blocks: Blocks = null;
-  condition: ChainableReference = null;
+  condition: Reference<boolean> = null;
   iterator: ListIterator = null;
   key: InternedString = null;
 
@@ -60,11 +60,11 @@ export class FrameStack {
     return this.frames[this.frame].op = op;
   }
 
-  getOperand(): PathReference {
+  getOperand(): PathReference<any> {
     return this.frames[this.frame].operand;
   }
 
-  setOperand(operand: PathReference): PathReference {
+  setOperand<T>(operand: PathReference<T>): PathReference<T> {
     return this.frames[this.frame].operand = operand;
   }
 
@@ -76,11 +76,11 @@ export class FrameStack {
     return this.frames[this.frame].args = args;
   }
 
-  getCondition(): ChainableReference {
+  getCondition(): Reference<boolean> {
     return this.frames[this.frame].condition;
   }
 
-  setCondition(condition: ChainableReference): ChainableReference {
+  setCondition(condition: Reference<boolean>): Reference<boolean> {
     return this.frames[this.frame].condition = condition;
   }
 

--- a/packages/node_modules/glimmer-runtime/lib/vm/update.ts
+++ b/packages/node_modules/glimmer-runtime/lib/vm/update.ts
@@ -2,7 +2,7 @@ import { Scope, DynamicScope, Environment } from '../environment';
 import { Bounds, clear, move } from '../bounds';
 import { ElementStack } from '../builder';
 import { Stack, LinkedList, InternedString, Dict, dict } from 'glimmer-util';
-import { ConstReference, RootReference, ListManager, ListDelegate } from 'glimmer-reference';
+import { ConstReference, PathReference, ListManager, ListDelegate } from 'glimmer-reference';
 import { EvaluatedArgs } from '../compiled/expressions/args';
 import { OpcodeJSON, OpSeq, UpdatingOpcode, UpdatingOpSeq } from '../opcodes';
 import { LabelOpcode } from '../compiled/opcodes/vm';
@@ -168,7 +168,7 @@ export class ListRevalidationDelegate implements ListDelegate {
     this.updating = updating;
   }
 
-  insert(key: InternedString, item: RootReference, before: InternedString) {
+  insert(key: InternedString, item: PathReference<any>, before: InternedString) {
     let { map, opcode, updating } = this;
     let nextSibling: Node = null;
     let reference = null;
@@ -199,10 +199,10 @@ export class ListRevalidationDelegate implements ListDelegate {
     map[<string>key] = tryOpcode;
   }
 
-  retain(key: InternedString, item: RootReference) {
+  retain(key: InternedString, item: PathReference<any>) {
   }
 
-  move(key: InternedString, item: RootReference, before: InternedString) {
+  move(key: InternedString, item: PathReference<any>, before: InternedString) {
     let { map, updating } = this;
 
     let entry = map[<string>key];

--- a/packages/node_modules/glimmer-runtime/tests/component-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/component-test.ts
@@ -1,8 +1,9 @@
 import { Template, RenderResult } from "glimmer-runtime";
 import { BasicComponent, TestEnvironment, equalTokens } from "glimmer-test-helpers";
 import { UpdatableReference } from "glimmer-reference";
+import { Opaque, opaque } from 'glimmer-util';
 
-let env: TestEnvironment, root: Element, result: RenderResult, self: UpdatableReference;
+let env: TestEnvironment, root: Element, result: RenderResult, self: UpdatableReference<Opaque>;
 
 function rootElement() {
   return env.getDOM().createElement('div', document.body);
@@ -19,14 +20,14 @@ function commonSetup() {
 }
 
 function render(template: Template, context={}) {
-  self = new UpdatableReference(context);
+  self = new UpdatableReference(opaque(context));
   result = template.render(self, env, { appendTo: root });
   assertInvariants(result);
   return result;
 }
 
 function rerender(context: Object={}) {
-  self.update(context);
+  self.update(opaque(context));
   result.rerender();
 }
 

--- a/packages/node_modules/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/ember-component-test.ts
@@ -734,7 +734,7 @@ QUnit.skip('dynamic named positional parameters', function() {
     positionalParams: ['name', 'age']
   });
 
-  env.registerEmberishCurlyComponent('sample-component', SampleComponent, '{{name}}{{age}}');
+  env.registerEmberishCurlyComponent('sample-component', SampleComponent as any, '{{name}}{{age}}');
 
   appendViewFor('{{sample-component myName myAge}}', {
     myName: 'Quint',
@@ -757,7 +757,7 @@ QUnit.skip('if a value is passed as a non-positional parameter, it takes precede
     positionalParams: ['name']
   });
 
-  env.registerEmberishCurlyComponent('sample-component', SampleComponent, '{{name}}');
+  env.registerEmberishCurlyComponent('sample-component', SampleComponent as any, '{{name}}');
 
   assert.throws(() => {
     appendViewFor('{{sample-component notMyName name=myName}}', {
@@ -774,7 +774,7 @@ QUnit.skip('static arbitrary number of positional parameters', function() {
     positionalParams: 'names'
   });
 
-  env.registerEmberishCurlyComponent('sample-component', SampleComponent, '{{#each names as |name|}}{{name}}{{/each}}');
+  env.registerEmberishCurlyComponent('sample-component', SampleComponent as any, '{{#each names as |name|}}{{name}}{{/each}}');
 
   appendViewFor(
     stripTight`<div>{{sample-component "Foo" 4 "Bar" id="args-3"}}
@@ -797,7 +797,7 @@ QUnit.skip('arbitrary positional parameter conflict with hash parameter is repor
     positionalParams: 'names'
   });
 
-  env.registerEmberishCurlyComponent('sample-component', SampleComponent, '{{#each attrs.names as |name|}}{{name}}{{/each}}');
+  env.registerEmberishCurlyComponent('sample-component', SampleComponent as any, '{{#each attrs.names as |name|}}{{name}}{{/each}}');
 
   assert.throws(function() {
     appendViewFor('{{sample-component "Foo" 4 "Bar" names=numbers id="args-3"}}', {
@@ -813,7 +813,7 @@ QUnit.skip('can use hash parameter instead of arbitrary positional param [GH #12
     positionalParams: 'names'
   });
 
-  env.registerEmberishCurlyComponent('sample-component', SampleComponent, '{{#each names as |name|}}{{name}}{{/each}}');
+  env.registerEmberishCurlyComponent('sample-component', SampleComponent as any, '{{#each names as |name|}}{{name}}{{/each}}');
 
   appendViewFor('{{sample-component names=things id="args-3"}}', {
     things: ['Foo', 4, 'Bar']
@@ -829,7 +829,7 @@ QUnit.skip('can use hash parameter instead of positional param', function() {
     positionalParams: ['first', 'second']
   });
 
-  env.registerEmberishCurlyComponent('sample-component', SampleComponent, '{{first}} - {{second}}');
+  env.registerEmberishCurlyComponent('sample-component', SampleComponent as any, '{{first}} - {{second}}');
 
   appendViewFor(`<div>
     {{sample-component "one" "two" id="two-positional"}}
@@ -855,7 +855,7 @@ QUnit.skip('dynamic arbitrary number of positional parameters', function() {
     positionalParams: 'n'
   });
 
-  env.registerEmberishCurlyComponent('sample-component', SampleComponent, '{{#each attrs.n as |name|}}{{name}}{{/each}}');
+  env.registerEmberishCurlyComponent('sample-component', SampleComponent as any, '{{#each attrs.n as |name|}}{{name}}{{/each}}');
 
   appendViewFor('<div>{{sample-component user1 user2 id="direct"}}{{!component "sample-component" user1 user2 id="helper"}}</div>', {
     user1: 'Foo',
@@ -920,21 +920,21 @@ QUnit.skip('components in template of a yielding component should have the prope
       this._super(...arguments);
       outer = this;
     }
-  });
+  }) as any;
 
   let InnerInTemplate = EmberishCurlyComponent.extend({
     init() {
       this._super(...arguments);
       innerTemplate = this;
     }
-  });
+  }) as any;
 
   let InnerInLayout = EmberishCurlyComponent.extend({
     init() {
       this._super(...arguments);
       innerLayout = this;
     }
-  });
+  }) as any;
 
   env.registerEmberishCurlyComponent('x-inner-in-layout', InnerInLayout, '');
   env.registerEmberishCurlyComponent('x-inner-in-template', InnerInTemplate, '');
@@ -974,8 +974,8 @@ QUnit.skip('newly-added sub-components get correct parentView', function() {
     }
   });
 
-  env.registerEmberishCurlyComponent('x-outer', Outer, `{{yield}}`);
-  env.registerEmberishCurlyComponent('x-inner', Inner, '');
+  env.registerEmberishCurlyComponent('x-outer', Outer as any, `{{yield}}`);
+  env.registerEmberishCurlyComponent('x-inner', Inner as any, '');
 
   appendViewFor('{{#x-outer}}{{#if showInner}}{{x-inner}}{{/if}}{{/x-outer}}', { showInner: false });
 

--- a/packages/node_modules/glimmer-runtime/tests/updating-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/updating-test.ts
@@ -17,7 +17,7 @@ const serializesNSAttributesCorrectly = (function() {
 
 let hooks, root: Element;
 let env: TestEnvironment;
-let self: UpdatableReference;
+let self: UpdatableReference<any>;
 let result: RenderResult;
 
 function compile(template: string) {

--- a/packages/node_modules/glimmer-test-helpers/lib/environment.ts
+++ b/packages/node_modules/glimmer-test-helpers/lib/environment.ts
@@ -31,7 +31,6 @@ import {
   // Syntax Classes
   StatementSyntax,
   AttributeSyntax,
-  ExpressionSyntax,
 
   // Concrete Syntax
   Layout,
@@ -60,7 +59,7 @@ import { Reference, PathReference, UpdatableReference } from "glimmer-reference"
 export type Attrs = Dict<any>;
 type AttrsDiff = { oldAttrs: Attrs, newAttrs: Attrs };
 
-export class BasicComponent implements Component {
+export class BasicComponent {
   public attrs: Attrs;
   public element: Element;
 
@@ -69,7 +68,7 @@ export class BasicComponent implements Component {
   }
 }
 
-export class EmberishCurlyComponent extends GlimmerObject implements Component {
+export class EmberishCurlyComponent extends GlimmerObject {
   public attrs: Attrs;
   public element: Element;
   public parentView: Component = null;
@@ -89,7 +88,7 @@ export class EmberishCurlyComponent extends GlimmerObject implements Component {
   didRender() {}
 }
 
-export class EmberishGlimmerComponent extends GlimmerObject implements Component {
+export class EmberishGlimmerComponent extends GlimmerObject {
   public attrs: Attrs;
   public element: Element;
   public parentView: Component = null;
@@ -267,7 +266,7 @@ export class TestEnvironment extends Environment {
     return this.registerComponent(name, definition);
   }
 
-  registerEmberishCurlyComponent(name: string, Component: ComponentClass, layout: string): ComponentDefinition<EmberishCurlyComponentDefinition> {
+  registerEmberishCurlyComponent(name: string, Component: EmberishCurlyComponentFactory, layout: string): ComponentDefinition<EmberishCurlyComponentDefinition> {
     let definition = new EmberishCurlyComponentDefinition(name, EMBERISH_CURLY_COMPONENT_MANAGER, Component, layout);
     return this.registerComponent(name, definition);
   }
@@ -277,11 +276,11 @@ export class TestEnvironment extends Environment {
     return this.registerComponent(name, definition);
   }
 
-  rootReferenceFor(object: any): PathReference {
+  rootReferenceFor(object: any): PathReference<any> {
     return new UpdatableReference(object);
   }
 
-  toConditionalReference(reference: Reference): ConditionalReference {
+  toConditionalReference(reference: Reference<any>): ConditionalReference {
     return new EmberishConditionalReference(reference);
   }
 
@@ -373,27 +372,15 @@ class CurlyComponentSyntax extends StatementSyntax {
   }
 }
 
-interface TemplateWithAttrsOptions {
-  defaults?: AttributeSyntax[];
-  outers?: AttributeSyntax[];
-  identity?: InternedString;
-}
-
-interface ComponentParts {
-  tag: InternedString;
-  attrs: Slice<AttributeSyntax>;
-  body: Slice<StatementSyntax>;
-}
-
 interface BasicComponentFactory {
   new(attrs: Dict<any>): BasicComponent;
 }
 
-abstract class GenericComponentDefinition<T extends Component> extends ComponentDefinition<T> {
-  private layoutString: string;
+abstract class GenericComponentDefinition<T> extends ComponentDefinition<T> {
+  private layoutString : string;
   private compiledLayout: Layout;
 
-  constructor(name: string, manager: ComponentManager<any>, ComponentClass: ComponentClass, layout: string) {
+  constructor(name: string, manager: ComponentManager<T>, ComponentClass: any, layout: string) {
     super(name, manager, ComponentClass);
     this.layoutString = layout;
   }
@@ -454,7 +441,7 @@ interface EmberishCurlyComponentFactory {
   create(options: { attrs: Attrs }): EmberishCurlyComponent;
 }
 
-function EmberID(vm: VM): PathReference {
+function EmberID(vm: VM): PathReference<string> {
   return new ValueReference(`ember${vm.getSelf().value()._guid}`);
 }
 

--- a/packages/node_modules/glimmer-test-helpers/lib/helpers.ts
+++ b/packages/node_modules/glimmer-test-helpers/lib/helpers.ts
@@ -5,7 +5,7 @@ import { Environment, Template, Layout } from "glimmer-runtime";
 import { TemplateSpec, compileSpec } from "glimmer-compiler";
 
 interface CompileOptions {
-  buildMeta?: FIXME; // currently does nothing
+  buildMeta?: FIXME<'currently does nothing'>;
   env: Environment;
 }
 

--- a/packages/node_modules/glimmer-util/index.ts
+++ b/packages/node_modules/glimmer-util/index.ts
@@ -1,7 +1,7 @@
 /*globals console*/
 
 export { getAttrNamespace } from './lib/namespaces';
-export { LITERAL, InternedString, symbol, intern, numberKey } from './lib/platform-utils';
+export { LITERAL, InternedString, Opaque, opaque, symbol, intern, numberKey } from './lib/platform-utils';
 export { default as assert } from './lib/assert';
 export { forEach, map, isArray, indexOfArray } from './lib/array-utils';
 export { default as voidMap } from './lib/void-tag-names';
@@ -17,4 +17,4 @@ export { types };
 export { Stack, Dict, DictWithNumberKeys, Set, DictSet, dict } from './lib/collections';
 export { EMPTY_SLICE, LinkedList, LinkedListNode, ListNode, CloneableListNode, ListSlice, Slice } from './lib/list-utils';
 
-export type FIXME = any;
+export type FIXME<T> = any;

--- a/packages/node_modules/glimmer-util/lib/collections.ts
+++ b/packages/node_modules/glimmer-util/lib/collections.ts
@@ -6,7 +6,7 @@ export interface Dict<T> {
 }
 
 export interface DictWithNumberKeys<T> {
-  [index: number]: T
+  [index: number]: T;
 }
 
 export interface Set<T> {

--- a/packages/node_modules/glimmer-util/lib/platform-utils.ts
+++ b/packages/node_modules/glimmer-util/lib/platform-utils.ts
@@ -11,6 +11,16 @@ export function intern(str: string): InternedString {
   // for (let key in obj) return <InternedString>key;
 }
 
+interface OpaqueMarker {
+  "a7613ac4-e3a3-4298-b06e-2349fe5a5ed5": boolean;
+}
+
+export type Opaque = OpaqueMarker;
+
+export function opaque(value: any): Opaque {
+  return value as Opaque;
+}
+
 export function numberKey(num: number): InternedString {
   return <InternedString>String(num);
 }


### PR DESCRIPTION
- Make Reference generic
- Fix incorrect usage of Reference types (mostly PathReferences in leaf
  positions)
- Make FIXME “generic” which allows us to add a description of the issue
- Introduce an Opaque type – this solves the problem of a value coming
  out of an `any` container (like Dict<any> or PathReference<any>) would
  lose any type safety (e.g. can be passed into any functions). The
  basic idea is that if you get an “any” value and pass it into a
  function expecting a string, TypeScript allows you to do it blindly,
  but we would like to make sure that we either do a type assertion or
  a generic conversion (like toString -> string)