### PR TITLE
Implement htmlSafe support

### DIFF
--- a/packages/glimmer-runtime/lib/builder.ts
+++ b/packages/glimmer-runtime/lib/builder.ts
@@ -279,6 +279,14 @@ export class ElementStack {
     return fragmentBounds;
   }
 
+  insertTextBefore(nextSibling: Node, text: string): Fragment {
+    let concreteBounds = this.dom.insertTextBefore(this.element, this.nextSibling, text);
+    let fragmentBounds = new Fragment(concreteBounds);
+    this.blockStack.current.newBounds(fragmentBounds);
+
+    return fragmentBounds;
+  }
+
   // setAttribute(name: InternedString, value: any) {
   //   this.dom.setAttribute(this.element, name, value);
   // }

--- a/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
@@ -2,7 +2,7 @@ import { Opcode, OpcodeJSON, UpdatingOpcode } from '../../opcodes';
 import { VM, UpdatingVM } from '../../vm';
 import { ReferenceCache, isModified, isConst, map } from 'glimmer-reference';
 import { Opaque, dict } from 'glimmer-util';
-import { clear } from '../../bounds';
+import { Bounds, clear } from '../../bounds';
 import { Fragment } from '../../builder';
 
 export function normalizeTextValue(value: Opaque): string {
@@ -11,6 +11,18 @@ export function normalizeTextValue(value: Opaque): string {
   } else {
     return String(value);
   }
+}
+
+export function normalizeTextOrTrustedValue(value: Opaque): Opaque {
+  if (isSafeString(value)) {
+    return value;
+  } else {
+    return normalizeTextValue(value);
+  }
+}
+
+export function isSafeString(value: Opaque): boolean {
+  return value && typeof value['toHTML'] === 'function';
 }
 
 abstract class UpdatingContentOpcode extends UpdatingOpcode {
@@ -27,12 +39,20 @@ export class AppendOpcode extends Opcode {
   evaluate(vm: VM) {
     let reference = vm.frame.getOperand();
 
-    let mapped = map(reference, normalizeTextValue);
+    let mapped = map(reference, normalizeTextOrTrustedValue);
     let cache = new ReferenceCache(mapped);
-    let node = vm.stack().appendText(cache.peek());
+    let value = cache.peek();
 
-    if (!isConst(reference)) {
-      vm.updateWith(new UpdateAppendOpcode(cache, node));
+    if (isSafeString(value)) {
+      let bounds = vm.stack().insertHTMLBefore(null, value);
+      vm.updateWith(new UpdateCautiousAppendOpcode(cache, bounds, null));
+    } else {
+      if (isConst(reference)) {
+        vm.stack().appendText(cache.peek());
+      } else {
+        let bounds = vm.stack().insertTextBefore(null, value);
+        vm.updateWith(new UpdateCautiousAppendOpcode(cache, bounds, bounds.firstNode() as Text));
+      }
     }
   }
 
@@ -42,33 +62,6 @@ export class AppendOpcode extends Opcode {
       type: this.type,
       args: ["$OPERAND"]
     };
-  }
-}
-
-export class UpdateAppendOpcode extends UpdatingContentOpcode {
-  type = 'update-append';
-  private cache: ReferenceCache<string>;
-  private textNode: Text;
-
-  constructor(cache: ReferenceCache<string>, textNode: Text) {
-    super();
-    this.cache = cache;
-    this.textNode = textNode;
-  }
-
-  evaluate() {
-    let value = this.cache.revalidate();
-    if (isModified(value)) this.textNode.nodeValue = value;
-  }
-
-  toJSON(): OpcodeJSON {
-    let { _guid: guid, type } = this;
-
-    let details = dict<string>();
-
-    details["lastValue"] = JSON.stringify(this.cache.peek());
-
-    return { guid, type, details };
   }
 }
 
@@ -123,6 +116,53 @@ export class UpdateTrustingAppendOpcode extends UpdatingContentOpcode {
     let details = dict<string>();
 
     details["lastValue"] = JSON.stringify(this.cache.peek());
+
+    return { guid, type, details };
+  }
+}
+
+export class UpdateCautiousAppendOpcode extends UpdatingContentOpcode {
+  type = 'update-cautious-append';
+  private cache: ReferenceCache<string>;
+  private bounds: Fragment;
+  private textNode: Text;
+
+  constructor(cache: ReferenceCache<string>, bounds: Fragment, textNode: Text) {
+    super();
+    this.cache = cache;
+    this.bounds = bounds;
+    this.textNode = textNode;
+  }
+
+  evaluate(vm: UpdatingVM) {
+    let value = this.cache.revalidate();
+
+    if (isModified(value)) {
+      let parent = <HTMLElement>this.bounds.parentElement();
+
+      if (isSafeString(value)) {
+        this.textNode = null;
+        let nextSibling = clear(this.bounds);
+        this.bounds.update(vm.dom.insertHTMLBefore(parent, nextSibling, value));
+      } else {
+        if(this.textNode) {
+          this.textNode.nodeValue = value;
+        } else {
+          let nextSibling = clear(this.bounds);
+          this.bounds.update(vm.dom.insertTextBefore(parent, nextSibling, value));
+          this.textNode = this.bounds.firstNode() as Text;
+        }
+      }
+    }
+  }
+
+  toJSON(): OpcodeJSON {
+    let { _guid: guid, type } = this;
+
+    let details = dict<string>();
+
+    details["lastValue"] = JSON.stringify(this.cache.peek());
+    details["isSafeString"] = JSON.stringify(isSafeString(this.cache.peek()));
 
     return { guid, type, details };
   }

--- a/packages/glimmer-runtime/lib/dom.ts
+++ b/packages/glimmer-runtime/lib/dom.ts
@@ -1,4 +1,4 @@
-import { ConcreteBounds, Bounds } from './bounds';
+import { ConcreteBounds, SingleNodeBounds, Bounds } from './bounds';
 import applyTableElementFix from './compat/inner-html-fix';
 import applySVGElementFix from './compat/svg-inner-html-fix';
 
@@ -113,6 +113,12 @@ class DOMHelper {
 
     let first = prev ? prev.nextSibling : parent.firstChild;
     return new ConcreteBounds(parent, first, last);
+  }
+
+  insertTextBefore(parent: Element, nextSibling: Node, text: string): Bounds {
+    let textNode = this.createTextNode(text);
+    this.insertBefore(parent, textNode, nextSibling);
+    return new SingleNodeBounds(parent, textNode);
   }
 
   insertBefore(element: Element, node: Node, reference: Node) {

--- a/packages/glimmer-runtime/tests/updating-test.ts
+++ b/packages/glimmer-runtime/tests/updating-test.ts
@@ -160,6 +160,39 @@ test("Cycling between two values in a trusting curly", () => {
   equalTokens(root, '<div><p>B</p></div>', "Updating");
 });
 
+test("updating a curly with a safe and unsafe string", () => {
+  let safeString = {
+    string: '<p>hello world</p>',
+    toHTML: function () { return this.string; },
+    toString: function () { return this.string; }
+  };
+  let unsafeString = '<b>Big old world!</b>';
+  let object = {
+    value: safeString
+  };
+  let template = compile('<div>{{value}}</div>');
+  render(template, object);
+  let valueNode = root.firstChild.firstChild.firstChild;
+
+  equalTokens(root, '<div><p>hello world</p></div>', "Initial render");
+
+  rerender();
+
+  equalTokens(root, '<div><p>hello world</p></div>', "no change");
+  strictEqual(root.firstChild.firstChild.firstChild, valueNode, "The text node was not blown away");
+
+  object.value = unsafeString;
+  rerender();
+
+  equalTokens(root, '<div>&lt;b&gt;Big old world!&lt;/b&gt;</div>', "After replacing with unsafe string");
+  notStrictEqual(root.firstChild.firstChild, valueNode, "The text node was blown away");
+
+  object.value = safeString;
+  rerender();
+
+  equalTokens(root, '<div><p>hello world</p></div>', "original input causes no problem");
+});
+
 test("dynamically scoped keywords can be passed to render, and used in curlies", assert => {
   let template = compile("{{view.name}}");
   let view = { name: 'Godfrey' };


### PR DESCRIPTION
This PR implements support for `htmlSafe` during append. It treats any value that isn't const as *possibly* a SafeString, and then later checks if the value really is one.

It's possible that a value that previously was a SafeString is no longer one, and vice-versa. To account for this, it is treated as a range of nodes with a `Bounds`. In the case that it is not a SafeString and currently is text, it simple updates the `nodeValue` -- the same way as `UpdateAppendOpcode` does. Otherwise, it works basically like `UpdateTrustingAppendOpcode`.

I still need to do some work around detecting SafeString using its symbol. For now I think this is far enough along to get feedback.