### PR TITLE
[WIP] "Automatic shouldComponentUpdate"

### DIFF
--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -170,6 +170,7 @@ export class UpdateComponentOpcode extends UpdatingOpcode {
 
   constructor({ name, component, manager, args, dynamicScope } : { name: string, component: Component, manager: ComponentManager<any>, args: EvaluatedArgs, dynamicScope: DynamicScope }) {
     super();
+    this.tag = args.tag;
     this.name = name;
     this.component = component;
     this.manager = manager;

--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -7,7 +7,7 @@ import { Templates } from '../../syntax/core';
 import { layoutFor } from '../../compiler';
 import { DynamicScope } from '../../environment';
 import { InternedString, Opaque, dict } from 'glimmer-util';
-import { Reference, ReferenceCache, isConst } from 'glimmer-reference';
+import { Reference, ReferenceCache, Revision, isConst } from 'glimmer-reference';
 
 export type DynamicComponentFactory<T> = (args: EvaluatedArgs, vm: PublicVM) => Reference<ComponentDefinition<T>>;
 
@@ -120,6 +120,7 @@ export class OpenComponentOpcode extends Opcode {
   }
 
   evaluate(vm: VM) {
+    vm.beginCacheGroup();
     vm.pushDynamicScope();
 
     let { args: rawArgs, shadow, definition, templates } = this;
@@ -147,6 +148,7 @@ export class OpenComponentOpcode extends Opcode {
     vm.pushRootScope(selfRef, layout.symbols);
     vm.invokeLayout({ templates, args, shadow, layout, callerScope });
     vm.env.didCreate(component, manager);
+
     vm.updateWith(new UpdateComponentOpcode({ name: definition.name, component, manager, args, dynamicScope }));
   }
 
@@ -167,6 +169,7 @@ export class UpdateComponentOpcode extends UpdatingOpcode {
   private manager: ComponentManager<Opaque>;
   private args: EvaluatedArgs;
   private dynamicScope: DynamicScope;
+  private lastUpdated: Revision;
 
   constructor({ name, component, manager, args, dynamicScope } : { name: string, component: Component, manager: ComponentManager<any>, args: EvaluatedArgs, dynamicScope: DynamicScope }) {
     super();
@@ -176,12 +179,17 @@ export class UpdateComponentOpcode extends UpdatingOpcode {
     this.manager = manager;
     this.args = args;
     this.dynamicScope = dynamicScope;
+    this.lastUpdated = args.tag.value();
   }
 
   evaluate(vm: UpdatingVM) {
-    let { component, manager, args, dynamicScope } = this;
-    manager.update(component, args, dynamicScope);
-    vm.env.didUpdate(component, manager);
+    let { component, manager, args, dynamicScope, lastUpdated } = this;
+
+    if (!args.tag.validate(lastUpdated)) {
+      manager.update(component, args, dynamicScope);
+      vm.env.didUpdate(component, manager);
+      this.lastUpdated = args.tag.value();
+    }
   }
 
   toJSON(): OpcodeJSON {
@@ -250,5 +258,6 @@ export class CloseComponentOpcode extends Opcode {
   evaluate(vm: VM) {
     vm.popScope();
     vm.popDynamicScope();
+    vm.commitCacheGroup();
   }
 }

--- a/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
@@ -1,5 +1,4 @@
 import Upsert, {
-  SafeString,
   Insertion,
   CautiousInsertion,
   TrustingInsertion,
@@ -16,7 +15,7 @@ import { Opcode, OpcodeJSON, UpdatingOpcode } from '../../opcodes';
 import { VM, UpdatingVM } from '../../vm';
 import { Reference, ReferenceCache, isModified, isConst, map } from 'glimmer-reference';
 import { Opaque, dict } from 'glimmer-util';
-import { Bounds, Cursor, SingleNodeBounds, clear } from '../../bounds';
+import { Cursor, clear } from '../../bounds';
 import { Fragment } from '../../builder';
 import {  } from '../../environment';
 
@@ -97,6 +96,7 @@ abstract class UpdateOpcode<T extends Insertion> extends UpdatingOpcode {
     private upsert: Upsert
   ) {
     super();
+    this.tag = cache.tag;
   }
 
   protected abstract insert(dom: DOMHelper, cursor: Cursor, value: T): Upsert;

--- a/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
@@ -17,7 +17,6 @@ import { NULL_REFERENCE } from '../../references';
 import { ValueReference } from '../../compiled/expressions/value';
 import { CompiledArgs, EvaluatedArgs } from '../../compiled/expressions/args';
 
-
 export class TextOpcode extends Opcode {
   public type = "text";
   public text: InternedString;
@@ -264,14 +263,13 @@ export class ModifierOpcode extends Opcode {
   }
 }
 
-export class UpdateModifierOpcode extends DOMUpdatingOpcode {
+export class UpdateModifierOpcode extends UpdatingOpcode {
   public type = "update-modifier";
 
   private element: Element;
-  public args: EvaluatedArgs;
+  private args: EvaluatedArgs;
   private manager: ModifierManager<Opaque>;
   private modifier: Opaque;
-  private tag: RevisionTag;
   private lastUpdated: Revision;
 
   constructor({ manager, modifier, element, args }: { manager: ModifierManager<Opaque>, modifier: Opaque, element: Element, args: EvaluatedArgs }) {
@@ -280,6 +278,7 @@ export class UpdateModifierOpcode extends DOMUpdatingOpcode {
     this.manager = manager;
     this.element = element;
     this.args = args;
+    this.tag = args.tag;
     this.lastUpdated = args.tag.value();
   }
 

--- a/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
@@ -17,13 +17,6 @@ import { NULL_REFERENCE } from '../../references';
 import { ValueReference } from '../../compiled/expressions/value';
 import { CompiledArgs, EvaluatedArgs } from '../../compiled/expressions/args';
 
-abstract class DOMUpdatingOpcode extends UpdatingOpcode {
-  public type: string;
-  public next = null;
-  public prev = null;
-
-  abstract evaluate(vm: UpdatingVM);
-}
 
 export class TextOpcode extends Opcode {
   public type = "text";
@@ -313,11 +306,14 @@ export interface ElementOperation {
 }
 
 abstract class ElementPatchOperation<V> implements ElementOperation {
+  public tag: RevisionTag;
+
   protected element: Element;
   protected reference: Reference<V>;
   protected cache: ReferenceCache<V> = null;
 
   constructor(element: Element, reference: Reference<V>) {
+    this.tag = reference.tag;
     this.element = element;
     this.reference = reference;
   }
@@ -569,13 +565,14 @@ export class DynamicPropOpcode extends Opcode {
   }
 }
 
-export class PatchElementOpcode extends DOMUpdatingOpcode {
+export class PatchElementOpcode extends UpdatingOpcode {
   public type = "patch-element";
 
   private operation: ElementPatchOperation<Opaque>;
 
   constructor(operation: ElementPatchOperation<Opaque>) {
     super();
+    this.tag = operation.tag;
     this.operation = operation;
   }
 

--- a/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -8,14 +8,6 @@ import { NULL_REFERENCE } from '../../references';
 import { ListSlice, Opaque, Slice, Dict, dict, assign } from 'glimmer-util';
 import { ReferenceCache, isConst, isModified } from 'glimmer-reference';
 
-abstract class VMUpdatingOpcode extends UpdatingOpcode {
-  public type: string;
-  public next = null;
-  public prev = null;
-
-  abstract evaluate(vm: UpdatingVM);
-}
-
 export class PushChildScopeOpcode extends Opcode {
   public type = "push-child-scope";
 
@@ -395,13 +387,14 @@ export class JumpUnlessOpcode extends JumpOpcode {
   }
 }
 
-export class Assert extends VMUpdatingOpcode {
+export class Assert extends UpdatingOpcode {
   public type = "assert";
 
   private cache: ReferenceCache<Opaque>;
 
   constructor(cache: ReferenceCache<Opaque>) {
     super();
+    this.tag = cache.tag;
     this.cache = cache;
   }
 

--- a/packages/glimmer-runtime/lib/opcodes.ts
+++ b/packages/glimmer-runtime/lib/opcodes.ts
@@ -62,7 +62,6 @@ export function inspect(opcodes: LinkedList<AbstractOpcode>): string {
 }
 
 function _inspect(opcode: OpcodeJSON, buffer: string[], level: number, index: number) {
-  let i = 1;
   let indentation = [];
 
   for (let i=0; i<level; i++) {

--- a/packages/glimmer-runtime/lib/opcodes.ts
+++ b/packages/glimmer-runtime/lib/opcodes.ts
@@ -1,6 +1,6 @@
-import { LinkedList, LinkedListNode, Slice } from 'glimmer-util';
+import { Dict, LinkedList, LinkedListNode, Slice, initializeGuid } from 'glimmer-util';
+import { RevisionTag } from 'glimmer-reference';
 import { VM, UpdatingVM } from './vm';
-import { Dict, initializeGuid } from 'glimmer-util';
 
 export interface OpcodeJSON {
   guid: number;
@@ -37,6 +37,8 @@ export type OpSeq = Slice<Opcode>;
 export type OpSeqBuilder = LinkedList<Opcode>;
 
 export abstract class UpdatingOpcode extends AbstractOpcode {
+  public tag: RevisionTag;
+
   next: UpdatingOpcode = null;
   prev: UpdatingOpcode = null;
 

--- a/packages/glimmer-runtime/lib/vm/append.ts
+++ b/packages/glimmer-runtime/lib/vm/append.ts
@@ -102,7 +102,7 @@ export default class VM implements PublicVM {
     this.stack().pushBlock();
     let state = this.capture();
 
-    let tryOpcode = new TryOpcode({ ops, state, updating });
+    let tryOpcode = new TryOpcode({ ops, state, children: updating });
 
     this.didEnter(tryOpcode, updating);
   }
@@ -112,7 +112,8 @@ export default class VM implements PublicVM {
 
     this.stack().pushBlock();
     let state = this.capture();
-    let tryOpcode = new TryOpcode({ ops, state, updating });
+
+    let tryOpcode = new TryOpcode({ ops, state, children: updating });
 
     this.listBlockStack.current.map[<string>key] = tryOpcode;
 
@@ -126,7 +127,7 @@ export default class VM implements PublicVM {
     let state = this.capture();
     let artifacts = this.frame.getIterator().artifacts;
 
-    let opcode = new ListBlockOpcode({ ops, state, updating, artifacts });
+    let opcode = new ListBlockOpcode({ ops, state, children: updating, artifacts });
 
     this.listBlockStack.push(opcode);
 
@@ -141,6 +142,10 @@ export default class VM implements PublicVM {
   exit() {
     this.stack().popBlock();
     this.updatingOpcodeStack.pop();
+
+    let parent = this.updatingOpcodeStack.current.tail() as BlockOpcode;
+
+    parent.didInitializeChildren();
   }
 
   exitList() {

--- a/packages/glimmer-runtime/lib/vm/update.ts
+++ b/packages/glimmer-runtime/lib/vm/update.ts
@@ -54,6 +54,10 @@ export default class UpdatingVM {
     }
   }
 
+  goto(op: UpdatingOpcode) {
+    this.frameStack.current.goto(op);
+  }
+
   try(ops: UpdatingOpSeq, handler: ExceptionHandler) {
     this.frameStack.push(new UpdatingVMFrame(this, ops, handler));
   }
@@ -364,6 +368,10 @@ export class UpdatingVMFrame {
     this.ops = ops;
     this.current = ops.head();
     this.exceptionHandler = handler;
+  }
+
+  goto(op: UpdatingOpcode) {
+    this.current = op;
   }
 
   nextStatement(): UpdatingOpcode {


### PR DESCRIPTION
Given...

1. The updating program is represented as list of updating opcodes, and
2. All the "dynamic" inputs to each updating opcode is represented by [references](https://github.com/tildeio/glimmer/blob/master/guides/04-references.md), and
3. There is a [revision tag](https://github.com/tildeio/glimmer/blob/master/guides/05-validators.md) on each reference indicating whether their `value` has changed, and
4. Validating the tag on a reference is usually much cheaper than recomputing the `value`

Therefore,

1. We can also assign a tag to each updating opcode (which is just a simple composition of it's input references), and
2. We can do a cheap revalidation on the updating opcode's tag to decide if we need to run that opcode

This allows us to combine the tags of multiple updating opcodes into a single tag and revalidate them as a group, a la an automatic version of React's `shouldComponentUpdate`. 

This is how it works in practice. Given this component template:

```handlebars
{{!-- foo-bar component --}}
<div>I'm inside a component! {{foo}} {{bar}} {{@outsideFoo}} {{@outsideBar}}</div>
```

...and the following invocation...

```handlebars
<foo-bar @outsideFoo=... @outsideBar=... />
```

We know that...

1. The component instance has a dependency on its invocation args, and
2. The component layout has a dependency on `foo`, `bar`, `@outsideFoo`, `@outsideBar`, and
3. If none of those things have changed, there is no need to run any hooks on the component, and
4. If none of those things have changed, there is no need to run any of the corresponding updating opcodes

In other words, because we own the "programming language" (the templates) here, we can automatically derive/infer all the know inputs to the "pure function" (the component invocation) and skip entire "sub-trees" if we know the inputs have not changed. (I put "sub-trees" in quotes, because in practice the updating program does not reflect the nesting as a tree).

* * *

Here is a real world example tested with Ember canary:

![ember example](http://cl.ly/2Z3g2i1H3J0j/application_hbs_-_update-test_and_UpdateTest_and_UpdateTest_and_try___catch_-_JavaScript___MDN.png)

As you can see, we are now inserting a `JUMP-IF-NOT-MODIFIED` and `DID-MODIFY` updating opcode pair around each component. The `JUMP-IF-NOT-MODIFIED` has a composite tag of all its "downstream" dependencies, and will skip pass the entire section of updating opcodes when they have not changed. The `DID-MODIFY` opcode updates the "lastRevision" on the first opcode after running the component hooks (and their child components, etc).

This is pretty easy to see in the "no-op rerender" cases, where practically the entire updating program is skipped. In the update case, you can see that we are skipping the updating opcodes for the unchanged (second and third) components. While the savings in that case looks fairly modest based on the number of opcodes executed, keep in mind that 1) the chrome inspector collapsed some of them in the output (the "2" badge next to the log lines) and 2) "label" opcodes are NO-OPs inserted purely as jump targets, they don't actually do anything. (`did-modify` is also very cheap.)

This is also a pretty small example. In practice the amount of opcodes we can skip will be much larger. For example, this is the default example we use in the visualizer:

![visualizer example](http://cl.ly/100Y2E082z1Z/Screenshot_4_13_16__5_30_PM.png)

...and it still doesn't use any nested components.

* * *

TODOs: clean up the code, run some benchmarks and write a commit message.