### PR TITLE
Use latest stable version of ember-cli.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "benchmark": "^1.0.0",
     "bower": "~1.3.3",
-    "ember-cli": "ember-cli/ember-cli",
+    "ember-cli": "^2.4.2",
     "ember-cli-release": "^0.2.2",
     "ember-cli-sauce": "^1.3.0",
     "tslint": "next"


### PR DESCRIPTION
Removes ember-cli/ember-cli#master, and replaces with a stable version...