### PR TITLE
Use Array.prototype.every in CompositeTag example

### DIFF
--- a/guides/05-validators.md
+++ b/guides/05-validators.md
@@ -319,13 +319,7 @@ class CompositeTag implements EntityTag<any[]> {
   validate(tickets: any[]): boolean {
     let { tags } = this;
 
-    tags.forEach((tag, i) => {
-      if (!tag.validate(tickets[i])) {
-        return false;
-      }
-    });
-
-    return true;
+    return tags.every((tag, i) => tag.validate(tickets[i]));
   }
 };
 ```


### PR DESCRIPTION
The current example uses a short-circuiting return within an each which would do the right thing in Ruby but not, I think, in JavaScript.