### PR TITLE
Apply content normalization rules for concat

### DIFF
--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -96,6 +96,10 @@ export {
 } from './lib/compiled/opcodes/dom';
 
 export {
+  normalizeTextValue
+} from './lib/compiled/opcodes/content';
+
+export {
   CompiledExpression
 } from './lib/compiled/expressions';
 

--- a/packages/glimmer-runtime/lib/compiled/expressions/concat.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/concat.ts
@@ -1,7 +1,8 @@
 import { CompiledExpression } from '../expressions';
+import { normalizeTextValue } from '../opcodes/content';
 import VM from '../../vm/append';
 import { PathReference, Reference } from 'glimmer-reference';
-import { Opaque, FIXME } from 'glimmer-util';
+import { Opaque } from 'glimmer-util';
 
 export default class CompiledConcat {
   public type = "concat";
@@ -38,7 +39,7 @@ class ConcatReference implements Reference<string> {
   value(): string {
     let parts = new Array<string>(this.parts.length);
     for (let i = 0; i < this.parts.length; i++) {
-      parts[i] = this.parts[i].value() as FIXME<'convert opaque to str'>;
+      parts[i] = normalizeTextValue(this.parts[i].value());
     }
     return parts.join('');
   }

--- a/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
@@ -1,12 +1,12 @@
 import { Opcode, OpcodeJSON, UpdatingOpcode } from '../../opcodes';
 import { VM, UpdatingVM } from '../../vm';
 import { PathReference } from 'glimmer-reference';
-import { dict } from 'glimmer-util';
+import { Opaque, dict } from 'glimmer-util';
 import { clear } from '../../bounds';
 import { Fragment } from '../../builder';
 
-function normalizeTextValue(value: any): string {
-  if (value === null || value === undefined || typeof value.toString !== 'function') {
+export function normalizeTextValue(value: Opaque): string {
+  if (value === null || value === undefined || typeof value['toString'] !== 'function') {
     return '';
   } else {
     return String(value);

--- a/packages/glimmer-runtime/tests/updating-test.ts
+++ b/packages/glimmer-runtime/tests/updating-test.ts
@@ -506,14 +506,19 @@ test("class attribute w/ concat follow the normal dirtying rules", function() {
 
   equalTokens(root, "<div class='hello world'>hello</div>");
 
+  rerender();
+
+  equalTokens(root, "<div class='hello world'>hello</div>");
+
   object.value = "universe";
-  rerender(); // without setting the node to dirty
-
-  equalTokens(root, "<div class='hello universe'>hello</div>");
-
   rerender();
 
   equalTokens(root, "<div class='hello universe'>hello</div>");
+
+  object.value = null;
+  rerender();
+
+  equalTokens(root, "<div class='hello '>hello</div>");
 
   object.value = "world";
   rerender();
@@ -551,14 +556,19 @@ test("attribute nodes w/ concat follow the normal dirtying rules", function() {
 
   equalTokens(root, "<div data-value='hello world'>hello</div>");
 
+  rerender();
+
+  equalTokens(root, "<div data-value='hello world'>hello</div>");
+
   object.value = "universe";
-  rerender(); // without setting the node to dirty
-
-  equalTokens(root, "<div data-value='hello universe'>hello</div>");
-
   rerender();
 
   equalTokens(root, "<div data-value='hello universe'>hello</div>");
+
+  object.value = null;
+  rerender();
+
+  equalTokens(root, "<div data-value='hello '>hello</div>");
 
   object.value = "world";
   rerender();
@@ -593,14 +603,24 @@ test("namespaced attribute nodes w/ concat follow the normal dirtying rules", fu
 
   equalTokens(root, "<div xml:lang='en-us'>hello</div>", "Initial render");
 
+  rerender();
+
+  equalTokens(root, "<div xml:lang='en-us'>hello</div>", "No-op rerender");
+
   object.locale = "uk";
   rerender();
 
-  equalTokens(root, "<div xml:lang='en-uk'>hello</div>", "Revalidating without dirtying");
+  equalTokens(root, "<div xml:lang='en-uk'>hello</div>", "After update");
 
+  object.locale = null;
   rerender();
 
-  equalTokens(root, "<div xml:lang='en-uk'>hello</div>", "Revalidating after dirtying");
+  equalTokens(root, "<div xml:lang='en-'>hello</div>", "After updating to null");
+
+  object.locale = "us";
+  rerender();
+
+  equalTokens(root, "<div xml:lang='en-us'>hello</div>", "After reset");
 });
 }
 
@@ -630,14 +650,24 @@ test("non-standard namespaced attribute nodes w/ concat follow the normal dirtyi
 
   equalTokens(root, "<div epub:type='dedication backmatter'>hello</div>", "Initial render");
 
+  rerender();
+
+  equalTokens(root, "<div epub:type='dedication backmatter'>hello</div>", "No-op rerender");
+
   object.type = "index";
   rerender();
 
-  equalTokens(root, "<div epub:type='dedication index'>hello</div>", "Revalidating without dirtying");
+  equalTokens(root, "<div epub:type='dedication index'>hello</div>", "After update");
 
+  object.type = null;
   rerender();
 
-  equalTokens(root, "<div epub:type='dedication index'>hello</div>", "Revalidating after dirtying");
+  equalTokens(root, "<div epub:type='dedication '>hello</div>", "After updating to null");
+
+  object.type = "backmatter";
+  rerender();
+
+  equalTokens(root, "<div epub:type='dedication backmatter'>hello</div>", "After reset");
 });
 
 test("property nodes follow the normal dirtying rules", function() {


### PR DESCRIPTION
Addresses @rwjblue's comment: https://github.com/tildeio/glimmer/compare/normalize-concat?expand=1