### PR TITLE
Implement has-block helper

### DIFF
--- a/packages/glimmer-compiler/lib/javascript-compiler.ts
+++ b/packages/glimmer-compiler/lib/javascript-compiler.ts
@@ -153,6 +153,11 @@ export default class JavaScriptCompiler {
     this.template.yields.add(to);
   }
 
+  hasBlock(name: string) {
+    this.pushValue(['hasBlock', name]);
+    this.template.yields.add(name);
+  }
+
   /// Expressions
 
   literal(value: any) {

--- a/packages/glimmer-runtime/lib/compiled/expressions/has-block.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/has-block.ts
@@ -1,0 +1,25 @@
+import VM from '../../vm/append';
+import { CompiledExpression } from '../expressions';
+import { ValueReference } from './value';
+import { InternedString } from 'glimmer-util';
+
+export default class CompiledHasBlock extends CompiledExpression<boolean> {
+  public type = "has-block";
+  public blockName: InternedString;
+  public blockSymbol: number;
+
+  constructor({ blockName, blockSymbol }: { blockName: InternedString, blockSymbol: number }) {
+    super();
+    this.blockName = blockName;
+    this.blockSymbol = blockSymbol;
+  }
+
+  evaluate(vm: VM): ValueReference<boolean> {
+    let blockRef = vm.referenceForSymbol(this.blockSymbol);
+    return new ValueReference(!!blockRef);
+  }
+
+  toJSON(): string {
+    return `has-block(${this.blockName})`;
+  }
+}

--- a/packages/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/glimmer-runtime/lib/syntax/core.ts
@@ -48,6 +48,8 @@ import {
   CompiledSelfRef
 } from '../compiled/expressions/ref';
 
+import CompiledHasBlock from '../compiled/expressions/has-block';
+
 import CompiledHelper from '../compiled/expressions/helper';
 
 import CompiledConcat from '../compiled/expressions/concat';
@@ -921,6 +923,40 @@ export class Helper extends ExpressionSyntax<Opaque> {
 
   simplePath(): InternedString {
     return this.ref.simplePath();
+  }
+}
+
+export class HasBlock extends ExpressionSyntax<boolean> {
+  type = "has-block";
+
+  static fromSpec(sexp: SerializedExpressions.HasBlock): HasBlock {
+    let [, blockName] = sexp;
+
+    return new HasBlock({
+      blockName: blockName as InternedString
+    });
+  }
+
+  static build(blockName: InternedString): HasBlock {
+    return new this({ blockName });
+  }
+
+  blockName: InternedString;
+
+  constructor({ blockName }: { blockName: InternedString }) {
+    super();
+    this.blockName = blockName;
+  }
+
+  prettyPrint() {
+    return new PrettyPrint('expr', 'has-block', [this.blockName]);
+  }
+
+  compile(compiler: SymbolLookup, env: Environment): CompiledHasBlock {
+    return new CompiledHasBlock({
+      blockName: this.blockName,
+      blockSymbol: compiler.getBlockSymbol(this.blockName)
+    });
   }
 }
 

--- a/packages/glimmer-runtime/lib/syntax/expressions.ts
+++ b/packages/glimmer-runtime/lib/syntax/expressions.ts
@@ -3,6 +3,7 @@ import {
   GetNamedParameter as AttrSyntax,
   Concat as ConcatSyntax,
   Get as GetSyntax,
+  HasBlock as HasBlockSyntax,
   Helper as HelperSyntax,
   Unknown as UnknownSyntax
 } from './core';
@@ -16,6 +17,7 @@ const {
   isAttr,
   isConcat,
   isGet,
+  isHasBlock,
   isHelper,
   isUnknown,
   isValue
@@ -30,5 +32,6 @@ export default function(sexp: SerializedExpression): any {
     if (isGet(sexp)) return GetSyntax.fromSpec(sexp);
     if (isHelper(sexp)) return HelperSyntax.fromSpec(sexp);
     if (isUnknown(sexp)) return UnknownSyntax.fromSpec(sexp);
+    if (isHasBlock(sexp)) return HasBlockSyntax.fromSpec(sexp);
   }
 };

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -507,36 +507,6 @@ testComponent('yielding to an non-existent block', {
   expected: 'Before--After'
 });
 
-testComponent('hasBlock is true when block supplied', {
-  skip: true,
-  layout: '{{#if hasBlock}}{{yield}}{{else}}No Block!{{/if}}',
-  invokeAs: { template: 'In template' },
-  expected: 'In template'
-});
-
-testComponent('hasBlock is false when block supplied', {
-  skip: true,
-  layout: '{{#if hasBlock}}{{yield}}{{else}}No Block!{{/if}}',
-  expected: 'No Block!'
-});
-
-testComponent('hasBlockParams is true when block param supplied', {
-  skip: true,
-  layout: '{{#if hasBlockParams}}{{yield this}} - In Component{{else}}{{yield}} No Block Param!{{/if}}',
-  invokeAs: {
-    blockParams: ['something'],
-    template: 'In template'
-  },
-  expected: 'In template - In Component'
-});
-
-testComponent('hasBlockParams is false when no block param supplied', {
-  skip: true,
-  layout: '{{#if hasBlockParams}}{{yield this}} - In Component{{else}}{{yield}} - No Block Param!{{/if}}',
-  invokeAs: { template: 'In template' },
-  expected: 'In template - No Block Param!'
-});
-
 testComponent('yield', {
   skip: 'glimmer',
   layout: '{{#if @predicate}}Yes:{{yield @someValue}}{{else}}No:{{yield to="inverse"}}{{/if}}',
@@ -567,10 +537,9 @@ testComponent('yield to inverse', {
   expected: 'No:Goodbyeouter'
 });
 
-testComponent('parameterized hasBlock (inverse) when inverse supplied', {
-  skip: true,
+testComponent('parameterized has-block (subexpr, inverse) when inverse supplied', {
   kind: 'curly',
-  layout: '{{#if (hasBlock "inverse")}}Yes{{else}}No{{/if}}',
+  layout: '{{#if (has-block "inverse")}}Yes{{else}}No{{/if}}',
   invokeAs: {
     template: 'block here',
     inverse: 'inverse here'
@@ -578,37 +547,142 @@ testComponent('parameterized hasBlock (inverse) when inverse supplied', {
   expected: 'Yes'
 });
 
-testComponent('parameterized hasBlock (inverse) when inverse not supplied', {
-  skip: true,
-  layout: '{{#if (hasBlock "inverse")}}Yes{{else}}No{{/if}}',
+testComponent('parameterized has-block (subexpr, inverse) when inverse not supplied', {
+  layout: '{{#if (has-block "inverse")}}Yes{{else}}No{{/if}}',
   invokeAs: { template: 'block here' },
   expected: 'No'
 });
 
-testComponent('parameterized hasBlock (default) when block supplied', {
-  skip: true,
-  layout: '{{#if (hasBlock)}}Yes{{else}}No{{/if}}',
+testComponent('parameterized has-block (subexpr, default) when block supplied', {
+  layout: '{{#if (has-block)}}Yes{{else}}No{{/if}}',
   invokeAs: { template: 'block here' },
   expected: 'Yes'
 });
 
-testComponent('parameterized hasBlock (default) when block not supplied', {
-  skip: true,
-  layout: '{{#if (hasBlock)}}Yes{{else}}No{{/if}}',
+testComponent('parameterized has-block (subexpr, default) when block not supplied', {
+  kind: 'curly',
+  layout: '{{#if (has-block)}}Yes{{else}}No{{/if}}',
   expected: 'No'
 });
 
-testComponent('hasBlock keyword when block supplied', {
-  skip: true,
-  layout: '{{#if hasBlock}}Yes{{else}}No{{/if}}',
+testComponent('parameterized has-block (content, inverse) when inverse supplied', {
+  kind: 'curly',
+  layout: '{{has-block "inverse"}}',
+  invokeAs: {
+    template: 'block here',
+    inverse: 'inverse here'
+  },
+  expected: 'true'
+});
+
+testComponent('parameterized has-block (content, inverse) when inverse not supplied', {
+  layout: '{{has-block "inverse"}}',
   invokeAs: { template: 'block here' },
-  expected: 'Yes'
+  expected: 'false'
 });
 
-testComponent('hasBlock keyword when block not supplied', {
+testComponent('parameterized has-block (content, default) when block supplied', {
+  layout: '{{has-block}}',
+  invokeAs: { template: 'block here' },
+  expected: 'true'
+});
+
+testComponent('parameterized has-block (content, default) when block not supplied', {
+  kind: 'curly',
+  layout: '{{has-block}}',
+  expected: 'false'
+});
+
+testComponent('parameterized has-block (prop, inverse) when inverse supplied', {
+  kind: 'curly',
+  layout: '<button name={{has-block "inverse"}}></button>',
+  invokeAs: {
+    template: 'block here',
+    inverse: 'inverse here'
+  },
+  expected: '<button name="true"></button>'
+});
+
+testComponent('parameterized has-block (prop, inverse) when inverse not supplied', {
+  layout: '<button name={{has-block "inverse"}}></button>',
+  invokeAs: { template: 'block here' },
+  expected: '<button name="false"></button>'
+});
+
+testComponent('parameterized has-block (prop, default) when block supplied', {
+  layout: '<button name={{has-block}}></button>',
+  invokeAs: { template: 'block here' },
+  expected: '<button name="true"></button>'
+});
+
+testComponent('parameterized has-block (prop, default) when block not supplied', {
+  kind: 'curly',
+  layout: '<button name={{has-block}}></button>',
+  expected: '<button name="false"></button>'
+});
+
+testComponent('parameterized has-block (attr, inverse) when inverse supplied', {
   skip: true,
-  layout: '{{#if hasBlock}}Yes{{else}}No{{/if}}',
-  expected: 'No'
+  kind: 'curly',
+  layout: '<button data-has-block="{{has-block "inverse"}}""></button>',
+  invokeAs: {
+    template: 'block here',
+    inverse: 'inverse here'
+  },
+  expected: '<button data-has-block="true"></button>'
+});
+
+testComponent('parameterized has-block (attr, inverse) when inverse not supplied', {
+  skip: true,
+  layout: '<button data-has-block="{{has-block "inverse"}}""></button>',
+  invokeAs: { template: 'block here' },
+  expected: '<button data-has-block="false"></button>'
+});
+
+testComponent('parameterized has-block (attr, default) when block supplied', {
+  skip: true,
+  layout: '<button data-has-block="{{has-block}}""></button>',
+  invokeAs: { template: 'block here' },
+  expected: '<button data-has-block="true"></button>'
+});
+
+testComponent('parameterized has-block (attr, default) when block not supplied', {
+  skip: true,
+  kind: 'curly',
+  layout: '<button data-has-block="{{has-block}}""></button>',
+  expected: '<button data-has-block="false"></button>'
+});
+
+testComponent('parameterized has-block (concatted attr, inverse) when inverse supplied', {
+  skip: true,
+  kind: 'curly',
+  layout: '<button data-has-block="is-{{has-block "inverse"}}""></button>',
+  invokeAs: {
+    template: 'block here',
+    inverse: 'inverse here'
+  },
+  expected: '<button data-has-block="is-true"></button>'
+});
+
+testComponent('parameterized has-block (concatted attr, inverse) when inverse not supplied', {
+  skip: true,
+  layout: '<button data-has-block="is-{{has-block "inverse"}}""></button>',
+  invokeAs: { template: 'block here' },
+  expected: '<button data-has-block="is-false"></button>'
+});
+
+testComponent('parameterized has-block (concatted attr, default) when block supplied', {
+  skip: true,
+  layout: '<button data-has-block="is-{{has-block}}""></button>',
+  invokeAs: { template: 'block here' },
+  expected: '<button data-has-block="is-true"></button>'
+});
+
+testComponent('parameterized has-block (concatted attr, default) when block not supplied', {
+  skip: true,
+  kind: 'curly',
+  layout: '<button data-has-block="is-{{has-block}}""></button>',
+  expected: '<button data-has-block="is-false"></button>'
 });
 
 module("Components - curlies - dynamic customizations");

--- a/packages/glimmer-wire-format/index.ts
+++ b/packages/glimmer-wire-format/index.ts
@@ -40,12 +40,14 @@ export namespace Expressions {
   export type Attr          = ['attr', Path];
   export type Get           = ['get', Path];
   export type Value         = str | number | boolean;
+  export type HasBlock      = ['hasBlock', str];
 
   export type Expression =
       Unknown
     | Attr
     | Get
     | Concat
+    | HasBlock
     | Helper
     | Value
     ;
@@ -67,6 +69,7 @@ export namespace Expressions {
   export const isGet          = is<Get>('get');
   export const isConcat       = is<Concat>('concat');
   export const isHelper       = is<Helper>('helper');
+  export const isHasBlock     = is<HasBlock>('hasBlock');
 
   export function isValue(value: any): value is Value {
     return value !== null && typeof value !== 'object';


### PR DESCRIPTION
Implements a has-block helper and tests it in subexpression, append and dynamic property position. I've always rewritten the tests to use `has-block` instead of `hasBlock`. We can deal with the camel-cased version in Ember's own tests.

A couple other things:
- I plan to refactor the template-compiler a bit so we don't have the `if (isHasBlock(action)) {` checks in 3 places.
- Attributes/concat don't work correctly because of a separate bug related to https://github.com/emberjs/ember.js/issues/12506

Actually both of these issues will likely be resolved together. The issue is that `foo="{{bar}}"` current assumes that this is a `get` for `bar`, but in fact it could also be a helper call for a helper named `bar`.