### PR TITLE
Fix Glimmer Visualizer

### DIFF
--- a/demos/glimmer-demos/visualizer.ts
+++ b/demos/glimmer-demos/visualizer.ts
@@ -3,6 +3,7 @@ import {
   EmberishCurlyComponent as CurlyComponent,
   EmberishGlimmerComponent as GlimmerComponent
 } from 'glimmer-demos';
+import { layoutFor } from 'glimmer-runtime';
 import { UpdatableReference } from 'glimmer-reference';
 
 import { compileSpec } from 'glimmer-compiler';
@@ -367,11 +368,12 @@ function renderContent() {
   let app = env.compile($template.value);
 
   function compileLayout(component) {
-    let def = env.getComponentDefinition([component]);
-    let layout = def.getLayout(env);
-    layout.compile(def, env);
-    layout.children.forEach(compileInner);
-    return layout;
+    let definition = env.getComponentDefinition([component]);
+    let compiled = layoutFor(definition, { env });
+    let children = definition.compileLayout(env).children;
+
+    // Fake a Block
+    return { compiled, children, compile() {} };
   }
 
   function compileInner(block) {
@@ -383,7 +385,7 @@ function renderContent() {
     compileInner(block);
 
     return {
-      opcodes: block.ops.toArray().map(op => op.toJSON()),
+      opcodes: block.compiled.ops.toArray().map(op => op.toJSON()),
       children: block.children.map(processOpcodes)
     };
   }

--- a/packages/node_modules/glimmer-runtime/index.ts
+++ b/packages/node_modules/glimmer-runtime/index.ts
@@ -38,7 +38,8 @@ export {
 
 export {
   default as Compiler,
-  CompileIntoList
+  CompileIntoList,
+  layoutFor
 } from './lib/compiler';
 
 export {

--- a/packages/node_modules/glimmer-test-helpers/lib/environment.ts
+++ b/packages/node_modules/glimmer-test-helpers/lib/environment.ts
@@ -34,6 +34,7 @@ import {
   ExpressionSyntax,
 
   // Concrete Syntax
+  Layout,
   Templates,
   ArgsSyntax,
 
@@ -389,15 +390,17 @@ interface BasicComponentFactory {
 }
 
 abstract class GenericComponentDefinition<T extends Component> extends ComponentDefinition<T> {
-  private layoutString : string;
+  private layoutString: string;
+  private compiledLayout: Layout;
 
   constructor(name: string, manager: ComponentManager<any>, ComponentClass: ComponentClass, layout: string) {
     super(name, manager, ComponentClass);
     this.layoutString = layout;
   }
 
-  protected getLayout(options: { env: Environment }) {
-    return rawCompileLayout(this.layoutString, options);
+  protected compileLayout(env: Environment) {
+    if (this.compiledLayout) return this.compiledLayout;
+    return this.compiledLayout = rawCompileLayout(this.layoutString, { env });
   }
 
   // private extractComponent(builder: ComponentLayoutBuilder, head: OpenElementSyntax) {
@@ -443,7 +446,7 @@ class BasicComponentDefinition extends GenericComponentDefinition<BasicComponent
   public ComponentClass: BasicComponentFactory;
 
   compile(builder: ComponentLayoutBuilder) {
-    builder.fromLayout(this.getLayout(builder));
+    builder.fromLayout(this.compileLayout(builder.env));
   }
 }
 
@@ -459,9 +462,7 @@ class EmberishCurlyComponentDefinition extends GenericComponentDefinition<Emberi
   public ComponentClass: EmberishCurlyComponentFactory;
 
   compile(builder: ComponentLayoutBuilder) {
-    let layout = this.getLayout(builder);
-
-    builder.wrapLayout(layout);
+    builder.wrapLayout(this.compileLayout(builder.env));
     builder.tag.static('div');
     builder.attrs.static('class', 'ember-view');
     builder.attrs.dynamic('id', EmberID);
@@ -476,7 +477,7 @@ class EmberishGlimmerComponentDefinition extends GenericComponentDefinition<Embe
   public ComponentClass: EmberishGlimmerComponentFactory;
 
   compile(builder: ComponentLayoutBuilder) {
-    builder.fromLayout(this.getLayout(builder));
+    builder.fromLayout(this.compileLayout(builder.env));
     builder.attrs.static('class', 'ember-view');
     builder.attrs.dynamic('id', EmberID);
   }


### PR DESCRIPTION
This is to account for some of the changes we made to how components are compiled. This might not be a very good long term solution, but would allow the visualizer to work again for now.