### PR TITLE
ComponentManagers should produce a self reference

### DIFF
--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -60,7 +60,7 @@ export class OpenDynamicComponentOpcode extends Opcode {
 
     let manager = definition.manager;
     let component = manager.create(definition, args, dynamicScope);
-    let selfRef = vm.env.rootReferenceFor(manager.getSelf(component));
+    let selfRef = manager.getSelf(component);
     let destructor = manager.getDestructor(component);
 
     let callerScope = vm.scope();
@@ -127,7 +127,7 @@ export class OpenComponentOpcode extends Opcode {
 
     let manager = definition.manager;
     let component = manager.create(definition, args, dynamicScope);
-    let selfRef = vm.env.rootReferenceFor(manager.getSelf(component));
+    let selfRef = manager.getSelf(component);
     let destructor = manager.getDestructor(component);
 
     let callerScope = vm.scope();

--- a/packages/glimmer-runtime/lib/component/interfaces.ts
+++ b/packages/glimmer-runtime/lib/component/interfaces.ts
@@ -6,6 +6,7 @@ import Environment, { DynamicScope } from '../environment';
 import { ElementOperations } from '../builder';
 
 import { Destroyable, Opaque } from 'glimmer-util';
+import { PathReference } from 'glimmer-reference';
 
 export type Component = Opaque;
 export type ComponentClass = any;
@@ -16,9 +17,9 @@ export interface ComponentManager<T> {
   // an opaque token, but in practice it is probably a component object.
   create(definition: ComponentDefinition<T>, attrs: EvaluatedArgs, dynamicScope: DynamicScope): T;
 
-  // Next, Glimmer asks the manager for the `self` it should use in the
-  // layout. This will likely be the component itself, but may not be.
-  getSelf(component: T): any;
+  // Next, Glimmer asks the manager to create a reference for the `self`
+  // it should use in the layout.
+  getSelf(component: T): PathReference<Opaque>;
 
   // The `didCreateElement` hook is meant to be used by the host to save
   // off the element. Hosts should use `didCreate`, which runs asynchronously

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -192,7 +192,6 @@ export abstract class Environment {
     return false;
   }
 
-  abstract rootReferenceFor(obj: any): PathReference<Opaque>;
   abstract hasHelper(helperName: InternedString[]): boolean;
   abstract lookupHelper(helperName: InternedString[]): Helper;
   abstract hasComponentDefinition(tagName: InternedString[]): boolean;

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -218,8 +218,8 @@ class BasicComponentManager implements ComponentManager<BasicComponent> {
     return new klass(args.named.value());
   }
 
-  getSelf(component: BasicComponent) {
-    return component;
+  getSelf(component: BasicComponent): PathReference<Opaque> {
+    return new UpdatableReference(component);
   }
 
   didCreateElement(component: BasicComponent, element: Element) {
@@ -257,8 +257,8 @@ class EmberishGlimmerComponentManager implements ComponentManager<EmberishGlimme
     return component;
   }
 
-  getSelf(component: EmberishGlimmerComponent) {
-    return component;
+  getSelf(component: EmberishGlimmerComponent): PathReference<Opaque> {
+    return new UpdatableReference(component);
   }
 
   didCreateElement(component: EmberishGlimmerComponent, element: Element) {
@@ -310,8 +310,8 @@ class EmberishCurlyComponentManager implements ComponentManager<EmberishCurlyCom
     return component;
   }
 
-  getSelf(component: EmberishCurlyComponent) {
-    return component;
+  getSelf(component: EmberishCurlyComponent): PathReference<Opaque> {
+    return new UpdatableReference(component);
   }
 
   didCreateElement(component: EmberishCurlyComponent, element: Element, operations: ElementOperations) {
@@ -448,10 +448,6 @@ export class TestEnvironment extends Environment {
   registerEmberishGlimmerComponent(name: string, Component: EmberishGlimmerComponentFactory, layout: string): ComponentDefinition<EmberishGlimmerComponentDefinition> {
     let definition = new EmberishGlimmerComponentDefinition(name, EMBERISH_GLIMMER_COMPONENT_MANAGER, Component, layout);
     return this.registerComponent(name, definition);
-  }
-
-  rootReferenceFor(object: any): PathReference<any> {
-    return new UpdatableReference(object);
   }
 
   toConditionalReference(reference: Reference<any>): Reference<boolean> {


### PR DESCRIPTION
This allows the environment to have more control over what kind of reference to use without the very generic "rootReferenceFor" hook.