### PR TITLE
Implement `ConstReference` optimization

### DIFF
--- a/demos/glimmer-demos/visualizer.ts
+++ b/demos/glimmer-demos/visualizer.ts
@@ -399,7 +399,7 @@ function renderContent() {
 
   env.begin();
   let self = new UpdatableReference(data);
-  let res = app.render(self, env, { appendTo: div });
+  let res = app.render(self, env, { appendTo: div, dynamicScope: new TestDynamicScope() });
   env.commit();
 
   ui.rendered = true;

--- a/packages/glimmer-reference/index.ts
+++ b/packages/glimmer-reference/index.ts
@@ -6,7 +6,7 @@ export { PushPullReference } from './lib/references/push-pull';
 export * from './lib/types';
 export { default as ObjectReference } from './lib/references/path';
 export { default as UpdatableReference, referenceFromParts } from './lib/references/root';
-export { ConstReference } from './lib/references/const';
+export { ConstReference, isConst } from './lib/references/const';
 export {
   IterationItem,
   Iterator,

--- a/packages/glimmer-reference/lib/references/const.ts
+++ b/packages/glimmer-reference/lib/references/const.ts
@@ -1,7 +1,12 @@
 import { Reference } from '../types';
+import { Opaque } from 'glimmer-util';
+
+export const CONST = "29c7034c-f1e1-4cf4-a843-1783dda9b744";
 
 export class ConstReference<T> implements Reference<T> {
   protected inner: T;
+
+  public "29c7034c-f1e1-4cf4-a843-1783dda9b744" = true;
 
   constructor(inner: T) {
     this.inner = inner;
@@ -13,6 +18,9 @@ export class ConstReference<T> implements Reference<T> {
 
   isDirty() { return false; }
   value(): T { return this.inner; }
-  chain() { return null; }
   destroy() {}
+}
+
+export function isConst(reference: Reference<Opaque>): boolean {
+  return !!reference[CONST];
 }

--- a/packages/glimmer-runtime/lib/compat/svg-inner-html-fix.ts
+++ b/packages/glimmer-runtime/lib/compat/svg-inner-html-fix.ts
@@ -14,13 +14,13 @@ const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
 //           approach is used. A pre/post SVG tag is added to the string, then
 //           that whole string is added to a div. The created nodes are plucked
 //           out and applied to the target location on DOM.
-export default function applyInnerHTMLFix(document: Document, DOMHelperClass: typeof DOMHelper, svgNamespace: String): typeof DOMHelper {
+export default function applyInnerHTMLFix(document: Document, DOMHelperClass: typeof DOMHelper, svgNamespace: string): typeof DOMHelper {
   if (!document) return DOMHelperClass;
 
   let svg = document.createElementNS(svgNamespace, 'svg');
 
   try {
-    svg.insertAdjacentHTML('beforeEnd', '<circle></circle>');
+    svg['insertAdjacentHTML']('beforeEnd', '<circle></circle>');
   } catch (e) {
     // IE, Edge: Will throw, insertAdjacentHTML is unsupported on SVG
     // Safari: Will throw, insertAdjacentHTML is not present on SVG

--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -7,7 +7,7 @@ import { Templates } from '../../syntax/core';
 import { layoutFor } from '../../compiler';
 import { DynamicScope } from '../../environment';
 import { InternedString, Opaque, dict } from 'glimmer-util';
-import { Reference } from 'glimmer-reference';
+import { Reference, isConst } from 'glimmer-reference';
 
 export type DynamicComponentFactory<T> = (args: EvaluatedArgs, vm: PublicVM) => Reference<ComponentDefinition<T>>;
 
@@ -73,7 +73,10 @@ export class OpenDynamicComponentOpcode extends Opcode {
     vm.invokeLayout({ templates, args, shadow, layout, callerScope });
     vm.env.didCreate(component, manager);
 
-    vm.updateWith(new Assert(definitionRef, definition));
+    if (!isConst(definitionRef)) {
+      vm.updateWith(new Assert(definitionRef, definition));
+    }
+
     vm.updateWith(new UpdateComponentOpcode({ name: definition.name, component, manager, args, dynamicScope }));
   }
 

--- a/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
@@ -1,6 +1,6 @@
 import { Opcode, OpcodeJSON, UpdatingOpcode } from '../../opcodes';
 import { VM, UpdatingVM } from '../../vm';
-import { PathReference } from 'glimmer-reference';
+import { PathReference, isConst } from 'glimmer-reference';
 import { Opaque, dict } from 'glimmer-util';
 import { clear } from '../../bounds';
 import { Fragment } from '../../builder';
@@ -28,7 +28,10 @@ export class AppendOpcode extends Opcode {
     let reference = vm.frame.getOperand();
     let value = normalizeTextValue(reference.value());
     let node = vm.stack().appendText(value);
-    vm.updateWith(new UpdateAppendOpcode(reference, value, node));
+
+    if (!isConst(reference)) {
+      vm.updateWith(new UpdateAppendOpcode(reference, value, node));
+    }
   }
 
   toJSON(): OpcodeJSON {
@@ -79,9 +82,11 @@ export class TrustingAppendOpcode extends Opcode {
   evaluate(vm: VM) {
     let reference = vm.frame.getOperand();
     let value = normalizeTextValue(reference.value());
-
     let bounds = vm.stack().insertHTMLBefore(null, value);
-    vm.updateWith(new UpdateTrustingAppendOpcode(reference, value, bounds));
+
+    if (!isConst(reference)) {
+      vm.updateWith(new UpdateTrustingAppendOpcode(reference, value, bounds));
+    }
   }
 }
 

--- a/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
@@ -398,6 +398,21 @@ export class PatchElementOpcode extends DOMUpdatingOpcode {
   evaluate(vm: UpdatingVM) {
     this.lastValue = this.attribute.apply(vm.env.getDOM(), this.element, this.lastValue);
   }
+
+  toJSON(): OpcodeJSON {
+    let { _guid: guid, type, element, attribute, lastValue } = this;
+
+    let details = dict<string>();
+
+    let [attributeType, attributeName] = attribute.toJSON();
+
+    details["element"] = JSON.stringify(`<${element.tagName.toLowerCase()} />`);
+    details["type"] = JSON.stringify(attributeType);
+    details["name"] = JSON.stringify(attributeName);
+    details["lastValue"] = JSON.stringify(lastValue);
+
+    return { guid, type, details };
+  }
 }
 
 export class CommentOpcode extends Opcode {

--- a/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -400,4 +400,15 @@ export class Assert extends VMUpdatingOpcode {
       vm.throw();
     }
   }
+
+  toJSON(): OpcodeJSON {
+    let { type, _guid, expected } = this;
+
+    return {
+      guid: _guid,
+      type,
+      args: [],
+      details: { expected: JSON.stringify(expected) }
+    };
+  }
 }

--- a/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -6,7 +6,7 @@ import { Layout, InlineBlock } from '../blocks';
 import { turbocharge } from '../../utils';
 import { NULL_REFERENCE } from '../../references';
 import { ListSlice, Opaque, Slice, Dict, dict, assign } from 'glimmer-util';
-import { Reference } from 'glimmer-reference';
+import { Reference, isConst } from 'glimmer-reference';
 
 abstract class VMUpdatingOpcode extends UpdatingOpcode {
   public type: string;
@@ -362,7 +362,9 @@ export class JumpIfOpcode extends JumpOpcode {
       super.evaluate(vm);
     }
 
-    vm.updateWith(new Assert(reference, value));
+    if (!isConst(reference)) {
+      vm.updateWith(new Assert(reference, value));
+    }
   }
 }
 
@@ -377,7 +379,9 @@ export class JumpUnlessOpcode extends JumpOpcode {
       super.evaluate(vm);
     }
 
-    vm.updateWith(new Assert(reference, value));
+    if (!isConst(reference)) {
+      vm.updateWith(new Assert(reference, value));
+    }
   }
 }
 

--- a/packages/glimmer-runtime/lib/dom.ts
+++ b/packages/glimmer-runtime/lib/dom.ts
@@ -86,7 +86,13 @@ class DOMHelper {
     return this.document.createElement(tag);
   }
 
-  insertHTMLBefore(parent: HTMLElement, nextSibling: Node, html: string): Bounds {
+  insertHTMLBefore(_parent: Element, nextSibling: Node, html: string): Bounds {
+    // TypeScript vendored an old version of the DOM spec where `insertAdjacentHTML`
+    // only exists on `HTMLElement` but not on `Element`. We actually work with the
+    // newer version of the DOM API here (and monkey-patch this method in `./compat`
+    // when we detect older browsers). This is a hack to work around this limitation.
+    let parent = _parent as HTMLElement;
+
     let prev = nextSibling ? nextSibling.previousSibling : parent.lastChild;
     let last;
 

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -109,7 +109,7 @@ export abstract class Environment {
     this.dom = dom;
   }
 
-  toConditionalReference(reference: Reference<Opaque>): ConditionalReference {
+  toConditionalReference(reference: Reference<Opaque>): Reference<boolean> {
     return new ConditionalReference(reference);
   }
 

--- a/packages/glimmer-runtime/lib/vm/update.ts
+++ b/packages/glimmer-runtime/lib/vm/update.ts
@@ -180,10 +180,9 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
   private marker: Comment;
 
   constructor(opcode: ListBlockOpcode, marker: Comment) {
-    let { map, updating } = opcode;
     this.opcode = opcode;
-    this.map = map;
-    this.updating = updating;
+    this.map = opcode.map;
+    this.updating = opcode['updating'];
     this.marker = marker;
   }
 

--- a/packages/glimmer-runtime/tests/updating-test.ts
+++ b/packages/glimmer-runtime/tests/updating-test.ts
@@ -90,7 +90,6 @@ test("null and undefined produces empty text nodes", () => {
   strictEqual(root.firstChild.firstChild.firstChild, valueNode1, "The text node was not blown away");
   strictEqual(root.firstChild.lastChild.firstChild, valueNode2, "The text node was not blown away");
 
-
   object.v1 = 'hello';
   rerender();
 
@@ -1320,7 +1319,7 @@ test("expression nested inside a namespace", function() {
 test("expression nested inside a namespaced root element", function() {
   let content = 'Maurice';
   let context = { content };
-  let getSvg = () => root.firstChild;
+  let getSvg = () => root.firstChild as Element;
   let template = compile('<svg>{{content}}</svg>');
   render(template, context);
 

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -69,7 +69,8 @@ import {
   OpaqueIterator,
   OpaqueIterable,
   AbstractIterable,
-  IterationItem
+  IterationItem,
+  isConst
 } from "glimmer-reference";
 
 type KeyFor = (item: Opaque, index: number) => string;
@@ -347,13 +348,17 @@ class EmberishCurlyComponentManager implements ComponentManager<EmberishCurlyCom
 
 const EMBERISH_CURLY_COMPONENT_MANAGER = new EmberishCurlyComponentManager();
 
+function emberToBool(value: any): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  } else {
+    return !!value;
+  }
+}
+
 class EmberishConditionalReference extends ConditionalReference {
   protected toBool(value: any): boolean {
-    if (Array.isArray(value)) {
-      return value.length > 0;
-    } else {
-      return super.toBool(value);
-    }
+    return emberToBool(value);
   }
 }
 
@@ -442,7 +447,11 @@ export class TestEnvironment extends Environment {
     return new UpdatableReference(object);
   }
 
-  toConditionalReference(reference: Reference<any>): ConditionalReference {
+  toConditionalReference(reference: Reference<any>): Reference<boolean> {
+    if (isConst(reference)) {
+      return new ValueReference(emberToBool(reference.value()));
+    }
+
     return new EmberishConditionalReference(reference);
   }
 


### PR DESCRIPTION
A const reference cannot change, so we do not need to emit an updating opcode for them.

For example:

```has
{{#if true}}...{{/if}}
```

In this case, the conditional is a literal, so it is impossible for the the {{#if}} to flip from default to inverse on the update pass, hence there is no need to emit an `Assert` for the conditional value.

While this in itself is pretty rare, it is quite common for this to happen indirectly. For example:

```hbs
{{!-- link-to component layout --}}
<a href="{{@url}}" title={{@title}}>{{@text}}</a>
```

```hbs
{{!-- link-to usage --}}
{{link-to url="http://static.string" title="does not change" text="also does not change"}}
```

In this case, there is no need to emit updating opcodes for the attributes and content curlies.

This optimization also composes nicely, allowing things like `EmberID` or `hasBlock` to return const references and drop the unnecessary work.

This is also quite noticeable because we don't currently distinguish between "component element" (whose attributes can be "clobbered" by the invocation) and a regular element, so all the "static" attributes still go through the merging policy object. (See 07069c69057731730d25bfe340f843db8b3c23cc) With this optimization, we at least do not pay an extra cost for those static attributes on update. (We should come back to optimize non-component elements more.)

![before/after](http://cl.ly/192Q0G1f200c/Screenshot_3_22_16__3_29_PM.png)

* * *

Another example:

![before/after](http://cl.ly/10313j3X0o3y/Glimmer_Visualizer_and_Glimmer_Visualizer_and_Glimmer_Visualizer.png)
