### PR TITLE
Fix regression with {{this.value}}

### DIFF
--- a/packages/glimmer-runtime/tests/compile-errors-test.ts
+++ b/packages/glimmer-runtime/tests/compile-errors-test.ts
@@ -1,0 +1,27 @@
+import { TestEnvironment } from "glimmer-test-helpers";
+
+let env: TestEnvironment;
+
+QUnit.module("Compile errors", {
+  setup() {
+    env = new TestEnvironment();
+  }
+});
+
+QUnit.test('context switching using ../ is not allowed', assert => {
+  assert.throws(() => {
+    env.compile('<div><p>{{../value}}</p></div>');
+  }, new Error("Changing context using \"../\" is not supported in Glimmer: \"../value\" on line 1."));
+});
+
+QUnit.test('mixing . and / is not allowed', assert => {
+  assert.throws(() => {
+    env.compile('<div><p>{{a/b.c}}</p></div>');
+  }, new Error("Mixing '.' and '/' in paths is not supported in Glimmer; use only '.' to separate property paths: \"a/b.c\" on line 1."));
+});
+
+QUnit.test('explicit self ref with ./ is not allowed', assert => {
+  assert.throws(() => {
+    env.compile('<div><p>{{./value}}</p></div>');
+  }, new Error("Using \"./\" is not supported in Glimmer and unnecessary: \"./value\" on line 1."), "should throw error");
+});

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -1003,29 +1003,6 @@ QUnit.test('component with slashed name', assert => {
   assert.equal(view.element.textContent, 'hello');
 });
 
-QUnit.test('context switching is not allowed', assert => {
-  let SampleComponent = EmberishCurlyComponent.extend({
-    hello: 'It twas me you were looking for.'
-  });
-
-  env.registerEmberishCurlyComponent('fizz-bar/baz-bar', SampleComponent as any, '{{../hello}}');
-
-  env.registerEmberishCurlyComponent('fizz-bar/bizz-bar', SampleComponent as any, '{{./hello}}');
-
-  let contextSwitch = () => {
-    appendViewFor('{{fizz-bar/baz-bar}}', {
-      hello: 'Is it me you are looking for?'
-    });
-  };
-
-  let localPropLookupUsingPath = () => {
-    appendViewFor('{{fizz-bar/bizz-bar}}');
-  }
-
-  assert.throws(contextSwitch, /Handlebars context switching \(using "..\/" in paths\) is not supported by Glimmer\. You should remove the context switching of "..\/hello" on line 1./);
-  assert.throws(localPropLookupUsingPath, /Using ".\/" in a path is not supported by Glimmer since there is no need to be explicit about the lookup context. You should change the lookup of ".\/hello" on line 1 to just "hello"\./);
-});
-
 QUnit.test('correct scope - simple', assert => {
   env.registerBasicComponent('sub-item', BasicComponent,
     `<p>{{@name}}</p>`

--- a/packages/glimmer-runtime/tests/updating-test.ts
+++ b/packages/glimmer-runtime/tests/updating-test.ts
@@ -184,6 +184,26 @@ test("dynamically scoped keywords can be passed to render, and used in curlies",
   equalTokens(root, 'Godfrey', "Reset with replacement");
 });
 
+test("updating a curly with this", () => {
+  let object = { value: 'hello world' };
+  let template = compile('<div><p>{{this.value}}</p></div>');
+  render(template, object);
+  let valueNode = root.firstChild.firstChild.firstChild;
+
+  equalTokens(root, '<div><p>hello world</p></div>', "Initial render");
+
+  rerender();
+
+  equalTokens(root, '<div><p>hello world</p></div>', "no change");
+  strictEqual(root.firstChild.firstChild.firstChild, valueNode, "The text node was not blown away");
+
+  object.value = 'goodbye world';
+  rerender();
+
+  equalTokens(root, '<div><p>goodbye world</p></div>', "After updating and dirtying");
+  strictEqual(root.firstChild.firstChild.firstChild, valueNode, "The text node was not blown away");
+});
+
 test("changing dynamic scope", assert => {
   let template = compile("{{view.name}} {{#with-keywords view=innerView}}{{view.name}}{{/with-keywords}} {{view.name}}");
   let view = { name: 'Godfrey' };

--- a/packages/glimmer-syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/glimmer-syntax/lib/parser/handlebars-node-visitors.ts
@@ -130,23 +130,19 @@ export default {
   PathExpression: function(path) {
     let { original, loc } = path;
 
-    if (original[0] === '@') {
-      original = original.slice(1);
+    if (original.indexOf('/') !== -1) {
+      // TODO add a SyntaxError with loc info
+      if (original.slice(0, 2) === './') {
+        throw new Error(`Using "./" is not supported in Glimmer and unnecessary: "${path.original}" on line ${loc.start.line}.`);
+      }
+      if (original.slice(0, 3) === '../') {
+        throw new Error(`Changing context using "../" is not supported in Glimmer: "${path.original}" on line ${loc.start.line}.`);
+      }
+      if (original.indexOf('.') !== -1) {
+        throw new Error(`Mixing '.' and '/' in paths is not supported in Glimmer; use only '.' to separate property paths: "${path.original}" on line ${loc.start.line}.`);
+      }
+      path.parts = [ path.parts.join('/') ];
     }
-
-    /**
-     * This detects if a [HandleBars context switch](http://handlebarsjs.com/#paths) has been declared.
-     * In Glimmer context switching in general is prohibited.
-     */
-    if (path.depth > 0) {
-      throw new Error(`Handlebars context switching (using "../" in paths) is not supported by Glimmer. You should remove the context switching of "${path.original}" on line ${loc.start.line}.`);
-    }
-
-    if (original.slice(0, 2) === './') {
-      throw new Error(`Using "./" in a path is not supported by Glimmer since there is no need to be explicit about the lookup context. You should change the lookup of "${path.original}" on line ${loc.start.line} to just "${original.slice(2)}".`);
-    }
-
-    path.parts = original.split('.');
 
     delete path.depth;
 


### PR DESCRIPTION
Adds test for {{this.value}} updating.

Moves tests compile errors into a different module and adds test for mixed slash and dot.