### PR TITLE
Allow the env to return a reference for helpers

### DIFF
--- a/packages/node_modules/glimmer-runtime/index.ts
+++ b/packages/node_modules/glimmer-runtime/index.ts
@@ -142,5 +142,5 @@ export {
   ComponentAttrsBuilder
 } from './lib/component/interfaces';
 
-export { default as DOMHelper, DOMHelper as IDOMHepler, isWhitespace } from './lib/dom';
+export { default as DOMHelper, DOMHelper as IDOMHelper, isWhitespace } from './lib/dom';
 export { ElementStack } from './lib/builder';

--- a/packages/node_modules/glimmer-runtime/lib/compiled/expressions/helper.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/expressions/helper.ts
@@ -1,10 +1,11 @@
 import { CompiledExpression } from '../expressions';
-import { CompiledArgs, EvaluatedArgs } from './args';
+import { CompiledArgs } from './args';
 import VM from '../../vm/append';
 import { Helper } from '../../environment';
 import { PathReference } from 'glimmer-reference';
+import { Opaque } from 'glimmer-util';
 
-export default class CompiledHelper<T> extends CompiledExpression<T> {
+export default class CompiledHelper<T> extends CompiledExpression<Opaque> {
   public type = "helper";
   public helper: Helper;
   public args: CompiledArgs;
@@ -16,31 +17,6 @@ export default class CompiledHelper<T> extends CompiledExpression<T> {
   }
 
   evaluate(vm: VM): PathReference<T> {
-    return new HelperInvocationReference(this.helper, this.args.evaluate(vm));
+    return this.helper.call(undefined, this.args.evaluate(vm));
   }
-}
-
-class HelperInvocationReference<T> implements PathReference<T> {
-  private helper: Helper;
-  private args: EvaluatedArgs;
-
-  constructor(helper: Helper, args: EvaluatedArgs) {
-    this.helper = helper;
-    this.args = args;
-  }
-
-  get(): PathReference<T> {
-    throw new Error("Unimplemented: Yielding the result of a helper call.");
-  }
-
-  isDirty() {
-    return true;
-  }
-
-  value(): any {
-    let { helper, args: { positional, named } }  = this;
-    return helper(positional.value(), named.value(), null);
-  }
-
-  destroy() {}
 }

--- a/packages/node_modules/glimmer-runtime/lib/compiled/expressions/positional-args.ts
+++ b/packages/node_modules/glimmer-runtime/lib/compiled/expressions/positional-args.ts
@@ -13,6 +13,7 @@ export abstract class CompiledPositionalArgs {
   }
 
   public type: string;
+  public length: number;
   abstract evaluate(vm: VM): EvaluatedPositionalArgs;
   abstract toJSON(): string;
 }
