### PR TITLE
Ensure column is reset when incrementing right stripped lines.

### DIFF
--- a/packages/glimmer-syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/glimmer-syntax/lib/parser/handlebars-node-visitors.ts
@@ -108,7 +108,7 @@ export default {
     }
 
     this.tokenizer.line = content.loc.start.line + changeLines;
-    this.tokenizer.column = content.loc.start.column;
+    this.tokenizer.column = changeLines ? 0 : content.loc.start.column;
 
     this.tokenizer.tokenizePart(content.value);
     this.tokenizer.flushData();

--- a/packages/glimmer-syntax/tests/loc-node-test.ts
+++ b/packages/glimmer-syntax/tests/loc-node-test.ts
@@ -113,6 +113,31 @@ test("html elements with nested blocks", function() {
   locEqual(p, 9, 14, 9, 30, 'p');
 });
 
+test("block + newline + element ", function() {
+  var ast = parse(`
+    {{#if stuff}}
+    {{/if}}
+    <p>Hi!</p>
+  `);
+
+  let [,ifBlock,,p] = ast.body;
+
+  locEqual(ifBlock, 2, 4, 3, 11, 'if block');
+  locEqual(p, 4, 4, 4, 14, 'p element');
+});
+
+test("mustache + newline + element ", function() {
+  var ast = parse(`
+    {{foo}}
+    <p>Hi!</p>
+  `);
+
+  let [,fooMustache,,p] = ast.body;
+
+  locEqual(fooMustache, 2, 4, 2, 11, 'if block');
+  locEqual(p, 3, 4, 3, 14, 'p element');
+});
+
 test("blocks with nested html elements", function() {
   let ast = parse(`
     {{#foo-bar}}<div>Foo</div>{{/foo-bar}} <p>Hi!</p>


### PR DESCRIPTION
https://github.com/tildeio/glimmer/pull/91 initially intended to fix this, but while adding more examples to the test scenarios I zeroed in on another bug (that was ultimately wider spread than this one).

When a closing block tag is followed by a newline, that newline is stripped. We were properly handling the line being stripped, but not resetting the column when we incremented the line.

This ensures that the column is reset to 0 if the lines are incremented.