### PR TITLE
Failing test for nested comments

### DIFF
--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -1050,6 +1050,12 @@ QUnit.test('correct scope - simple', assert => {
    equalsElement(view.element, 'p', {}, '0');
 });
 
+QUnit.test("Nested comments", (assert) => {
+  appendViewFor("{{!--<h1>{{!--WAT --}}</h1>--}}", {});
+
+  equalsElement(view.element, 'div', {}, '');
+});
+
 QUnit.test('correct scope - complex', assert => {
   env.registerBasicComponent('sub-item', BasicComponent,
     `<p>{{@name}}</p>`


### PR DESCRIPTION
Results in

```
Closing tag `h1` (on line 1) without an open tag.
    at validateEndTag (http://localhost:7357/amd/glimmer-compiler.amd.js:1743:19)
    at Parser.exports.default.finishEndTag (http://localhost:7357/amd/glimmer-compiler.amd.js:1648:13)
    at Parser.exports.default.finishTag (http://localhost:7357/amd/glimmer-compiler.amd.js:1631:22)
    at Object.EventedTokenizer.states.tagName (http://localhost:7357/amd/glimmer-compiler.amd.js:3885:25)
    at Object.EventedTokenizer.tokenizePart (http://localhost:7357/amd/glimmer-compiler.amd.js:3709:33)
    at Parser.exports.default.ContentStatement (http://localhost:7357/amd/glimmer-compiler.amd.js:1478:28)
    at Parser.acceptNode (http://localhost:7357/amd/glimmer-compiler.amd.js:1792:31)
    at Parser.exports.default.Program (http://localhost:7357/amd/glimmer-compiler.amd.js:1393:22)
    at Parser.acceptNode (http://localhost:7357/amd/glimmer-compiler.amd.js:1792:31)
    at Object.preprocess (http://localhost:7357/amd/glimmer-compiler.amd.js:1759:50)
    at Object.compileSpec (http://localhost:7357/amd/glimmer-compiler.amd.js:32:30)
```