### PR TITLE
fix launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,8 +7,8 @@
 			"request": "launch",
 			"url": "http://localhost:7357/tests/index.html",
 			"sourceMaps": true,
-			"userDataDir": "tmp/chrome-user-data",
-			"webRoot": "packages/node_modules"
+			"userDataDir": "${workspaceRoot}/tmp/chrome-user-data",
+			"webRoot": "${workspaceRoot}/packages/node_modules"
 		},
 		{
 			"name": "glimmer-runtime",
@@ -16,8 +16,8 @@
 			"request": "launch",
 			"url": "http://localhost:7357/tests/index.html?packages=glimmer-runtime",
 			"sourceMaps": true,
-			"userDataDir": "tmp/chrome-user-data",
-			"webRoot": "packages/node_modules"
+			"userDataDir": "${workspaceRoot}/tmp/chrome-user-data",
+			"webRoot": "${workspaceRoot}/packages/node_modules"
 		},
 		{
 			"name": "focused",
@@ -25,8 +25,8 @@
 			"request": "launch",
 			"url": "http://localhost:7357/tests/index.html?packages=glimmer-runtime&testId=8b1252f6",
 			"sourceMaps": true,
-			"userDataDir": "tmp/chrome-user-data",
-			"webRoot": "packages/node_modules"
+			"userDataDir": "${workspaceRoot}/tmp/chrome-user-data",
+			"webRoot": "${workspaceRoot}/packages/node_modules"
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pretest": "ember build",
     "test": "ember test",
     "test:ci": "ember test --test-port=7000 --config-file=testem-sauce.json",
-    "start": "ember serve",
+    "start": "ember serve --port=7357",
     "tsc": "tsc -p . --noEmit",
     "tslint": "tslint ./packages/**/*.ts",
     "vscode-build": "tslint -s ./.vscode/tslint-formatters -t vscode ./packages/**/*.ts; tsc -p . --noEmit",


### PR DESCRIPTION
visual studio now requires launch.json to use absolute paths, update relative paths to use `$workspaceRoot`
make npm start use the port used by the debugging tasks