### PR TITLE
Implement has-block-params helper

### DIFF
--- a/packages/glimmer-compiler/lib/javascript-compiler.ts
+++ b/packages/glimmer-compiler/lib/javascript-compiler.ts
@@ -158,6 +158,11 @@ export default class JavaScriptCompiler {
     this.template.yields.add(name);
   }
 
+  hasBlockParams(name: string) {
+    this.pushValue(['hasBlockParams', name]);
+    this.template.yields.add(name);
+  }
+
   /// Expressions
 
   literal(value: any) {

--- a/packages/glimmer-compiler/lib/template-compiler.ts
+++ b/packages/glimmer-compiler/lib/template-compiler.ts
@@ -104,6 +104,9 @@ export default class TemplateCompiler {
     } else if (isHasBlock(action)) {
       let name = assertValidHasBlock(action);
       this.hasBlock(name, action);
+    } else if (isHasBlockParams(action)) {
+      let name = assertValidHasBlockParams(action);
+      this.hasBlockParams(name, action);
     } else if (action.path.data) {
       this.attr([action.path]);
     } else if (isHelper(action)) {
@@ -131,6 +134,9 @@ export default class TemplateCompiler {
     } else if (isHasBlock(action)) {
       let name = assertValidHasBlock(action);
       this.hasBlock(name, action);
+    } else if (isHasBlockParams(action)) {
+      let name = assertValidHasBlockParams(action);
+      this.hasBlockParams(name, action);
     } else if (isHelper(action)) {
       this.prepareHelper(action);
       this.opcode('helper', action, path.parts);
@@ -161,12 +167,19 @@ export default class TemplateCompiler {
     this.opcode('hasBlock', action, name);
   }
 
+  hasBlockParams(name: string, action) {
+    this.opcode('hasBlockParams', action, name);
+  }
+
   /// Expressions, invoked recursively from prepareParams and prepareHash
 
   SubExpression(expr) {
     if (isHasBlock(expr)) {
       let name = assertValidHasBlock(expr);
       this.hasBlock(name, expr);
+    } else if (isHasBlockParams(expr)) {
+      let name = assertValidHasBlockParams(expr);
+      this.hasBlockParams(name, expr);
     } else {
       this.prepareHelper(expr);
       this.opcode('helper', expr, expr.path.parts);
@@ -294,6 +307,10 @@ function isHasBlock({ path }) {
   return path.original === 'has-block';
 }
 
+function isHasBlockParams({ path }) {
+  return path.original === 'has-block-params';
+}
+
 function assertValidYield({ hash }): string {
   let pairs = hash.pairs;
 
@@ -319,5 +336,19 @@ function assertValidHasBlock({ params }): string {
     }
   } else {
     throw new Error(`has-block only takes a single positional argument`);
+  }
+}
+
+function assertValidHasBlockParams({ params }): string {
+  if (params.length === 0) {
+    return 'default';
+  } else if (params.length === 1) {
+    if (params[0].type === 'StringLiteral') {
+      return params[0].value;
+    } else {
+      throw new Error(`you can only yield to a literal value`);
+    }
+  } else {
+    throw new Error(`has-block-params only takes a single positional argument`);
   }
 }

--- a/packages/glimmer-runtime/lib/compiled/expressions/has-block-params.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/has-block-params.ts
@@ -2,9 +2,10 @@ import VM from '../../vm/append';
 import { CompiledExpression } from '../expressions';
 import { ValueReference } from './value';
 import { InternedString } from 'glimmer-util';
+import { InlineBlock } from '../blocks';
 
-export default class CompiledHasBlock extends CompiledExpression<boolean> {
-  public type = "has-block";
+export default class CompiledHasBlockParams extends CompiledExpression<boolean> {
+  public type = "has-block-params";
   public blockName: InternedString;
   public blockSymbol: number;
 
@@ -16,10 +17,10 @@ export default class CompiledHasBlock extends CompiledExpression<boolean> {
 
   evaluate(vm: VM): ValueReference<boolean> {
     let blockRef = vm.scope().getBlock(this.blockSymbol);
-    return new ValueReference(!!blockRef);
+    return new ValueReference(!!(blockRef && blockRef.locals.length > 0));
   }
 
   toJSON(): string {
-    return `has-block(${this.blockName})`;
+    return `has-block-params(${this.blockName})`;
   }
 }

--- a/packages/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/glimmer-runtime/lib/syntax/core.ts
@@ -50,6 +50,8 @@ import {
 
 import CompiledHasBlock from '../compiled/expressions/has-block';
 
+import CompiledHasBlockParams from '../compiled/expressions/has-block-params';
+
 import CompiledHelper from '../compiled/expressions/helper';
 
 import CompiledConcat from '../compiled/expressions/concat';
@@ -951,6 +953,40 @@ export class HasBlock extends ExpressionSyntax<boolean> {
 
   compile(compiler: SymbolLookup, env: Environment): CompiledHasBlock {
     return new CompiledHasBlock({
+      blockName: this.blockName,
+      blockSymbol: compiler.getBlockSymbol(this.blockName)
+    });
+  }
+}
+
+export class HasBlockParams extends ExpressionSyntax<boolean> {
+  type = "has-block-params";
+
+  static fromSpec(sexp: SerializedExpressions.HasBlockParams): HasBlockParams {
+    let [, blockName] = sexp;
+
+    return new HasBlockParams({
+      blockName: blockName as InternedString
+    });
+  }
+
+  static build(blockName: InternedString): HasBlockParams {
+    return new this({ blockName });
+  }
+
+  blockName: InternedString;
+
+  constructor({ blockName }: { blockName: InternedString }) {
+    super();
+    this.blockName = blockName;
+  }
+
+  prettyPrint() {
+    return new PrettyPrint('expr', 'has-block-params', [this.blockName]);
+  }
+
+  compile(compiler: SymbolLookup, env: Environment): CompiledHasBlockParams {
+    return new CompiledHasBlockParams({
       blockName: this.blockName,
       blockSymbol: compiler.getBlockSymbol(this.blockName)
     });

--- a/packages/glimmer-runtime/lib/syntax/expressions.ts
+++ b/packages/glimmer-runtime/lib/syntax/expressions.ts
@@ -4,6 +4,7 @@ import {
   Concat as ConcatSyntax,
   Get as GetSyntax,
   HasBlock as HasBlockSyntax,
+  HasBlockParams as HasBlockParamsSyntax,
   Helper as HelperSyntax,
   Unknown as UnknownSyntax
 } from './core';
@@ -18,6 +19,7 @@ const {
   isConcat,
   isGet,
   isHasBlock,
+  isHasBlockParams,
   isHelper,
   isUnknown,
   isValue
@@ -33,5 +35,6 @@ export default function(sexp: SerializedExpression): any {
     if (isHelper(sexp)) return HelperSyntax.fromSpec(sexp);
     if (isUnknown(sexp)) return UnknownSyntax.fromSpec(sexp);
     if (isHasBlock(sexp)) return HasBlockSyntax.fromSpec(sexp);
+    if (isHasBlockParams(sexp)) return HasBlockParamsSyntax.fromSpec(sexp);
   }
 };

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -537,6 +537,8 @@ testComponent('yield to inverse', {
   expected: 'No:Goodbyeouter'
 });
 
+module('Components - has-block helper')
+
 testComponent('parameterized has-block (subexpr, inverse) when inverse supplied', {
   kind: 'curly',
   layout: '{{#if (has-block "inverse")}}Yes{{else}}No{{/if}}',
@@ -624,7 +626,7 @@ testComponent('parameterized has-block (prop, default) when block not supplied',
 testComponent('parameterized has-block (attr, inverse) when inverse supplied', {
   skip: true,
   kind: 'curly',
-  layout: '<button data-has-block="{{has-block "inverse"}}""></button>',
+  layout: '<button data-has-block="{{has-block "inverse"}}"></button>',
   invokeAs: {
     template: 'block here',
     inverse: 'inverse here'
@@ -634,14 +636,14 @@ testComponent('parameterized has-block (attr, inverse) when inverse supplied', {
 
 testComponent('parameterized has-block (attr, inverse) when inverse not supplied', {
   skip: true,
-  layout: '<button data-has-block="{{has-block "inverse"}}""></button>',
+  layout: '<button data-has-block="{{has-block "inverse"}}"></button>',
   invokeAs: { template: 'block here' },
   expected: '<button data-has-block="false"></button>'
 });
 
 testComponent('parameterized has-block (attr, default) when block supplied', {
   skip: true,
-  layout: '<button data-has-block="{{has-block}}""></button>',
+  layout: '<button data-has-block="{{has-block}}"></button>',
   invokeAs: { template: 'block here' },
   expected: '<button data-has-block="true"></button>'
 });
@@ -649,14 +651,14 @@ testComponent('parameterized has-block (attr, default) when block supplied', {
 testComponent('parameterized has-block (attr, default) when block not supplied', {
   skip: true,
   kind: 'curly',
-  layout: '<button data-has-block="{{has-block}}""></button>',
+  layout: '<button data-has-block="{{has-block}}"></button>',
   expected: '<button data-has-block="false"></button>'
 });
 
 testComponent('parameterized has-block (concatted attr, inverse) when inverse supplied', {
   skip: true,
   kind: 'curly',
-  layout: '<button data-has-block="is-{{has-block "inverse"}}""></button>',
+  layout: '<button data-has-block="is-{{has-block "inverse"}}"></button>',
   invokeAs: {
     template: 'block here',
     inverse: 'inverse here'
@@ -666,14 +668,14 @@ testComponent('parameterized has-block (concatted attr, inverse) when inverse su
 
 testComponent('parameterized has-block (concatted attr, inverse) when inverse not supplied', {
   skip: true,
-  layout: '<button data-has-block="is-{{has-block "inverse"}}""></button>',
+  layout: '<button data-has-block="is-{{has-block "inverse"}}"></button>',
   invokeAs: { template: 'block here' },
   expected: '<button data-has-block="is-false"></button>'
 });
 
 testComponent('parameterized has-block (concatted attr, default) when block supplied', {
   skip: true,
-  layout: '<button data-has-block="is-{{has-block}}""></button>',
+  layout: '<button data-has-block="is-{{has-block}}"></button>',
   invokeAs: { template: 'block here' },
   expected: '<button data-has-block="is-true"></button>'
 });
@@ -681,9 +683,212 @@ testComponent('parameterized has-block (concatted attr, default) when block supp
 testComponent('parameterized has-block (concatted attr, default) when block not supplied', {
   skip: true,
   kind: 'curly',
-  layout: '<button data-has-block="is-{{has-block}}""></button>',
+  layout: '<button data-has-block="is-{{has-block}}"></button>',
   expected: '<button data-has-block="is-false"></button>'
 });
+
+module('Components - has-block-params helper')
+
+testComponent('parameterized has-block-params (subexpr, inverse) when inverse supplied without block params', {
+  kind: 'curly',
+  layout: '{{#if (has-block-params "inverse")}}Yes{{else}}No{{/if}}',
+  invokeAs: {
+    template: 'block here',
+    inverse: 'inverse here'
+  },
+  expected: 'No'
+});
+
+testComponent('parameterized has-block-params (subexpr, inverse) when inverse not supplied', {
+  layout: '{{#if (has-block-params "inverse")}}Yes{{else}}No{{/if}}',
+  invokeAs: { template: 'block here' },
+  expected: 'No'
+});
+
+testComponent('parameterized has-block-params (subexpr, default) when block supplied with block params', {
+  kind: 'curly',
+  layout: '{{#if (has-block-params)}}Yes{{else}}No{{/if}}',
+  invokeAs: {
+    blockParams: ['param'],
+    template: 'block here'
+  },
+  expected: 'Yes'
+});
+
+testComponent('parameterized has-block-params (subexpr, default) when block supplied without block params', {
+  layout: '{{#if (has-block-params)}}Yes{{else}}No{{/if}}',
+  invokeAs: { template: 'block here' },
+  expected: 'No'
+});
+
+testComponent('parameterized has-block-params (subexpr, default) when block not supplied', {
+  kind: 'curly',
+  layout: '{{#if (has-block-params)}}Yes{{else}}No{{/if}}',
+  expected: 'No'
+});
+
+testComponent('parameterized has-block-params (content, inverse) when inverse supplied without block params', {
+  kind: 'curly',
+  layout: '{{has-block-params "inverse"}}',
+  invokeAs: {
+    template: 'block here',
+    inverse: 'inverse here'
+  },
+  expected: 'false'
+});
+
+testComponent('parameterized has-block-params (content, inverse) when inverse not supplied', {
+  layout: '{{has-block-params "inverse"}}',
+  invokeAs: { template: 'block here' },
+  expected: 'false'
+});
+
+testComponent('parameterized has-block-params (content, default) when block supplied with block params', {
+  kind: 'curly',
+  layout: '{{has-block-params}}',
+  invokeAs: {
+    blockParams: ['param'],
+    template: 'block here'
+  },
+  expected: 'true'
+});
+
+testComponent('parameterized has-block-params (content, default) when block supplied without block params', {
+  layout: '{{has-block-params}}',
+  invokeAs: { template: 'block here' },
+  expected: 'false'
+});
+
+testComponent('parameterized has-block-params (content, default) when block not supplied', {
+  kind: 'curly',
+  layout: '{{has-block-params}}',
+  expected: 'false'
+});
+
+testComponent('parameterized has-block-params (prop, inverse) when inverse supplied without block params', {
+  kind: 'curly',
+  layout: '<button name={{has-block-params "inverse"}}></button>',
+  invokeAs: {
+    template: 'block here',
+    inverse: 'inverse here'
+  },
+  expected: '<button name="false"></button>'
+});
+
+testComponent('parameterized has-block-params (prop, inverse) when inverse not supplied', {
+  layout: '<button name={{has-block-params "inverse"}}></button>',
+  invokeAs: { template: 'block here' },
+  expected: '<button name="false"></button>'
+});
+
+testComponent('parameterized has-block-params (prop, default) when block supplied with block params', {
+  kind: 'curly',
+  layout: '<button name={{has-block-params}}></button>',
+  invokeAs: {
+    blockParams: ['param'],
+    template: 'block here'
+  },
+  expected: '<button name="true"></button>'
+});
+
+testComponent('parameterized has-block-params (prop, default) when block supplied without block params', {
+  layout: '<button name={{has-block-params}}></button>',
+  invokeAs: { template: 'block here' },
+  expected: '<button name="false"></button>'
+});
+
+testComponent('parameterized has-block-params (prop, default) when block not supplied', {
+  kind: 'curly',
+  layout: '<button name={{has-block-params}}></button>',
+  expected: '<button name="false"></button>'
+});
+
+testComponent('parameterized has-block-params (attr, inverse) when inverse supplied without block params', {
+  skip: true,
+  kind: 'curly',
+  layout: '<button data-has-block-params="{{has-block-params "inverse"}}"></button>',
+  invokeAs: {
+    template: 'block here',
+    inverse: 'inverse here'
+  },
+  expected: '<button data-has-block-params="false"></button>'
+});
+
+testComponent('parameterized has-block-params (attr, inverse) when inverse not supplied', {
+  skip: true,
+  layout: '<button data-has-block-params="{{has-block-params "inverse"}}"></button>',
+  invokeAs: { template: 'block here' },
+  expected: '<button data-has-block-params="false"></button>'
+});
+
+testComponent('parameterized has-block-params (attr, default) when block supplied with block params', {
+  skip: true,
+  kind: 'curly',
+  layout: '<button data-has-block-params="{{has-block-params}}"></button>',
+  invokeAs: {
+    blockParams: ['param'],
+    template: 'block here'
+  },
+  expected: '<button data-has-block-params="true"></button>'
+});
+
+testComponent('parameterized has-block-params (attr, default) when block supplied without block params', {
+  skip: true,
+  layout: '<button data-has-block-params="{{has-block-params}}"></button>',
+  invokeAs: { template: 'block here' },
+  expected: '<button data-has-block-params="false"></button>'
+});
+
+testComponent('parameterized has-block-params (attr, default) when block not supplied', {
+  skip: true,
+  kind: 'curly',
+  layout: '<button data-has-block-params="{{has-block-params}}"></button>',
+  expected: '<button data-has-block-params="false"></button>'
+});
+
+testComponent('parameterized has-block-params (concatted attr, inverse) when inverse supplied without block params', {
+  skip: true,
+  kind: 'curly',
+  layout: '<button data-has-block-params="is-{{has-block-params "inverse"}}"></button>',
+  invokeAs: {
+    template: 'block here',
+    inverse: 'inverse here'
+  },
+  expected: '<button data-has-block-params="is-false"></button>'
+});
+
+testComponent('parameterized has-block-params (concatted attr, inverse) when inverse not supplied', {
+  skip: true,
+  layout: '<button data-has-block-params="is-{{has-block-params "inverse"}}"></button>',
+  invokeAs: { template: 'block here' },
+  expected: '<button data-has-block-params="is-false"></button>'
+});
+
+testComponent('parameterized has-block-params (concatted attr, default) when block supplied with block params', {
+  skip: true,
+  kind: 'curly',
+  layout: '<button data-has-block-params="is-{{has-block-params}}"></button>',
+  invokeAs: {
+    blockParams: ['param'],
+    template: 'block here'
+  },
+  expected: '<button data-has-block-params="is-true"></button>'
+});
+
+testComponent('parameterized has-block-params (concatted attr, default) when block supplied without block params', {
+  skip: true,
+  layout: '<button data-has-block-params="is-{{has-block-params}}"></button>',
+  invokeAs: { template: 'block here' },
+  expected: '<button data-has-block-params="is-false"></button>'
+});
+
+testComponent('parameterized has-block-params (concatted attr, default) when block not supplied', {
+  skip: true,
+  kind: 'curly',
+  layout: '<button data-has-block-params="is-{{has-block-params}}"></button>',
+  expected: '<button data-has-block-params="is-false"></button>'
+});
+
 
 module("Components - curlies - dynamic customizations");
 

--- a/packages/glimmer-wire-format/index.ts
+++ b/packages/glimmer-wire-format/index.ts
@@ -36,11 +36,12 @@ export namespace Expressions {
   type Params = Core.Params;
   type Hash = Core.Hash;
 
-  export type Unknown       = ['unknown', Path];
-  export type Attr          = ['attr', Path];
-  export type Get           = ['get', Path];
-  export type Value         = str | number | boolean;
-  export type HasBlock      = ['hasBlock', str];
+  export type Unknown        = ['unknown', Path];
+  export type Attr           = ['attr', Path];
+  export type Get            = ['get', Path];
+  export type Value          = str | number | boolean;
+  export type HasBlock       = ['hasBlock', str];
+  export type HasBlockParams = ['hasBlockParams', str];
 
   export type Expression =
       Unknown
@@ -48,6 +49,7 @@ export namespace Expressions {
     | Get
     | Concat
     | HasBlock
+    | HasBlockParams
     | Helper
     | Value
     ;
@@ -64,12 +66,13 @@ export namespace Expressions {
     [3]: Hash;
   }
 
-  export const isUnknown      = is<Unknown>('unknown');
-  export const isAttr         = is<Attr>('attr');
-  export const isGet          = is<Get>('get');
-  export const isConcat       = is<Concat>('concat');
-  export const isHelper       = is<Helper>('helper');
-  export const isHasBlock     = is<HasBlock>('hasBlock');
+  export const isUnknown        = is<Unknown>('unknown');
+  export const isAttr           = is<Attr>('attr');
+  export const isGet            = is<Get>('get');
+  export const isConcat         = is<Concat>('concat');
+  export const isHelper         = is<Helper>('helper');
+  export const isHasBlock       = is<HasBlock>('hasBlock');
+  export const isHasBlockParams = is<HasBlockParams>('hasBlockParams');
 
   export function isValue(value: any): value is Value {
     return value !== null && typeof value !== 'object';


### PR DESCRIPTION
Implements the has-block-helper with a bunch of tests. Many are skipped. I have a separate PR coming up that fixes the semantics of mustaches in attributes (and hence all of skipped tests in has-block/has-block-params) and hopefully can reduce some of code duplication that is present between the mustache/attributeMustache/SubExpression handlers in the template-compiler.