### PR TITLE
BUGFIX Allow for slashed components

### DIFF
--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -788,6 +788,39 @@ QUnit.test('correct scope - self', assert => {
   );
 });
 
+QUnit.test('component with slashed name', assert => {
+  let SampleComponent = EmberishCurlyComponent.extend();
+
+  env.registerEmberishCurlyComponent('fizz-bar/baz-bar', SampleComponent as any, '{{@hey}}');
+
+  appendViewFor('{{fizz-bar/baz-bar hey="hello"}}');
+
+  assert.equal(view.element.textContent, 'hello');
+});
+
+QUnit.test('context switching is not allowed', assert => {
+  let SampleComponent = EmberishCurlyComponent.extend({
+    hello: 'It twas me you were looking for.'
+  });
+
+  env.registerEmberishCurlyComponent('fizz-bar/baz-bar', SampleComponent as any, '{{../hello}}');
+
+  env.registerEmberishCurlyComponent('fizz-bar/bizz-bar', SampleComponent as any, '{{./hello}}');
+
+  let contextSwitch = () => {
+    appendViewFor('{{fizz-bar/baz-bar}}', {
+      hello: 'Is it me you are looking for?'
+    });
+  };
+
+  let localPropLookupUsingPath = () => {
+    appendViewFor('{{fizz-bar/bizz-bar}}');
+  }
+
+  assert.throws(contextSwitch, /Handlebars context switching \(using "..\/" in paths\) is not supported by Glimmer\. You should remove the context switching of "..\/hello" on line 1./);
+  assert.throws(localPropLookupUsingPath, /Using ".\/" in a path is not supported by Glimmer since there is no need to be explicit about the lookup context. You should change the lookup of ".\/hello" on line 1 to just "hello"\./);
+});
+
 QUnit.test('correct scope - simple', assert => {
   env.registerBasicComponent('sub-item', BasicComponent,
     `<p>{{@name}}</p>`

--- a/packages/glimmer-syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/glimmer-syntax/lib/parser/handlebars-node-visitors.ts
@@ -128,6 +128,26 @@ export default {
   },
 
   PathExpression: function(path) {
+    let { original, loc } = path;
+
+    if (original[0] === '@') {
+      original = original.slice(1);
+    }
+
+    /**
+     * This detects if a [HandleBars context switch](http://handlebarsjs.com/#paths) has been declared.
+     * In Glimmer context switching in general is prohibited.
+     */
+    if (path.depth > 0) {
+      throw new Error(`Handlebars context switching (using "../" in paths) is not supported by Glimmer. You should remove the context switching of "${path.original}" on line ${loc.start.line}.`);
+    }
+
+    if (original.slice(0, 2) === './') {
+      throw new Error(`Using "./" in a path is not supported by Glimmer since there is no need to be explicit about the lookup context. You should change the lookup of "${path.original}" on line ${loc.start.line} to just "${original.slice(2)}".`);
+    }
+
+    path.parts = original.split('.');
+
     delete path.depth;
 
     return path;


### PR DESCRIPTION
This allows components to be declared as `{{foo-bar/biz-bar}}` in Glimmer. It also adds guard rails for the Glimmer subset of HandleBars.