@@ -23,6 +24,7 @@ class CompiledNonEmptyPositionalArgs extends CompiledPositionalArgs {
 
   constructor({ values }: { values: CompiledExpression<any>[] }) {
     super();
+    this.length = values.length;
     this.values = values;
   }
 
@@ -45,6 +47,8 @@ class CompiledNonEmptyPositionalArgs extends CompiledPositionalArgs {
 export const COMPILED_EMPTY_POSITIONAL_ARGS = new (class extends CompiledPositionalArgs {
   public type = "empty-positional-args";
 
+  public length = 0;
+
   evaluate(vm): EvaluatedPositionalArgs {
     return EvaluatedPositionalArgs.empty();
   }
@@ -65,6 +69,7 @@ export abstract class EvaluatedPositionalArgs {
 
   public type: string;
   public values: PathReference<any>[];
+  public length: number;
 
   forEach(callback: (value: PathReference<any>) => void) {
     let values = this.values;
@@ -82,6 +87,7 @@ class NonEmptyEvaluatedPositionalArgs extends EvaluatedPositionalArgs {
 
   constructor({ values }: { values: PathReference<any>[] }) {
     super();
+    this.length = values.length;
     this.values = values;
   }
 
@@ -100,6 +106,9 @@ class NonEmptyEvaluatedPositionalArgs extends EvaluatedPositionalArgs {
 }
 
 export const EVALUATED_EMPTY_POSITIONAL_ARGS = new (class extends EvaluatedPositionalArgs {
+  public length = 0;
+  public values = [];
+
   at(): PathReference<any> {
     return NULL_REFERENCE;
   }

--- a/packages/node_modules/glimmer-runtime/lib/environment.ts
+++ b/packages/node_modules/glimmer-runtime/lib/environment.ts
@@ -11,8 +11,7 @@ import {
 } from './component/interfaces';
 
 import {
-  PathReference,
-  ConstReference,
+  PathReference
 } from 'glimmer-reference';
 
 import {
@@ -216,11 +215,7 @@ type PositionalArguments = Opaque[];
 type KeywordArguments = Dict<Opaque>;
 
 export interface Helper {
-  (positional: PositionalArguments, named: KeywordArguments, options: Object): Insertion;
-}
-
-export function helper(h: Helper): ConstReference<Helper> {
-  return new ConstReference(h);
+  (args: EvaluatedArgs): PathReference<Opaque>;
 }
 
 export interface ParsedStatement {

--- a/packages/node_modules/glimmer-runtime/tests/initial-render-test.ts
+++ b/packages/node_modules/glimmer-runtime/tests/initial-render-test.ts
@@ -290,7 +290,7 @@ test("Morphs are escaped correctly", function() {
     return params[0];
   });
 
-  env.registerHelper('testing-escaped', function(params, hash, blocks) {
+  env.registerHelper('testing-escaped', function(params, hash) {
     return params[0];
   });
 
@@ -369,7 +369,7 @@ test("The compiler can handle multiple invocations of sexprs", function() {
 
 test("The compiler passes along the hash arguments", function() {
   env.registerHelper('testing', function(params, hash) {
-    return hash.first + '-' + hash.second;
+    return hash['first'] + '-' + hash['second'];
   });
 
   compilesTo('<div>{{testing first="one" second="two"}}</div>', '<div>one-two</div>');
@@ -424,7 +424,7 @@ test("A helper can return a stream for the attribute", function() {
 */
 test("Attribute helpers take a hash", function() {
   env.registerHelper('testing', function(params, hash) {
-    return hash.path;
+    return hash['path'];
   });
 
   compilesTo('<a href="{{testing path=url}}">linky</a>', '<a href="linky.html">linky</a>', { url: 'linky.html' });
@@ -569,88 +569,6 @@ test("A block helper can have an else block", function() {
 
 module("Initial render - miscellaneous");
 
-QUnit.skip("Node helpers can modify the node", function() {
-  env.registerHelper('testing', function(params, hash, options) {
-    options.element.setAttribute('zomg', 'zomg');
-  });
-
-  compilesTo('<div {{testing}}>Node helpers</div>', '<div zomg="zomg">Node helpers</div>');
-});
-
-QUnit.skip("Node helpers can modify the node after one node appended by top-level helper", function() {
-  env.registerHelper('top-helper', function() {
-    return document.createElement('span');
-  });
-  env.registerHelper('attr-helper', function(params, hash, options) {
-    options.element.setAttribute('zomg', 'zomg');
-  });
-
-  compilesTo('<div {{attr-helper}}>Node helpers</div>{{top-helper}}', '<div zomg="zomg">Node helpers</div><span></span>');
-});
-
-QUnit.skip("Node helpers can modify the node after one node prepended by top-level helper", function() {
-  env.registerHelper('top-helper', function() {
-    return document.createElement('span');
-  });
-  env.registerHelper('attr-helper', function(params, hash, options) {
-    options.element.setAttribute('zomg', 'zomg');
-  });
-
-  compilesTo('{{top-helper}}<div {{attr-helper}}>Node helpers</div>', '<span></span><div zomg="zomg">Node helpers</div>');
-});
-
-QUnit.skip("Node helpers can modify the node after many nodes returned from top-level helper", function() {
-  env.registerHelper('top-helper', function() {
-    let frag = document.createDocumentFragment();
-    frag.appendChild(document.createElement('span'));
-    frag.appendChild(document.createElement('span'));
-    return frag;
-  });
-  env.registerHelper('attr-helper', function(params, hash, options) {
-    options.element.setAttribute('zomg', 'zomg');
-  });
-
-  compilesTo(
-    '{{top-helper}}<div {{attr-helper}}>Node helpers</div>',
-    '<span></span><span></span><div zomg="zomg">Node helpers</div>' );
-});
-
-QUnit.skip("Node helpers can be used for attribute bindings", function() {
-  env.registerHelper('testing', function(params, hash, options) {
-    let value = hash.href,
-        element = options.element;
-
-    element.setAttribute('href', value);
-  });
-
-  let object = { url: 'linky.html' };
-  let template = compile('<a {{testing href=url}}>linky</a>');
-  let result = render(template, object);
-
-  equalTokens(root, '<a href="linky.html">linky</a>');
-  object.url = 'zippy.html';
-
-  result.rerender();
-
-  equalTokens(root, '<a href="zippy.html">linky</a>');
-});
-
-function equalHash(_actual, expected) {
-  let actual = {};
-  Object.keys(_actual).forEach(k => actual[k] = _actual[k]);
-
-  QUnit.deepEqual(actual, expected);
-}
-
-QUnit.skip('Components - Called as helpers', function () {
-  env.registerHelper('x-append', function(params, hash, blocks) {
-    equalHash(hash, { text: 'de' });
-    blocks.template.yield();
-  });
-  let object = { bar: 'e', baz: 'c' };
-  compilesTo('a<x-append text="d{{bar}}">b{{baz}}</x-append>f','abcf', object);
-});
-
 test('Components - Unknown helpers fall back to elements', function () {
   let object = { size: 'med', foo: 'b' };
   compilesTo('<x-bar class="btn-{{size}}">a{{foo}}c</x-bar>','<x-bar class="btn-med">abc</x-bar>', object);
@@ -693,51 +611,6 @@ test('Block params in HTML syntax - Throws exception if given zero parameters', 
   QUnit.throws(function() {
     compile('<x-bar as | |>foo</x-bar>');
   }, /Cannot use zero block parameters: 'as \| \|'/);
-});
-
-QUnit.skip('Block params in HTML syntax - Works with a single parameter', function () {
-  env.registerHelper('x-bar', function(params, hash, blocks) {
-    return blocks.template.yield(['Xerxes']);
-  });
-
-  compilesTo('<x-bar as |x|>{{x}}</x-bar>', 'Xerxes', {});
-});
-
-QUnit.skip('Block params in HTML syntax - Works with other attributes', function () {
-  env.registerHelper('x-bar', function(params, hash) {
-    equalHash(hash, {firstName: 'Alice', lastName: 'Smith'});
-  });
-  let template = compile('<x-bar firstName="Alice" lastName="Smith" as |x y|></x-bar>');
-  render(template, {});
-});
-
-QUnit.skip('Block params in HTML syntax - Ignores whitespace', function () {
-  expect(3);
-
-  env.registerHelper('x-bar', function(params, hash, blocks) {
-    return blocks.template.yield(['Xerxes', 'York']);
-  });
-
-  compilesTo('<x-bar as |x y|>{{x}},{{y}}</x-bar>', 'Xerxes,York', {});
-  compilesTo('<x-bar as | x y|>{{x}},{{y}}</x-bar>', 'Xerxes,York', {});
-  compilesTo('<x-bar as | x y |>{{x}},{{y}}</x-bar>', 'Xerxes,York', {});
-});
-
-QUnit.skip('Block params in HTML syntax - Helper should know how many block params it was called with', function () {
-  expect(4);
-
-  env.registerHelper('count-block-params', function(params, hash, options) {
-    equal(
-      options.template.arity,
-      parseInt(hash.count, 10),
-      'Helpers should receive the correct number of block params in options.template.blockParams.'
-    );
-  });
-
-  render(compile('<count-block-params count="0"></count-block-params>'), { count: 0 });
-  render(compile('<count-block-params count="1" as |x|></count-block-params>'), { count: 1 });
-  render(compile('<count-block-params count="2" as |x y|></count-block-params>'), { count: 2 });
-  render(compile('<count-block-params count="3" as |x y z|></count-block-params>'), { count: 3 });
 });
 
 test("Block params in HTML syntax - Throws an error on invalid block params syntax", function() {

--- a/packages/node_modules/glimmer-test-helpers/lib/environment.ts
+++ b/packages/node_modules/glimmer-test-helpers/lib/environment.ts
@@ -13,7 +13,7 @@ import {
   ParsedStatement,
   Environment,
   DOMHelper,
-  IDOMHepler,
+  IDOMHelper,
 
   // Opcodes
   EvaluateOpcode,
@@ -343,7 +343,7 @@ export class TestEnvironment extends Environment {
   private helpers = {};
   private components = dict<ComponentDefinition<any>>();
 
-  constructor(dom?: IDOMHepler) {
+  constructor(dom?: IDOMHelper) {
     super(dom || new DOMHelper(document));
 
     this.registerHelper("if", ([cond, yes, no]) => cond ? yes : no);

--- a/packages/node_modules/glimmer-test-helpers/lib/environment.ts
+++ b/packages/node_modules/glimmer-test-helpers/lib/environment.ts
@@ -12,6 +12,7 @@ import {
   // Environment
   ParsedStatement,
   Environment,
+  Helper as GlimmerHelper,
   DOMHelper,
   IDOMHelper,
 
@@ -339,8 +340,54 @@ class EmberishConditionalReference extends ConditionalReference {
   }
 }
 
+export class SimplePathReference<T> implements PathReference<T> {
+  private parent: Reference<T>;
+  private property: InternedString;
+
+  constructor(parent: Reference<T>, property: InternedString) {
+    this.parent = parent;
+    this.property = property;
+  }
+
+  isDirty() { return true; }
+  destroy() {}
+
+  value(): T {
+    return this.parent.value()[<string>this.property];
+  }
+
+  get(prop: InternedString): PathReference<Opaque> {
+    return new SimplePathReference(this, prop);
+  }
+}
+
+type UserHelper = (args: any[], named: Dict<any>) => any;
+
+class HelperReference implements PathReference<Opaque> {
+  private helper: UserHelper;
+  private args: EvaluatedArgs;
+
+  constructor(helper: UserHelper, args: EvaluatedArgs) {
+    this.helper = helper;
+    this.args = args;
+  }
+
+  isDirty() { return true; }
+  destroy() {}
+
+  value() {
+    let { helper, args: { positional, named } } = this;
+
+    return helper(positional.value(), named.value());
+  }
+
+  get(prop: InternedString): SimplePathReference<Opaque> {
+    return new SimplePathReference(this, prop);
+  }
+}
+
 export class TestEnvironment extends Environment {
-  private helpers = {};
+  private helpers = dict<GlimmerHelper>();
   private components = dict<ComponentDefinition<any>>();
 
   constructor(dom?: IDOMHelper) {
@@ -350,8 +397,8 @@ export class TestEnvironment extends Environment {
     this.registerHelper("unless", ([cond, yes, no]) => cond ? no : yes);
   }
 
-  registerHelper(name, helper) {
-    this.helpers[name] = helper;
+  registerHelper(name: string, helper: UserHelper) {
+    this.helpers[name] = (args: EvaluatedArgs) => new HelperReference(helper, args);
   }
 
   registerComponent(name: string, definition: ComponentDefinition<any>) {


### PR DESCRIPTION
This enables the “class-based helpers” feature in Ember