### PR TITLE
Rearchitect #each implementation

### DIFF
--- a/demos/glimmer-demos/visualizer.ts
+++ b/demos/glimmer-demos/visualizer.ts
@@ -152,7 +152,7 @@ const UI =
       <div class="content full-height">
         <h3>Opcodes</h3>
         <ol>
-          {{#each updatingOpcodes as |opcode|}}
+          {{#each updatingOpcodes key="@index" as |opcode|}}
             <opcode-inspector opcode={{opcode}} />
           {{/each}}
         </ol>
@@ -215,7 +215,7 @@ function renderUI() {
 `<div>
   <h3>Statements</h3>
   <ol>
-    {{#each @spec.statements as |statement|}}
+    {{#each @spec.statements key="@index" as |statement|}}
       <li><span class="pre">{{json statement}}</span></li>
     {{/each}}
   </ol>
@@ -223,7 +223,7 @@ function renderUI() {
   {{#if @spec.locals}}
     <h3>Locals</h3>
     <ol>
-      {{#each @spec.locals as |local|}}
+      {{#each @spec.locals key="@index" as |local|}}
         <li><span class="pre">{{json local}}</span></li>
       {{/each}}
     </ol>
@@ -232,7 +232,7 @@ function renderUI() {
   {{#if @spec.named}}
     <h3>Named</h3>
     <ol>
-      {{#each @spec.named as |name|}}
+      {{#each @spec.named key="@index" as |name|}}
         <li><span class="pre">{{json name}}</span></li>
       {{/each}}
     </ol>
@@ -241,7 +241,7 @@ function renderUI() {
   {{#if @spec.yields}}
     <h3>Yields</h3>
     <ol>
-      {{#each @spec.yields as |yield|}}
+      {{#each @spec.yields key="@index" as |yield|}}
         <li><span class="pre">{{json yield}}</span></li>
       {{/each}}
     </ol>
@@ -250,7 +250,7 @@ function renderUI() {
   {{#if @spec.blocks}}
     <h3>Blocks</h3>
     <ol>
-      {{#each @spec.blocks as |block|}}
+      {{#each @spec.blocks key="@index" as |block|}}
         <li>
           <h3>Block</h3>
           {{wire-format-inspector spec=block}}
@@ -309,7 +309,7 @@ function renderUI() {
     {{/each}}
   </ol>
   <hr />
-  {{#each @block.children as |inner|}}
+  {{#each @block.children key="@index" as |inner|}}
     <div class="indent">{{block-inspector block=inner}}</div>
   {{/each}}
 </div>`);

--- a/packages/node_modules/glimmer-reference/index.ts
+++ b/packages/node_modules/glimmer-reference/index.ts
@@ -4,6 +4,19 @@ export { CLASS_META, default as Meta, metaFor } from "./lib/meta";
 export { setProperty, notifyProperty } from './lib/object';
 export { PushPullReference } from './lib/references/push-pull';
 export * from './lib/types';
+export { default as ObjectReference } from './lib/references/path';
 export { default as UpdatableReference, referenceFromParts } from './lib/references/root';
 export { ConstReference } from './lib/references/const';
-export { ListManager, ListIterator, ListDelegate } from './lib/references/iterable';
+export {
+  IterationItem,
+  Iterator,
+  Iterable,
+  OpaqueIterator,
+  OpaqueIterable,
+  AbstractIterator,
+  AbstractIterable,
+  IterationArtifacts,
+  ReferenceIterator,
+  IteratorSynchronizer,
+  IteratorSynchronizerDelegate
+} from './lib/references/iterable';

--- a/packages/node_modules/glimmer-reference/lib/references/iterable.ts
+++ b/packages/node_modules/glimmer-reference/lib/references/iterable.ts
@@ -1,10 +1,158 @@
-import { LinkedList, ListNode, InternedString, Dict, dict, intern, symbol } from 'glimmer-util';
+import { FIXME, LinkedList, ListNode, InternedString, Opaque, Dict, dict, intern, symbol } from 'glimmer-util';
 import { Reference, PathReference } from '../types';
 import UpdatableReference from './root';
 
-export const REFERENCE_ITERATOR: string = symbol("reference-iterator");
+export interface IterationItem<T> {
+  key: string;
+  value: T;
+}
 
-export interface ListDelegate {
+export interface AbstractIterator<T, U extends IterationItem<T>> {
+  isEmpty(): boolean;
+  next(): U;
+}
+
+export interface AbstractIterable<T, ItemType extends IterationItem<T>, ReferenceType extends PathReference<T>> {
+  iterate(): AbstractIterator<T, ItemType>;
+  referenceFor(item: ItemType): ReferenceType;
+  updateReference(reference: ReferenceType, item: ItemType);
+}
+
+export type Iterator<T> = AbstractIterator<T, IterationItem<T>>;
+export type Iterable<T> = AbstractIterable<T, IterationItem<T>, PathReference<T>>;
+
+type OpaqueIterationItem = IterationItem<Opaque>;
+export type OpaqueIterator = AbstractIterator<Opaque, OpaqueIterationItem>;
+export type OpaqueIterable = AbstractIterable<Opaque, OpaqueIterationItem, PathReference<Opaque>>;
+
+class ListItem extends ListNode<PathReference<Opaque>> implements IterationItem<PathReference<Opaque>> {
+  public key: InternedString;
+  public retained: boolean = false;
+  public seen: boolean = false;
+  private iterable: OpaqueIterable;
+
+  constructor(iterable: OpaqueIterable, result: OpaqueIterationItem) {
+    super(iterable.referenceFor(result));
+    this.key = result.key as FIXME<'user string to InternedString'>;
+    this.iterable = iterable;
+  }
+
+  update(item: OpaqueIterationItem) {
+    this.retained = true;
+    this.iterable.updateReference(this.value, item);
+  }
+
+  shouldRemove(): boolean {
+    return !this.retained;
+  }
+
+  reset() {
+    this.retained = false;
+    this.seen = false;
+  }
+}
+
+export class IterationArtifacts {
+  private iterable: OpaqueIterable;
+  private iterator: OpaqueIterator;
+  private map = dict<ListItem>();
+  private list = new LinkedList<ListItem>();
+
+  constructor(iterable: OpaqueIterable) {
+    this.iterable = iterable;
+  }
+
+  isEmpty(): boolean {
+    let iterator = this.iterator = this.iterable.iterate();
+    return iterator.isEmpty();
+  }
+
+  iterate(): OpaqueIterator {
+    let iterator = this.iterator || this.iterable.iterate();
+    this.iterator = null;
+
+    return iterator;
+  }
+
+  has(key: string): boolean {
+    return !!this.map[key];
+  }
+
+  get(key: string): ListItem {
+    return this.map[key];
+  }
+
+  wasSeen(key: string): boolean {
+    let node = this.map[key];
+    return node && node.seen;
+  }
+
+  append(item: OpaqueIterationItem): ListItem {
+    let { map, list, iterable } = this;
+
+    let node = map[item.key] = new ListItem(iterable, item);
+    list.append(node);
+    return node;
+  }
+
+  insertBefore(item: OpaqueIterationItem, reference: ListItem): ListItem {
+    let { map, list, iterable } = this;
+
+    let node = map[item.key] = new ListItem(iterable, item);
+    node.retained = true;
+    list.insertBefore(node, reference);
+    return node;
+  }
+
+  move(item: ListItem, reference: ListItem) {
+    let { list } = this;
+
+    item.retained = true;
+    list.remove(item);
+    list.insertBefore(item, reference);
+  }
+
+  remove(item: ListItem) {
+    let { list, map } = this;
+
+    list.remove(item);
+    delete this.map[<string>item.key];
+  }
+
+  nextNode(item: ListItem) {
+    return this.list.nextNode(item);
+  }
+
+  head() {
+    return this.list.head();
+  }
+}
+
+export class ReferenceIterator {
+  public artifacts: IterationArtifacts;
+  private iterator: OpaqueIterator = null;
+
+  // if anyone needs to construct this object with something other than
+  // an iterable, let @wycats know.
+  constructor(iterable: OpaqueIterable) {
+    let artifacts = new IterationArtifacts(iterable);
+    this.artifacts = artifacts;
+  }
+
+  next(): IterationItem<PathReference<Opaque>> {
+    let { artifacts } = this;
+
+    let iterator = (this.iterator = this.iterator || artifacts.iterate());
+
+    let item = iterator.next();
+
+    if (!item) return null;
+
+    return artifacts.append(item);
+  }
+}
+
+export interface IteratorSynchronizerDelegate {
   retain(key: InternedString, item: PathReference<any>);
   insert(key: InternedString, item: PathReference<any>, before: InternedString);
   move(key: InternedString, item: PathReference<any>, before: InternedString);
@@ -12,235 +160,130 @@ export interface ListDelegate {
   done();
 }
 
-class ListItem<T> extends ListNode<UpdatableReference<T>> {
-  public key: InternedString;
-  public handled: boolean = true;
-
-  constructor(value: UpdatableReference<T>, key: InternedString) {
-    super(value);
-    this.key = key;
-  }
-
-  handle(value: T) {
-    this.handled = true;
-    this.value.update(value);
-  }
-}
-
-export class ListManager {
-  private array: Reference<any[]>;
-  private keyPath: InternedString;
-
-  /* tslint:disable:no-unused-variable */
-  private map = dict<ListItem<any>>();
-  private list = new LinkedList<ListItem<any>>();
-  /* tslint:enable:no-unused-variable */
-
-  constructor(array: Reference<any[]>, keyPath: InternedString) {
-    this.array = array;
-    this.keyPath = keyPath;
-  }
-
-  iterator(target: ListDelegate): ListIterator {
-    let { array, map, list, keyPath } = this;
-
-    let keyFor;
-
-    if (keyPath === '@index') {
-      keyFor = (_, index: number) => {
-        return String(index);
-      };
-    } else if (keyPath === '@primitive') {
-      keyFor = (value: string | number | boolean) => {
-        return String(value);
-      };
-    } else {
-      keyFor = (item: InternedString) => {
-        return intern(item[<string>keyPath]);
-      };
-    }
-
-    return new ListIterator({ array: array.value(), keyFor, target, map, list });
-  }
-
-  sync(target: ListDelegate) {
-    let iterator = this.iterator(target);
-    while (!iterator.next());
-  }
-}
-
-interface IteratorOptions {
-  array: any[];
-  keyFor: (obj: any, index: number) => InternedString;
-  target: ListDelegate;
-  map: Dict<ListItem<any>>;
-  list: LinkedList<ListItem<any>>;
+interface IteratorSynchronizerOptions {
+  target: IteratorSynchronizerDelegate;
+  artifacts: IterationArtifacts;
 }
 
 enum Phase {
-  FirstAppend,
   Append,
   Prune,
   Done
 }
 
-export class ListIterator {
-  /* tslint:disable:no-unused-variable */
-  private candidates = dict<ListItem<any>>();
-  /* tslint:enable:no-unused-variable*/
-  private array: any[];
-  private keyFor: (obj, index: number) => InternedString;
-  private target: ListDelegate;
+export class IteratorSynchronizer {
+  private target: IteratorSynchronizerDelegate;
+  private iterator: OpaqueIterator;
+  private current: ListItem;
+  private artifacts: IterationArtifacts;
 
-  private map: Dict<ListItem<any>>;
-  private list: LinkedList<ListItem<any>>;
-
-  private arrayPosition = 0;
-  private listPosition: ListItem<any>;
-  private phase: Phase = Phase.Append;
-
-  constructor({ array, keyFor, target, map, list }: IteratorOptions) {
-    this.array = array;
-    this.keyFor = keyFor;
+  constructor({ target, artifacts }: IteratorSynchronizerOptions) {
     this.target = target;
-    this.map = map;
-    this.list = list;
-
-    if (list.isEmpty()) {
-      this.phase = Phase.FirstAppend;
-    } else {
-      this.phase = Phase.Append;
-    }
-
-    this.listPosition = list.head();
+    this.artifacts = artifacts;
+    this.iterator = artifacts.iterate();
+    this.current = artifacts.head();
   }
 
-  advanceToKey(key: InternedString) {
-    let { listPosition, candidates, list } = this;
+  sync() {
+    let phase: Phase = Phase.Append;
 
-    let seek = listPosition;
+    while (true) {
+      switch (phase) {
+        case Phase.Append: phase = this.nextAppend(); break;
+        case Phase.Prune: phase = this.nextPrune(); break;
+        case Phase.Done: this.nextDone(); return;
+      }
+    }
+  }
+
+  private advanceToKey(key: InternedString) {
+    let { current, artifacts } = this;
+
+    let seek = current;
 
     while (seek && seek.key !== key) {
-      candidates[<string>seek.key] = seek;
-      seek = list.nextNode(seek);
+      seek.seen = true;
+      seek = artifacts.nextNode(seek);
     }
 
-    this.listPosition = seek && list.nextNode(seek);
+    this.current = seek && artifacts.nextNode(seek);
   }
 
-  next(): boolean {
-    while (true) {
-      let handled = false;
-      switch (this.phase) {
-        case Phase.FirstAppend:
-          if (this.array.length <= this.arrayPosition) {
-            this.startPrune();
-          } else {
-            handled = this.nextInitialAppend();
-          }
-          break;
-        case Phase.Append: handled = this.nextAppend(); break;
-        case Phase.Prune: this.nextPrune(); break;
-        case Phase.Done: this.nextDone(); return true;
-      }
+  private nextAppend(): Phase {
+    let { iterator, current, artifacts } = this;
 
-      if (handled) return false;
-    }
-  }
+    let item = iterator.next();
 
-  private nextInitialAppend(): boolean {
-    let { array, arrayPosition, keyFor, listPosition, map } = this;
-
-    let item = array[this.arrayPosition++];
-
-    if (item === null || item === undefined) return;
-
-    let key = keyFor(item, arrayPosition);
-    this.nextInsert(map, listPosition, key, item);
-    return true;
-  }
-
-  private nextAppend(): boolean {
-    let { keyFor, array, listPosition, arrayPosition, map } = this;
-
-    if (array.length <= arrayPosition) {
-      this.startPrune();
-      return;
+    if (item === null) {
+      return this.startPrune();
     }
 
-    let item = array[this.arrayPosition++];
+    let { key, value } = item;
 
-    if (item === null || item === undefined) return;
-
-    let key = keyFor(item, arrayPosition);
-
-    if (listPosition && listPosition.key === key) {
-      this.nextRetain(listPosition, key, item);
-      return false;
-    } else if (map[<string>key]) {
-      this.nextMove(map, listPosition, key, item);
-      return false;
+    if (current && current.key === key) {
+      this.nextRetain(item);
+    } else if (artifacts.has(key)) {
+      this.nextMove(item);
     } else {
-      this.nextInsert(map, listPosition, key, item);
-      return true;
+      this.nextInsert(item);
     }
+
+    return Phase.Append;
   }
 
-  private nextRetain(current: ListItem<any>, key: InternedString, item: any) {
-    current.handle(item);
-    this.listPosition = this.list.nextNode(current);
-    this.target.retain(key, item);
+  private nextRetain(item: OpaqueIterationItem) {
+    let { artifacts, current } = this;
+
+    current.update(item);
+    this.current = artifacts.nextNode(current);
+    this.target.retain(item.key as FIXME<'user string to InternedString'>, current.value);
   }
 
-  private nextMove(map: Dict<ListItem<any>>, current: ListItem<any>, key: InternedString, item: any) {
-    let { candidates, list, target } = this;
-    let found = map[<string>key];
-    found.handle(item);
+  private nextMove(item: OpaqueIterationItem) {
+    let { current, artifacts, target } = this;
+    let { key, value } = item;
 
-    if (candidates[<string>key]) {
-      list.remove(found);
-      list.insertBefore(found, current);
+    let found = artifacts.get(item.key);
+    found.update(item);
+
+    if (artifacts.wasSeen(item.key)) {
+      artifacts.move(found, current);
       target.move(found.key, found.value, current ? current.key : null);
     } else {
-      this.advanceToKey(key);
+      this.advanceToKey(key as FIXME<'user string to InternedString'>);
     }
   }
 
-  private nextInsert(map: Dict<ListItem<any>>, current: ListItem<any>, key: InternedString, item: any) {
-    let { list, target } = this;
+  private nextInsert(item: OpaqueIterationItem) {
+    let { artifacts, target, current } = this;
 
-    let reference = new UpdatableReference(item);
-    let node = map[<string>key] = new ListItem(reference, key);
-    list.append(node);
+    let node = artifacts.insertBefore(item, current);
     target.insert(node.key, node.value, current ? current.key : null);
   }
 
-  private startPrune(): boolean {
-    this.phase = Phase.Prune;
-    this.listPosition = this.list.head();
-    return true;
+  private startPrune(): Phase {
+    this.current = this.artifacts.head();
+    return Phase.Prune;
   }
 
-  private nextPrune() {
-    let { list, target } = this;
+  private nextPrune(): Phase {
+    let { artifacts, target, current } = this;
 
-    if (this.listPosition === null) {
-      this.phase = Phase.Done;
-      return;
+    if (current === null) {
+      return Phase.Done;
     }
 
-    let node = this.listPosition;
-    this.listPosition = list.nextNode(node);
+    let node = current;
+    this.current = artifacts.nextNode(node);
 
-    if (node.handled) {
-      node.handled = false;
-      return;
-    } else {
-      list.remove(node);
-      delete this.map[<string>node.key];
+    if (node.shouldRemove()) {
+      artifacts.remove(node);
       target.delete(node.key);
-      return;
+    } else {
+      node.reset();
     }
+
+    return Phase.Prune;
   }
 
   private nextDone() {

--- a/packages/node_modules/glimmer-reference/lib/references/path.ts
+++ b/packages/node_modules/glimmer-reference/lib/references/path.ts
@@ -21,7 +21,7 @@ class UnchainFromPath {
   }
 }
 
-export class PathReference<T> extends PushPullReference<T> implements IPathReference<T>, HasGuid {
+export default class PathReference<T> extends PushPullReference<T> implements IPathReference<T>, HasGuid {
   private parent: IPathReference<any>;
   private property: InternedString;
   protected cache: any = EMPTY_CACHE;
@@ -103,3 +103,5 @@ export class PathReference<T> extends PushPullReference<T> implements IPathRefer
     return parent;
   }
 }
+
+export { PathReference };

--- a/packages/node_modules/glimmer-reference/tests/iterable-test.ts
+++ b/packages/node_modules/glimmer-reference/tests/iterable-test.ts
@@ -1,185 +1,249 @@
-import { Reference, RootReference, UpdatableReference, ListManager, ListDelegate } from 'glimmer-reference';
-import { LITERAL, LinkedList, ListNode, InternedString, dict } from 'glimmer-util';
+import {
+  Reference,
+  RootReference,
+  UpdatableReference,
+  AbstractIterable,
+  AbstractIterator,
+  Iterable,
+  Iterator,
+  IterationItem,
+  IterationArtifacts,
+  ReferenceIterator,
+  IteratorSynchronizer,
+  IteratorSynchronizerDelegate
+} from 'glimmer-reference';
+import { Opaque, LITERAL, LinkedList, ListNode, InternedString, dict } from 'glimmer-util';
 
 QUnit.module("Reference iterables");
 
-class Target implements ListDelegate {
-  private map = dict<ListNode<RootReference<any>>>();
-  private list = new LinkedList<ListNode<RootReference<any>>>();
+class Target implements IteratorSynchronizerDelegate {
+  private map = dict<ListNode<Reference<any>>>();
+  private list = new LinkedList<ListNode<Reference<any>>>();
 
-  retain() {}
+  retain(key: string, item: Reference<any>) {
+    if (item !== this.map[key].value) {
+      throw new Error("unstable reference");
+    }
+  }
+
   done() {}
 
-  insert(key: InternedString, item: RootReference<any>, before: InternedString) {
-    let referenceNode = before ? this.map[<string>before] : null;
-    let node = this.map[<string>key] = new ListNode(item);
+  append(key: string, item: Reference<any>) {
+    let node = this.map[key] = new ListNode(item);
+    this.list.append(node);
+  }
+
+  insert(key: string, item: Reference<any>, before: string) {
+    let referenceNode = before ? this.map[before] : null;
+    let node = this.map[key] = new ListNode(item);
     this.list.insertBefore(node, referenceNode);
   }
 
-  move(key: InternedString, item: RootReference<any>, before: InternedString) {
-    let referenceNode = before ? this.map[<string>before] : null;
-    let node = this.map[<string>key];
+  move(key: string, item: Reference<any>, before: string) {
+    let referenceNode = before ? this.map[before] : null;
+    let node = this.map[key];
+
+    if (item !== node.value) {
+      throw new Error("unstable reference");
+    }
+
     this.list.remove(node);
     this.list.insertBefore(node, referenceNode);
   }
 
-  delete(key: InternedString) {
-    let node = this.map[<string>key];
-    delete this.map[<string>key];
+  delete(key: string) {
+    let node = this.map[key];
+    delete this.map[key];
     this.list.remove(node);
   }
 
-  toArray() {
+  toArray(): Reference<any>[] {
     return this.list.toArray().map(node => node.value);
+  }
+
+  toValues(): any[] {
+    return this.toArray().map(ref => ref.value());
   }
 }
 
-function toValues(target: Target): any[] {
-  let refs: Reference<any>[] = target.toArray();
-  return refs.map(ref => ref.value());
+interface TestItem {
+  key: string;
+  name: string;
+}
+
+class TestIterationItem implements IterationItem<Opaque> {
+  public key: string;
+  public value: Opaque;
+
+  constructor(key: string, value: any) {
+    this.key = key;
+    this.value = value;
+  }
+}
+
+class TestIterator implements Iterator<Opaque> {
+  private array: TestItem[];
+  private position = 0;
+
+  constructor(array: TestItem[]) {
+    this.array = array;
+  }
+
+  isEmpty(): boolean {
+    return this.array.length === 0;
+  }
+
+  next(): IterationItem<Opaque> {
+    let { position, array } = this;
+
+    if (position >= array.length) return null;
+
+    let value = array[position];
+
+    this.position++;
+
+    return new TestIterationItem(value.key, value);
+  }
+}
+
+class TestIterable implements AbstractIterable<Opaque, IterationItem<Opaque>, UpdatableReference<Opaque>> {
+  private arrayRef: UpdatableReference<TestItem[]>;
+
+  constructor(arrayRef: UpdatableReference<TestItem[]>) {
+    this.arrayRef = arrayRef;
+  }
+
+  iterate(): TestIterator {
+    return new TestIterator(this.arrayRef.value());
+  }
+
+  referenceFor(item: TestIterationItem): UpdatableReference<Opaque> {
+    return new UpdatableReference(item.value);
+  }
+
+  updateReference(reference: UpdatableReference<Opaque>, item: TestIterationItem) {
+    reference.update(item.value);
+  }
+}
+
+function initialize(arr: TestItem[]): { artifacts: IterationArtifacts, target: Target, reference: UpdatableReference<TestItem[]> } {
+  let target = new Target();
+  let reference = new UpdatableReference(arr);
+  let iterator = new ReferenceIterator(new TestIterable(reference));
+  let item: IterationItem<Reference<Opaque>>;
+
+  while (item = iterator.next()) {
+    target.append(item.key, item.value);
+  }
+
+  return { reference, target, artifacts: iterator.artifacts };
+}
+
+function sync(target: Target, artifacts: IterationArtifacts) {
+  let synchronizer = new IteratorSynchronizer({ target, artifacts });
+  synchronizer.sync();
 }
 
 QUnit.test("They provide a sequence of references with keys", assert => {
   let arr = [{ key: "a", name: "Yehuda" }, { key: "b", name: "Godfrey" }];
-  let arrRef = new UpdatableReference(arr);
-  let target = new Target();
+  let { target } = initialize(arr);
 
-  let manager = new ListManager(arrRef, LITERAL('key'));
-  manager.sync(target);
-
-  assert.deepEqual(toValues(target), arr);
+  assert.deepEqual(target.toValues(), arr);
 });
 
 QUnit.test("When re-iterated via mutation, the original references are updated", assert => {
   let arr = [{ key: "a", name: "Yehuda" }, { key: "b", name: "Godfrey" }];
-  let arrRef = new UpdatableReference(arr);
-  let target = new Target();
+  let { target, reference, artifacts } = initialize(arr);
 
-  let manager = new ListManager(arrRef, LITERAL('key'));
-  manager.sync(target);
-
-  let [ yehudaRef, godfreyRef ] = target.toArray();
-
-  assert.equal(yehudaRef.value().name, "Yehuda");
-  assert.equal(godfreyRef.value().name, "Godfrey");
+  assert.deepEqual(target.toValues(), arr);
 
   arr.reverse();
 
-  manager.sync(target);
+  sync(target, artifacts);
 
-  assert.deepEqual(toValues(target), arr);
-  assert.deepEqual(target.toArray(), [ godfreyRef, yehudaRef ]);
+  assert.deepEqual(target.toValues(), arr);
 
   arr.push({ key: "c", name: "Godhuda" });
 
-  manager.sync(target);
+  sync(target, artifacts);
 
-  let [ , , godhudaRef ] = target.toArray();
-
-  assert.deepEqual(toValues(target), arr);
-  assert.deepEqual(target.toArray(), [ godfreyRef, yehudaRef, godhudaRef ]);
+  assert.deepEqual(target.toValues(), arr);
 
   arr.shift();
 
-  manager.sync(target);
+  sync(target, artifacts);
 
-  assert.deepEqual(target.toArray(), [ yehudaRef, godhudaRef ]);
-  assert.deepEqual(toValues(target), arr);
+  assert.deepEqual(target.toValues(), arr);
 });
 
 QUnit.test("When re-iterated via deep mutation, the original references are updated", assert => {
   let arr = [{ key: "a", name: "Yehuda" }, { key: "b", name: "Godfrey" }];
-  let arrRef = new UpdatableReference(arr);
-  let target = new Target();
+  let { target, reference, artifacts } = initialize(arr);
 
-  let manager = new ListManager(arrRef, LITERAL('key'));
-  manager.sync(target);
-
-  let [ yehudaRef, godfreyRef ] = target.toArray();
-
-  assert.equal(yehudaRef.value().name, "Yehuda");
-  assert.equal(godfreyRef.value().name, "Godfrey");
+  assert.deepEqual(target.toValues(), arr);
 
   arr[0].key = "b";
   arr[0].name = "Godfrey";
   arr[1].key = "a";
   arr[1].name = "Yehuda";
 
-  manager.sync(target);
+  sync(target, artifacts);
 
-  assert.deepEqual(toValues(target), arr);
-  assert.deepEqual(target.toArray(), [ godfreyRef, yehudaRef ]);
+  assert.deepEqual(target.toValues(), arr);
 
   arr[0].name = "Yehuda";
   arr[1].name = "Godfrey";
 
-  manager.sync(target);
+  sync(target, artifacts);
 
-  assert.deepEqual(toValues(target), arr);
-  assert.deepEqual(target.toArray(), [ godfreyRef, yehudaRef ]);
+  assert.deepEqual(target.toValues(), arr);
 
   arr.push({ key: "c", name: "Godhuda" });
 
-  manager.sync(target);
+  sync(target, artifacts);
 
-  let [ , , godhudaRef ] = target.toArray();
-
-  assert.deepEqual(toValues(target), arr);
-  assert.deepEqual(target.toArray(), [ godfreyRef, yehudaRef, godhudaRef ]);
+  assert.deepEqual(target.toValues(), arr);
 
   arr.shift();
 
-  manager.sync(target);
+  sync(target, artifacts);
 
-  assert.deepEqual(target.toArray(), [ yehudaRef, godhudaRef ]);
-  assert.deepEqual(toValues(target), arr);
+  assert.deepEqual(target.toValues(), arr);
 });
 
 QUnit.test("When re-iterated via replacement, the original references are updated", assert => {
   let arr = [{ key: "a", name: "Yehuda" }, { key: "b", name: "Godfrey" }];
-  let arrRef = new UpdatableReference(arr);
-  let target = new Target();
+  let { target, reference, artifacts } = initialize(arr);
 
-  let manager = new ListManager(arrRef, LITERAL('key'));
-  manager.sync(target);
-
-  let [ yehudaRef, godfreyRef ] = target.toArray();
-
-  assert.equal(yehudaRef.value().name, "Yehuda");
-  assert.equal(godfreyRef.value().name, "Godfrey");
+  assert.deepEqual(target.toValues(), arr);
 
   arr = arr.slice();
   arr.reverse();
-  arrRef.update(arr);
+  reference.update(arr);
 
-  manager.sync(target);
+  sync(target, artifacts);
 
-  assert.deepEqual(toValues(target), arr);
-  assert.deepEqual(target.toArray(), [ godfreyRef, yehudaRef ]);
+  assert.deepEqual(target.toValues(), arr);
 
-  arrRef.update([{ key: 'a', name: "Tom" }, { key: "b", name: "Stef "}]);
-  manager.sync(target);
+  reference.update([{ key: 'a', name: "Tom" }, { key: "b", name: "Stef "}]);
 
-  assert.deepEqual(toValues(target), [{ key: 'a', name: "Tom" }, { key: "b", name: "Stef "}]);
-  assert.deepEqual(target.toArray(), [ yehudaRef, godfreyRef ]);
+  sync(target, artifacts);
+
+  assert.deepEqual(target.toValues(), [{ key: 'a', name: "Tom" }, { key: "b", name: "Stef "}]);
 
   arr = arr.slice();
   arr.push({ key: "c", name: "Godhuda" });
-  arrRef.update(arr);
+  reference.update(arr);
 
-  manager.sync(target);
+  sync(target, artifacts);
 
-  let [ , , godhudaRef ] = target.toArray();
-
-  assert.deepEqual(toValues(target), arr);
-  assert.deepEqual(target.toArray(), [ godfreyRef, yehudaRef, godhudaRef ]);
+  assert.deepEqual(target.toValues(), arr);
 
   arr = arr.slice();
   arr.shift();
-  arrRef.update(arr);
+  reference.update(arr);
 
-  manager.sync(target);
+  sync(target, artifacts);
 
-  assert.deepEqual(target.toArray(), [ yehudaRef, godhudaRef ]);
-  assert.deepEqual(toValues(target), arr);
+  assert.deepEqual(target.toValues(), arr);
 });

--- a/packages/node_modules/glimmer-runtime/lib/builder.ts
+++ b/packages/node_modules/glimmer-runtime/lib/builder.ts
@@ -1,8 +1,10 @@
-import Bounds from './bounds';
+import Bounds, { clear } from './bounds';
 
 import { DOMHelper } from './dom';
 
 import { InternedString, Stack, LinkedList, LinkedListNode, assert } from 'glimmer-util';
+
+import { Environment } from './environment';
 
 import {
   Destroyable,
@@ -90,6 +92,42 @@ class GroupedElementOperations {
   }
 }
 
+export class Fragment implements Bounds {
+  private bounds: Bounds;
+
+  constructor(bounds: Bounds) {
+    this.bounds = bounds;
+  }
+
+  parentElement(): Element {
+    return this.bounds.parentElement();
+  }
+
+  firstNode(): Node {
+    return this.bounds.firstNode();
+  }
+
+  lastNode(): Node {
+    return this.bounds.lastNode();
+  }
+
+  update(bounds: Bounds) {
+    this.bounds = bounds;
+  }
+}
+
+interface InitialRenderOptions {
+  parentNode: Element;
+  nextSibling: Node;
+  dom: DOMHelper;
+}
+
+interface UpdateTrackerOptions {
+  tracker: Tracker;
+  nextSibling: Node;
+  dom: DOMHelper;
+}
+
 export class ElementStack {
   public nextSibling: Node;
   public dom: DOMHelper;
@@ -101,11 +139,23 @@ export class ElementStack {
   private elementOperationsStack = new Stack<GroupedElementOperations>();
   private blockStack = new Stack<Tracker>();
 
+  static forInitialRender({ parentNode, nextSibling, dom }: InitialRenderOptions) {
+    return new ElementStack({ dom, parentNode, nextSibling });
+  }
+
+  static resume({ tracker, nextSibling, dom }: UpdateTrackerOptions) {
+    let parentNode = tracker.parentElement();
+
+    let stack = new ElementStack({ dom, parentNode, nextSibling });
+    stack.pushBlockTracker(tracker);
+
+    return stack;
+  }
+
   constructor({ dom, parentNode, nextSibling }: ElementStackOptions) {
     this.dom = dom;
     this.element = parentNode;
     this.nextSibling = nextSibling;
-    if (nextSibling && !(nextSibling instanceof Node)) throw new Error("NOPE");
 
     this.elementStack.push(this.element);
     this.nextSiblingStack.push(this.nextSibling);
@@ -146,6 +196,11 @@ export class ElementStack {
 
   pushBlock(): Tracker {
     let tracker = new BlockTracker(this.element);
+    this.pushBlockTracker(tracker);
+    return tracker;
+  }
+
+  private pushBlockTracker(tracker: Tracker) {
     let current = this.blockStack.current;
 
     if (current !== null) {
@@ -157,7 +212,7 @@ export class ElementStack {
     return tracker;
   }
 
-  pushBlockList(list: LinkedList<Bounds & LinkedListNode>): Tracker {
+  pushBlockList(list: LinkedList<LinkedListNode & Bounds & Destroyable>): Tracker {
     let tracker = new BlockListTracker(this.element, list);
     let current = this.blockStack.current;
 
@@ -206,13 +261,13 @@ export class ElementStack {
     return comment;
   }
 
-  insertHTMLBefore(nextSibling: Node, html: string): Bounds {
+  insertHTMLBefore(nextSibling: Node, html: string): Fragment {
     let element = this.element;
 
     if (!canInsertHTML(element)) {
       throw new Error(`You cannot insert HTML (using triple-curlies or htmlSafe) into an SVG context: ${element.tagName}`);
     } else {
-      let bounds = this.dom.insertHTMLBefore(element, nextSibling, html);
+      let bounds = new Fragment(this.dom.insertHTMLBefore(element, nextSibling, html));
       this.blockStack.current.newBounds(bounds);
       return bounds;
     }
@@ -253,13 +308,14 @@ function canInsertHTML(node: Node): node is HTMLElement {
   return node instanceof HTMLElement;
 }
 
-interface Tracker extends Bounds, Destroyable {
+export interface Tracker extends Bounds, Destroyable {
   openElement(element: Element);
   closeElement();
   newNode(node: Node);
   newBounds(bounds: Bounds);
   newDestroyable(d: Destroyable);
   finalize(stack: ElementStack);
+  reset(env: Environment);
 }
 
 class BlockTracker implements Tracker {
@@ -335,27 +391,38 @@ class BlockTracker implements Tracker {
       stack.appendComment('');
     }
   }
+
+  reset(env: Environment) {
+    let { destroyables } = this;
+
+    if (destroyables && destroyables.length) {
+      for (let i=0; i<destroyables.length; i++) {
+        env.didDestroy(destroyables[i]);
+      }
+    }
+
+    let nextSibling = clear(this);
+
+    this.destroyables = null;
+    this.first = null;
+    this.last = null;
+
+    return nextSibling;
+  }
 }
 
 class BlockListTracker implements Tracker {
   private last: Node = null;
   private parent: Element;
-  private boundList: LinkedList<Bounds & LinkedListNode>;
-  private destroyables: Destroyable[] = null;
+  private boundList: LinkedList<LinkedListNode & Bounds & Destroyable>;
 
-  constructor(parent: Element, boundList: LinkedList<Bounds & LinkedListNode>) {
+  constructor(parent: Element, boundList: LinkedList<LinkedListNode & Bounds & Destroyable>) {
     this.parent = parent;
     this.boundList = boundList;
   }
 
   destroy() {
-    let { destroyables } = this;
-
-    if (destroyables && destroyables.length) {
-      for (let i=0; i<destroyables.length; i++) {
-        destroyables[i].destroy();
-      }
-    }
+    this.boundList.forEachNode(node => node.destroy());
   }
 
   parentElement() {
@@ -388,8 +455,6 @@ class BlockListTracker implements Tracker {
   }
 
   newDestroyable(d: Destroyable) {
-    this.destroyables = this.destroyables || [];
-    this.destroyables.push(d);
   }
 
   finalize(stack: ElementStack) {
@@ -400,4 +465,6 @@ class BlockListTracker implements Tracker {
 
     this.last = comment;
   }
+
+  reset() {}
 }

--- a/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/content.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/content.ts
@@ -2,7 +2,8 @@ import { Opcode, OpcodeJSON, UpdatingOpcode } from '../../opcodes';
 import { VM, UpdatingVM } from '../../vm';
 import { PathReference } from 'glimmer-reference';
 import { dict } from 'glimmer-util';
-import Bounds, { clear } from '../../bounds';
+import { clear } from '../../bounds';
+import { Fragment } from '../../builder';
 
 abstract class UpdatingContentOpcode extends UpdatingOpcode {
   public type: string;
@@ -81,9 +82,9 @@ export class UpdateTrustingAppendOpcode extends UpdatingContentOpcode {
 
   private reference: PathReference<string>;
   private lastValue: string;
-  private bounds: Bounds;
+  private bounds: Fragment;
 
-  constructor(reference: PathReference<string>, lastValue: string, bounds: Bounds) {
+  constructor(reference: PathReference<string>, lastValue: string, bounds: Fragment) {
     super();
     this.reference = reference;
     this.lastValue = lastValue;
@@ -98,7 +99,7 @@ export class UpdateTrustingAppendOpcode extends UpdatingContentOpcode {
 
       let parent = <HTMLElement>this.bounds.parentElement();
       let nextSibling = clear(this.bounds);
-      this.bounds = vm.dom.insertHTMLBefore(parent, nextSibling, val);
+      this.bounds.update(vm.dom.insertHTMLBefore(parent, nextSibling, val));
     }
   }
 }

--- a/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/lists.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/opcodes/lists.ts
@@ -2,8 +2,8 @@ import { Opcode, OpcodeJSON, UpdatingOpcode } from '../../opcodes';
 import { VM, UpdatingVM } from '../../vm';
 import { LabelOpcode } from '../../compiled/opcodes/vm';
 import { EvaluatedArgs } from '../expressions/args';
-import { LITERAL, ListSlice, Slice, InternedString, assert } from 'glimmer-util';
-import { PathReference, ConstReference, ListManager, ListDelegate } from 'glimmer-reference';
+import { FIXME, LITERAL, Opaque, ListSlice, Slice, InternedString, assert } from 'glimmer-util';
+import { Reference, PathReference, ConstReference, ReferenceIterator, IterationArtifacts, OpaqueIterable } from 'glimmer-reference';
 
 abstract class ListUpdatingOpcode extends UpdatingOpcode {
   public type: string;
@@ -13,10 +13,43 @@ abstract class ListUpdatingOpcode extends UpdatingOpcode {
   abstract evaluate(vm: UpdatingVM);
 }
 
+class IterablePresenceReference implements Reference<boolean> {
+  private artifacts: IterationArtifacts;
+
+  constructor(artifacts: IterationArtifacts) {
+    this.artifacts = artifacts;
+  }
+
+  value(): boolean {
+    return !this.artifacts.isEmpty();
+  }
+
+  isDirty(): boolean {
+    return true;
+  }
+
+  destroy() {}
+}
+
+export class PutIteratorOpcode extends Opcode {
+  public type = "put-iterator";
+
+  evaluate(vm: VM) {
+    let listRef = vm.frame.getOperand();
+    let args = vm.frame.getArgs();
+    let iterable = vm.env.iterableFor(listRef, args);
+    let iterator = new ReferenceIterator(iterable);
+
+    vm.frame.setIterator(iterator);
+    vm.frame.setCondition(new IterablePresenceReference(iterator.artifacts));
+  }
+}
+
 export class EnterListOpcode extends Opcode {
   public type = "enter-list";
 
   public slice: Slice<Opcode>;
+  private iterable: OpaqueIterable;
 
   constructor(start: LabelOpcode, end: LabelOpcode) {
     super();
@@ -24,15 +57,7 @@ export class EnterListOpcode extends Opcode {
   }
 
   evaluate(vm: VM) {
-    let listRef = vm.frame.getOperand();
-    let keyPath = vm.frame.getArgs().named.get(LITERAL("key")).value();
-
-    let manager =  new ListManager(listRef, keyPath);
-    let delegate = new IterateDelegate(vm);
-
-    vm.frame.setIterator(manager.iterator(delegate));
-
-    vm.enterList(manager, this.slice);
+    vm.enterList(this.slice);
   }
 
   toJSON(): OpcodeJSON {
@@ -94,41 +119,6 @@ export class EnterWithKeyOpcode extends Opcode {
 const TRUE_REF = new ConstReference(true);
 const FALSE_REF = new ConstReference(false);
 
-class IterateDelegate implements ListDelegate {
-  private vm: VM;
-
-  constructor(vm: VM) {
-    this.vm = vm;
-  }
-
-  insert(key: InternedString, item: PathReference<any>, before: InternedString) {
-    let { vm } = this;
-
-    assert(!before, "Insertion should be append-only on initial render");
-
-    vm.frame.setArgs(EvaluatedArgs.positional([item]));
-    vm.frame.setOperand(item);
-    vm.frame.setCondition(TRUE_REF);
-    vm.frame.setKey(key);
-  }
-
-  retain(key: InternedString, item: PathReference<any>) {
-    assert(false, "Insertion should be append-only on initial render");
-  }
-
-  move(key: InternedString, item: PathReference<any>, before: InternedString) {
-    assert(false, "Insertion should be append-only on initial render");
-  }
-
-  delete(key: InternedString) {
-    assert(false, "Insertion should be append-only on initial render");
-  }
-
-  done() {
-    this.vm.frame.setCondition(FALSE_REF);
-  }
-}
-
 export class NextIterOpcode extends Opcode {
   public type = "next-iter";
 
@@ -140,23 +130,16 @@ export class NextIterOpcode extends Opcode {
   }
 
   evaluate(vm: VM) {
-    if (vm.frame.getIterator().next()) {
+    let item = vm.frame.getIterator().next();
+
+    if (item) {
+      vm.frame.setCondition(TRUE_REF);
+      vm.frame.setKey(item.key as FIXME<'user str to InternedString'>);
+      vm.frame.setOperand(item.value);
+      vm.frame.setArgs(EvaluatedArgs.positional([item.value]));
+    } else {
+      vm.frame.setCondition(FALSE_REF);
       vm.goto(this.end);
     }
-  }
-}
-
-class ReiterateOpcode extends ListUpdatingOpcode {
-  public type = "reiterate";
-
-  private initialize: (vm: VM) => void;
-
-  constructor(initialize: (vm: VM) => void) {
-    super();
-    this.initialize = initialize;
-  }
-
-  evaluate(vm: UpdatingVM) {
-    vm.throw(this.initialize);
   }
 }

--- a/packages/node_modules/glimmer-runtime/lib/environment.ts
+++ b/packages/node_modules/glimmer-runtime/lib/environment.ts
@@ -1,7 +1,7 @@
 import { Statement as StatementSyntax } from './syntax';
 
 import { DOMHelper } from './dom';
-import { Destroyable, Reference } from 'glimmer-reference';
+import { Destroyable, Reference, OpaqueIterable } from 'glimmer-reference';
 import { NULL_REFERENCE, ConditionalReference } from './references';
 
 import {
@@ -21,6 +21,8 @@ import {
   intern,
   ensureGuid
 } from 'glimmer-util';
+
+import { EvaluatedArgs } from './compiled/expressions/args';
 
 import { InlineBlock } from './compiled/blocks';
 
@@ -138,6 +140,8 @@ export abstract class Environment {
     return new ConditionalReference(reference);
   }
 
+  abstract iterableFor(reference: Reference<Opaque>, args: EvaluatedArgs): OpaqueIterable;
+
   getDOM(): DOMHelper { return this.dom; }
 
   getIdentity(object: HasGuid): InternedString {
@@ -209,24 +213,6 @@ export abstract class Environment {
     for (let i=0; i<this.destructors.length; i++) {
       this.destructors[i].destroy();
     }
-  }
-
-  iteratorFor(iterable: PathReference<Opaque[]>) {
-    let position = 0;
-    let len = iterable.value().length;
-
-    return {
-      next() {
-        if (position >= len) return { done: true, value: undefined };
-
-        position++;
-
-        return {
-          done: false,
-          value: iterable.get(intern("" + (position - 1)))
-        };
-      }
-    };
   }
 
   abstract rootReferenceFor(obj: any): PathReference<Opaque>;

--- a/packages/node_modules/glimmer-runtime/lib/syntax/builtins/each.ts
+++ b/packages/node_modules/glimmer-runtime/lib/syntax/builtins/each.ts
@@ -6,9 +6,11 @@ import {
 import * as Syntax from '../core';
 
 import {
+  EnterOpcode,
   LabelOpcode,
   PutArgsOpcode,
   JumpOpcode,
+  JumpUnlessOpcode,
   EvaluateOpcode,
   ExitOpcode,
   PushChildScopeOpcode,
@@ -16,6 +18,7 @@ import {
 } from '../../compiled/opcodes/vm';
 
 import {
+  PutIteratorOpcode,
   EnterListOpcode,
   NextIterOpcode,
   EnterWithKeyOpcode,
@@ -42,39 +45,72 @@ export default class EachSyntax extends StatementSyntax {
   }
 
   compile(compiler: StatementCompilationBuffer, env: Environment) {
-    //        PutArgs
-    //        EnterList(BEGIN, END)
-    // ITER:  Noop
-    //        NextIter(BREAK)
-    //        EnterWithKey(BEGIN, END)
-    // BEGIN: Noop
-    //        PushChildScope
-    //        Evaluate(default)
-    //        PopScope
-    // END:   Noop
-    //        Exit
-    //        Jump(ITER)
-    // BREAK: Noop
-    //        ExitList
+    //         Enter(BEGIN, END)
+    // BEGIN:  Noop
+    //         PutArgs
+    //         PutIterable
+    //         JumpUnless(ELSE)
+    //         EnterList(BEGIN2, END2)
+    // ITER:   Noop
+    //         NextIter(BREAK)
+    //         EnterWithKey(BEGIN2, END2)
+    // BEGIN2: Noop
+    //         PushChildScope
+    //         Evaluate(default)
+    //         PopScope
+    // END2:   Noop
+    //         Exit
+    //         Jump(ITER)
+    // BREAK:  Noop
+    //         ExitList
+    //         Jump(END)
+    // ELSE:   Noop
+    //         Evalulate(inverse)
+    // END:    Noop
+    //         Exit
+
 
     let BEGIN = new LabelOpcode({ label: "BEGIN" });
     let ITER = new LabelOpcode({ label: "ITER" });
+    let BEGIN2 = new LabelOpcode({ label: "BEGIN2" });
+    let END2 = new LabelOpcode({ label: "END2" });
     let BREAK = new LabelOpcode({ label: "BREAK" });
+    let ELSE = new LabelOpcode({ label: "ELSE" });
     let END = new LabelOpcode({ label: "END" });
 
+
+    compiler.append(new EnterOpcode({ begin: BEGIN, end: END }));
+    compiler.append(BEGIN);
     compiler.append(new PutArgsOpcode({ args: this.args.compile(compiler, env) }));
-    compiler.append(new EnterListOpcode(BEGIN, END));
+    compiler.append(new PutIteratorOpcode());
+
+    if (this.templates.inverse) {
+      compiler.append(new JumpUnlessOpcode({ target: ELSE }));
+    } else {
+      compiler.append(new JumpUnlessOpcode({ target: END }));
+    }
+
+    compiler.append(new EnterListOpcode(BEGIN2, END2));
     compiler.append(ITER);
     compiler.append(new NextIterOpcode(BREAK));
-    compiler.append(new EnterWithKeyOpcode(BEGIN, END));
-    compiler.append(BEGIN);
+    compiler.append(new EnterWithKeyOpcode(BEGIN2, END2));
+    compiler.append(BEGIN2);
     compiler.append(new PushChildScopeOpcode());
     compiler.append(new EvaluateOpcode({ debug: "default", block: this.templates.default }));
     compiler.append(new PopScopeOpcode());
-    compiler.append(END);
+    compiler.append(END2);
     compiler.append(new ExitOpcode());
     compiler.append(new JumpOpcode({ target: ITER }));
     compiler.append(BREAK);
     compiler.append(new ExitListOpcode());
+    compiler.append(new JumpOpcode({ target: END }));
+
+    if (this.templates.inverse) {
+      compiler.append(ELSE);
+      compiler.append(new EvaluateOpcode({ debug: "inverse", block: this.templates.inverse }));
+    }
+
+    compiler.append(END);
+    compiler.append(new ExitOpcode());
   }
 }

--- a/packages/node_modules/glimmer-runtime/lib/template.ts
+++ b/packages/node_modules/glimmer-runtime/lib/template.ts
@@ -42,7 +42,7 @@ export default class Template {
   }
 
   render(self: PathReference<any>, env: Environment, { keywords, appendTo }: RenderOptions, blockArguments: any[]=null) {
-    let elementStack = new ElementStack({ dom: env.getDOM(), parentNode: appendTo, nextSibling: null });
+    let elementStack = ElementStack.forInitialRender({ dom: env.getDOM(), parentNode: appendTo, nextSibling: null });
     let compiled = this.raw.compile(env);
     let vm = VM.initial(env, { self, elementStack, size: compiled.symbols });
 

--- a/packages/node_modules/glimmer-runtime/lib/vm/append.ts
+++ b/packages/node_modules/glimmer-runtime/lib/vm/append.ts
@@ -1,7 +1,7 @@
 import { Scope, DynamicScope, Environment } from '../environment';
 import { ElementStack } from '../builder';
 import { Dict, Stack, LinkedList, LOGGER, InternedString, Opaque } from 'glimmer-util';
-import { Destroyable, PathReference, ListManager, ListIterator } from 'glimmer-reference';
+import { Destroyable, PathReference, ReferenceIterator } from 'glimmer-reference';
 import Template from '../template';
 import { Templates } from '../syntax/core';
 import { InlineBlock, CompiledBlock } from '../compiled/blocks';
@@ -32,7 +32,7 @@ interface Registers {
   operand: PathReference<any>;
   args: EvaluatedArgs;
   condition: PathReference<boolean>;
-  iterator: ListIterator;
+  iterator: ReferenceIterator;
   key: InternedString;
   templates: Dict<Template>;
 }
@@ -119,13 +119,14 @@ export default class VM {
     this.didEnter(tryOpcode, updating);
   }
 
-  enterList(manager: ListManager, ops: OpSeq) {
+  enterList(ops: OpSeq) {
     let updating = new LinkedList<BlockOpcode>();
 
     this.stack().pushBlockList(updating);
     let state = this.capture();
+    let artifacts = this.frame.getIterator().artifacts;
 
-    let opcode = new ListBlockOpcode({ ops, state, updating, manager });
+    let opcode = new ListBlockOpcode({ ops, state, updating, artifacts });
 
     this.listBlockStack.push(opcode);
 

--- a/packages/node_modules/glimmer-runtime/lib/vm/frame.ts
+++ b/packages/node_modules/glimmer-runtime/lib/vm/frame.ts
@@ -1,6 +1,6 @@
 import { Scope } from '../environment';
 import { InternedString } from 'glimmer-util';
-import { Reference, PathReference, ListIterator } from 'glimmer-reference';
+import { Reference, PathReference, ReferenceIterator } from 'glimmer-reference';
 import { InlineBlock } from '../compiled/blocks';
 import { EvaluatedArgs } from '../compiled/expressions/args';
 import { Opcode, OpSeq } from '../opcodes';
@@ -14,7 +14,7 @@ class Frame {
   callerScope: Scope = null;
   blocks: Blocks = null;
   condition: Reference<boolean> = null;
-  iterator: ListIterator = null;
+  iterator: ReferenceIterator = null;
   key: InternedString = null;
 
   constructor(ops: OpSeq) {
@@ -84,11 +84,11 @@ export class FrameStack {
     return this.frames[this.frame].condition = condition;
   }
 
-  getIterator(): ListIterator {
+  getIterator(): ReferenceIterator {
     return this.frames[this.frame].iterator;
   }
 
-  setIterator(iterator: ListIterator): ListIterator {
+  setIterator(iterator: ReferenceIterator): ReferenceIterator {
     return this.frames[this.frame].iterator = iterator;
   }
 

--- a/packages/node_modules/glimmer-runtime/lib/vm/update.ts
+++ b/packages/node_modules/glimmer-runtime/lib/vm/update.ts
@@ -1,8 +1,8 @@
 import { Scope, DynamicScope, Environment } from '../environment';
 import { Bounds, clear, move } from '../bounds';
-import { ElementStack } from '../builder';
-import { Stack, LinkedList, InternedString, Dict, dict } from 'glimmer-util';
-import { ConstReference, Destroyable, PathReference, ListManager, ListDelegate } from 'glimmer-reference';
+import { ElementStack, Tracker } from '../builder';
+import { Opaque, Stack, LinkedList, InternedString, Dict, dict } from 'glimmer-util';
+import { Reference, ConstReference, Destroyable, PathReference, IterationArtifacts, IteratorSynchronizer, IteratorSynchronizerDelegate } from 'glimmer-reference';
 import { EvaluatedArgs } from '../compiled/expressions/args';
 import { OpcodeJSON, OpSeq, UpdatingOpcode, UpdatingOpSeq } from '../opcodes';
 import { LabelOpcode } from '../compiled/opcodes/vm';
@@ -43,8 +43,8 @@ export default class UpdatingVM {
     this.frameStack.push(new UpdatingVMFrame(this, ops, handler));
   }
 
-  throw(initialize?: (vm: VM) => void) {
-    this.frameStack.current.handleException(initialize);
+  throw() {
+    this.frameStack.current.handleException();
     this.frameStack.pop();
   }
 
@@ -54,14 +54,14 @@ export default class UpdatingVM {
 }
 
 export interface ExceptionHandler {
-  handleException(initialize?: (vm: VM) => void);
+  handleException();
 }
 
 export interface VMState {
   env: Environment;
   scope: Scope;
   dynamicScope: DynamicScope;
-  block: Bounds & Destroyable;
+  block: Tracker;
 }
 
 export interface BlockOpcodeOptions {
@@ -70,7 +70,7 @@ export interface BlockOpcodeOptions {
   updating: LinkedList<UpdatingOpcode>;
 }
 
-export abstract class BlockOpcode extends UpdatingOpcode implements Bounds {
+export abstract class BlockOpcode extends UpdatingOpcode implements Bounds, Destroyable {
   public type = "block";
   public next = null;
   public prev = null;
@@ -79,7 +79,7 @@ export abstract class BlockOpcode extends UpdatingOpcode implements Bounds {
   protected scope: Scope;
   protected dynamicScope: DynamicScope;
   protected updating: LinkedList<UpdatingOpcode>;
-  protected bounds: Bounds & Destroyable;
+  protected bounds: Tracker;
   public ops: OpSeq;
 
   constructor({ ops, updating, state }: BlockOpcodeOptions) {
@@ -109,6 +109,10 @@ export abstract class BlockOpcode extends UpdatingOpcode implements Bounds {
     vm.try(this.updating, null);
   }
 
+  destroy() {
+    this.bounds.destroy();
+  }
+
   didDestroy() {
     this.env.didDestroy(this.bounds);
   }
@@ -131,32 +135,30 @@ export abstract class BlockOpcode extends UpdatingOpcode implements Bounds {
   }
 }
 
-export class TryOpcode extends BlockOpcode implements UpdatingOpcode, ExceptionHandler {
+export class TryOpcode extends BlockOpcode implements UpdatingOpcode, ExceptionHandler, Destroyable {
   public type = "try";
 
   evaluate(vm: UpdatingVM) {
     vm.try(this.updating, this);
   }
 
-  handleException(initialize?: (vm: VM) => void) {
+  handleException() {
     let { env, scope, dynamicScope } = this;
 
-    let elementStack = new ElementStack({
+    let elementStack = ElementStack.resume({
       dom: this.env.getDOM(),
-      parentNode: this.bounds.parentElement(),
-      nextSibling: initialize ? this.bounds.lastNode().nextSibling : clear(this.bounds)
+      tracker: this.bounds,
+      nextSibling: this.bounds.reset(env)
     });
 
-    env.didDestroy(this.bounds);
-
     let vm = new VM({ env, scope, dynamicScope, elementStack });
-    let result = vm.execute(this.ops, initialize);
+    let result = vm.execute(this.ops);
 
-    if (!initialize) {
-      this.updating = result.opcodes();
-    }
+    this.updating = result.opcodes();
+  }
 
-    this.bounds = result;
+  destroy() {
+    this.bounds.destroy();
   }
 
   toJSON() : OpcodeJSON {
@@ -171,7 +173,7 @@ export class TryOpcode extends BlockOpcode implements UpdatingOpcode, ExceptionH
   }
 }
 
-export class ListRevalidationDelegate implements ListDelegate {
+export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
   private opcode: ListBlockOpcode;
   private map: Dict<BlockOpcode>;
   private updating: LinkedList<UpdatingOpcode>;
@@ -245,22 +247,21 @@ export class ListRevalidationDelegate implements ListDelegate {
   }
 
   done() {
-    // this.vm.registers.condition = new ConstReference(false);
   }
 }
 
 export interface ListBlockOpcodeOptions extends BlockOpcodeOptions {
-  manager: ListManager;
+  artifacts: IterationArtifacts;
 }
 
 export class ListBlockOpcode extends BlockOpcode {
   public type = "list-block";
   public map = dict<BlockOpcode>();
-  public manager: ListManager;
+  public artifacts: IterationArtifacts;
 
   constructor(options: ListBlockOpcodeOptions) {
     super(options);
-    this.manager = options.manager;
+    this.artifacts = options.artifacts;
   }
 
   firstNode(): Node {
@@ -279,9 +280,11 @@ export class ListBlockOpcode extends BlockOpcode {
 
   evaluate(vm: UpdatingVM) {
     // Revalidate list somehow....
-    let delegate = new ListRevalidationDelegate(this);
+    let { artifacts } = this;
+    let target = new ListRevalidationDelegate(this);
+    let synchronizer = new IteratorSynchronizer({ target, artifacts });
 
-    this.manager.sync(delegate);
+    synchronizer.sync();
 
     // Run now-updated updating opcodes
     super.evaluate(vm);
@@ -290,7 +293,7 @@ export class ListBlockOpcode extends BlockOpcode {
   vmForInsertion(nextSibling?: Node) {
     let { env, scope, dynamicScope } = this;
 
-    let elementStack = new ElementStack({
+    let elementStack = ElementStack.forInitialRender({
       dom: this.env.getDOM(),
       parentNode: this.bounds.parentElement(),
       nextSibling: nextSibling || this.bounds.lastNode()
@@ -332,7 +335,7 @@ export class UpdatingVMFrame {
     return current;
   }
 
-  handleException(initialize?: (vm: VM) => void) {
-    this.exceptionHandler.handleException(initialize);
+  handleException() {
+    this.exceptionHandler.handleException();
   }
 }

--- a/packages/node_modules/glimmer-runtime/tests/updating-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/updating-test.ts
@@ -651,6 +651,48 @@ test("top-level bounds are correct when swapping order", assert => {
   assertInvariants(result, "after emptying the list");
 });
 
+test("top-level bounds are correct when toggling conditionals", assert => {
+  let template = compile("{{#if item}}{{item.name}}{{/if}}");
+
+  let tom = { name: "Tom Dale" };
+  let yehuda = { name: "Yehuda Katz" };
+  let object = { item: tom };
+
+  render(template, object);
+  assertInvariants(result, "initial render");
+
+  rerender();
+  assertInvariants(result, "after no-op rerender");
+
+  object = { item: yehuda };
+  rerender(object);
+  assertInvariants(result, "after replacement");
+
+  object = { item: null };
+  rerender(object);
+  assertInvariants(result, "after nulling");
+});
+
+test("top-level bounds are correct when changing innerHTML", assert => {
+  let template = compile("{{{html}}}");
+
+  let object = { html: "<b>inner</b>-<b>before</b>" };
+
+  render(template, object);
+  assertInvariants(result, "initial render");
+
+  rerender();
+  assertInvariants(result, "after no-op rerender");
+
+  object = { html: "<p>inner-after</p>" };
+  rerender(object);
+  assertInvariants(result, "after replacement");
+
+  object = { html: "" };
+  rerender(object);
+  assertInvariants(result, "after emptying");
+});
+
 testEachHelper(
   "An implementation of #each using block params",
   "<ul>{{#each list key='key' as |item|}}<li class='{{item.class}}'>{{item.name}}</li>{{/each}}</ul>"

--- a/packages/node_modules/glimmer-test-helpers/lib/environment.ts
+++ b/packages/node_modules/glimmer-test-helpers/lib/environment.ts
@@ -25,6 +25,9 @@ import {
   ComponentManager,
   ComponentDefinition,
   ComponentLayoutBuilder,
+
+  // Values
+  EvaluatedArgs,
   EvaluatedNamedArgs,
 
   // Syntax Classes
@@ -44,6 +47,7 @@ import {
 import { compile as rawCompile, compileLayout as rawCompileLayout } from "./helpers";
 
 import {
+  Opaque,
   Slice,
   Dict,
   InternedString,
@@ -53,7 +57,90 @@ import {
 
 import GlimmerObject, { GlimmerObjectFactory } from "glimmer-object";
 
-import { Destroyable, Reference, PathReference, UpdatableReference } from "glimmer-reference";
+import {
+  Destroyable,
+  Reference,
+  PathReference,
+  UpdatableReference,
+  OpaqueIterator,
+  OpaqueIterable,
+  AbstractIterable,
+  IterationItem
+} from "glimmer-reference";
+
+type KeyFor = (item: Opaque, index: number) => string;
+
+class ArrayIterator implements OpaqueIterator {
+  private array: Opaque[];
+  private keyFor: KeyFor;
+  private position = 0;
+
+  constructor(array: any[], keyFor: KeyFor) {
+    this.array = array;
+    this.keyFor = keyFor;
+  }
+
+  isEmpty(): boolean {
+    return this.array.length === 0;
+  }
+
+  next(): IterationItem<Opaque> {
+    let { position, array, keyFor } = this;
+
+    if (position >= array.length) return null;
+
+    let value = array[position];
+    let key = keyFor(value, position);
+
+    this.position++;
+
+    return { key, value };
+  }
+}
+
+class EmptyIterator implements OpaqueIterator {
+  isEmpty(): boolean {
+    return true;
+  }
+
+  next(): IterationItem<Opaque> {
+    throw new Error(`Cannot call next() on an empty iterator`);
+  }
+}
+
+const EMPTY_ITERATOR = new EmptyIterator();
+
+class Iterable implements AbstractIterable<Opaque, IterationItem<Opaque>, UpdatableReference<Opaque>> {
+  private ref: Reference<Opaque>;
+  private keyFor: KeyFor;
+
+  constructor(ref: Reference<Opaque>, keyFor: KeyFor) {
+    this.ref = ref;
+    this.keyFor = keyFor;
+  }
+
+  iterate(): OpaqueIterator {
+    let { ref, keyFor } = this;
+
+    let iterable = ref.value() as any;
+
+    if (Array.isArray(iterable)) {
+      return iterable.length > 0 ? new ArrayIterator(iterable, keyFor) : EMPTY_ITERATOR;
+    } else if (iterable === undefined || iterable === null) {
+      return EMPTY_ITERATOR;
+    } else {
+      throw new Error(`Don't know how to {{#each ${iterable}}}`);
+    }
+  }
+
+  referenceFor(item: IterationItem<Opaque>): UpdatableReference<Opaque> {
+    return new UpdatableReference(item.value);
+  }
+
+  updateReference(reference: UpdatableReference<Opaque>, item: IterationItem<Opaque>) {
+    reference.update(item.value);
+  }
+}
 
 export type Attrs = Dict<any>;
 type AttrsDiff = { oldAttrs: Attrs, newAttrs: Attrs };
@@ -359,6 +446,29 @@ export class TestEnvironment extends Environment {
 
   getKeywords(): InternedString[] {
     return [ 'view' as InternedString ];
+  }
+
+  iterableFor(ref: Reference<Opaque>, args: EvaluatedArgs): OpaqueIterable {
+    let keyPath = args.named.get("key" as InternedString).value();
+    let keyFor: KeyFor;
+
+    if (!keyPath) {
+      throw new Error('Must specify a key for #each');
+    }
+
+    switch (keyPath) {
+      case '@index':
+        keyFor = (_, index: number) => String(index);
+        break;
+      case '@primitive':
+        keyFor = (item: Opaque) => String(item);
+        break;
+      default:
+        keyFor = (item: Opaque) => item[<string>keyPath];
+        break;
+    }
+
+    return new Iterable(ref, keyFor);
   }
 }
 


### PR DESCRIPTION
Previously, the strategy for acquiring a key and its associated updatable reference for a given iteration item was hardcoded in glimmer-reference.

This is unacceptable, as the reference type is intended to provide object-model-specific semantics such as those provided by Ember, but also libraries like immutable.js.

This change decouples these strategies from the iterator implementation, allowing the environment to participate.

The environment must now implement an iterableFor hook, which produces an iterable for a given array-like object and #each arguments. This iterable produces an iterator per render (and revalidation). The iterator yields { key, value }. The iterable also encodes the policy for producing and updating a reference for a given value.