### PR TITLE
Fix loc info for content statements with leading newlines.

### DIFF
--- a/packages/node_modules/glimmer-syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/node_modules/glimmer-syntax/lib/parser/handlebars-node-visitors.ts
@@ -107,7 +107,9 @@ export default {
       changeLines = leadingNewlineDifference(content.original, content.value);
     }
 
-    this.tokenizer.line = this.tokenizer.line + changeLines;
+    this.tokenizer.line = content.loc.start.line + changeLines;
+    this.tokenizer.column = content.loc.start.column;
+
     this.tokenizer.tokenizePart(content.value);
     this.tokenizer.flushData();
   },

--- a/packages/node_modules/glimmer-syntax/tests/loc-node-test.ts
+++ b/packages/node_modules/glimmer-syntax/tests/loc-node-test.ts
@@ -85,3 +85,54 @@ test("html elements", function() {
   locEqual(div, 4, 6, 6, 12, 'div element');
   locEqual(hr, 5, 8, 5, 14, 'hr element');
 });
+
+test("html elements with nested blocks", function() {
+  var ast = parse(`
+    <div>
+      {{#if isSingleError}}
+        Single error here!
+      {{else if errors}}
+        Multiple errors here!
+      {{else}}
+        No errors found!
+      {{/if}} <p>Hi there!</p>
+    </div>
+  `);
+
+  let [,div] = ast.body;
+  let [,ifBlock,,p] = div.children;
+  let inverseBlock = ifBlock.inverse;
+  let [nestedIfBlock] = inverseBlock.body;
+  let nestedIfInverseBlock = nestedIfBlock.inverse;
+
+  locEqual(div, 2, 4, 10, 10, 'div element');
+  locEqual(ifBlock, 3, 6, 9, 13, 'outer if block');
+  locEqual(inverseBlock, 5, 6, 9, 6, 'inverse block');
+  locEqual(nestedIfBlock, 5, 6, 9, 6, 'nested if block');
+  locEqual(nestedIfInverseBlock, 7, 6, 9, 6, 'nested inverse block');
+  locEqual(p, 9, 14, 9, 30, 'p');
+});
+
+test("blocks with nested html elements", function() {
+  var ast = parse(`
+    {{#foo-bar}}<div>Foo</div>{{/foo-bar}} <p>Hi!</p>
+  `);
+
+  let block = ast.body[1].program;
+  let [div] = block.body;
+  let p = ast.body[3];
+
+  locEqual(p, 2, 43, 2, 53, 'p element');
+  locEqual(div, 2, 16, 2, 30, 'div element');
+});
+
+test("html elements after mustache", function() {
+  var ast = parse(`
+    {{foo-bar}} <p>Hi!</p>
+  `);
+
+  let [,mustache,,p] = ast.body;
+
+  locEqual(mustache, 2, 4, 2, 15, '{{foo-bar}}');
+  locEqual(p, 2, 16, 2, 26, 'div element');
+});


### PR DESCRIPTION
Given the following:

```hbs
<div>
  {{#if isSingleError}}
    Single error here!
  {{else if errors}}
    Multiple errors here!
  {{else}}
    No errors found!
  {{/if}}
</div>
```

The `ElementNode` for the `<div>` was indicating that its `loc.end.column` was 12. This is ultimately due to how Handlebars handles trailing newlines after the `{{/if}}`. We were properly detecting that the node was `rightStripped` and adding the number of stripped newlines to the `tokenizer.line` number, but we did not reset the `tokenizer.column` also.

The fix is to ensure that the column is reset when incrementing the line count.

---

This is also being fixed in HTMLBars in https://github.com/tildeio/htmlbars/pull/450