### PR TITLE
Support for htmlSafe/SafeString

### DIFF
--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -135,7 +135,8 @@ export {
   default as Environment,
   Helper,
   ParsedStatement,
-  DynamicScope
+  DynamicScope,
+  SafeString
 } from './lib/environment';
 
 export {

--- a/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
@@ -1,11 +1,11 @@
 import { CompiledExpression } from '../expressions';
 import { CompiledArgs } from './args';
 import VM from '../../vm/append';
-import { Helper } from '../../environment';
+import { Helper, Insertion } from '../../environment';
 import { PathReference } from 'glimmer-reference';
-import { Opaque, InternedString } from 'glimmer-util';
+import { InternedString } from 'glimmer-util';
 
-export default class CompiledHelper<T> extends CompiledExpression<T> {
+export default class CompiledHelper extends CompiledExpression<Insertion> {
   public type = "helper";
   public name: InternedString[];
   public helper: Helper;
@@ -18,7 +18,7 @@ export default class CompiledHelper<T> extends CompiledExpression<T> {
     this.args = args;
   }
 
-  evaluate(vm: VM): PathReference<T> {
+  evaluate(vm: VM): PathReference<Insertion> {
     return this.helper.call(undefined, this.args.evaluate(vm));
   }
 

--- a/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
@@ -2,63 +2,64 @@ import { Opcode, OpcodeJSON, UpdatingOpcode } from '../../opcodes';
 import { VM, UpdatingVM } from '../../vm';
 import { ReferenceCache, isModified, isConst, map } from 'glimmer-reference';
 import { Opaque, dict } from 'glimmer-util';
-import { clear } from '../../bounds';
-import { Fragment } from '../../builder';
+import { Bounds, clear, SingleNodeBounds } from '../../bounds';
+import { FragmentBounds } from '../../builder';
+import { Insertion, TrustedInsertion, SafeString, isSafeString, isNode, isString } from '../../environment';
 
-export function normalizeTextValue(value: Opaque): string {
-  if (value === null || value === undefined || typeof value['toString'] !== 'function') {
-    return '';
-  } else {
-    return String(value);
-  }
+function isEmpty(value: Opaque): boolean {
+  return value === null || value === undefined || typeof value['toString'] !== 'function';
 }
 
-abstract class UpdatingContentOpcode extends UpdatingOpcode {
-  public type: string;
+export function normalizeTextValue(value: Opaque): string {
+  if (isEmpty(value)) {
+    return '';
+  }
+  return String(value);
+}
+
+export function normalizeTrustedValue(value: Opaque): TrustedInsertion {
+  if (isEmpty(value)) {
+    return '';
+  }
+  if (isString(value)) {
+    return value;
+  }
+  if (isSafeString(value)) {
+    return value.toHTML();
+  }
+  if (isNode(value)) {
+    return value;
+  }
+  return String(value);
+}
+
+export function normalizeValue(value: Opaque): Insertion {
+  if (isEmpty(value)) {
+    return '';
+  }
+  if (isString(value)) {
+    return value;
+  }
+  if (isSafeString(value) || isNode(value)) {
+    return value;
+  }
+  return String(value);
+}
+
+class UpdatingContentOpcode<T> extends UpdatingOpcode {
   public next = null;
   public prev = null;
 
-  abstract evaluate(vm: UpdatingVM);
-}
-
-export class AppendOpcode extends Opcode {
-  type = 'append';
-
-  evaluate(vm: VM) {
-    let reference = vm.frame.getOperand();
-
-    let mapped = map(reference, normalizeTextValue);
-    let cache = new ReferenceCache(mapped);
-    let node = vm.stack().appendText(cache.peek());
-
-    if (!isConst(reference)) {
-      vm.updateWith(new UpdateAppendOpcode(cache, node));
-    }
-  }
-
-  toJSON(): OpcodeJSON {
-    return {
-      guid: this._guid,
-      type: this.type,
-      args: ["$OPERAND"]
-    };
-  }
-}
-
-export class UpdateAppendOpcode extends UpdatingContentOpcode {
-  type = 'update-append';
-  private cache: ReferenceCache<string>;
-  private textNode: Text;
-
-  constructor(cache: ReferenceCache<string>, textNode: Text) {
+  constructor(public type: string, private cache: ReferenceCache<T>, private bounds: FragmentBounds<T>) {
     super();
-    this.cache = cache;
-    this.textNode = textNode;
   }
 
-  evaluate() {
+  evaluate(vm: UpdatingVM) {
     let value = this.cache.revalidate();
-    if (isModified(value)) this.textNode.nodeValue = value;
+
+    if (isModified(value)) {
+      this.bounds.update(vm.dom, value);
+    }
   }
 
   toJSON(): OpcodeJSON {
@@ -69,6 +70,33 @@ export class UpdateAppendOpcode extends UpdatingContentOpcode {
     details["lastValue"] = JSON.stringify(this.cache.peek());
 
     return { guid, type, details };
+  }
+}
+
+export class AppendOpcode extends Opcode {
+  type = 'append';
+
+  evaluate(vm: VM) {
+    let reference = vm.frame.getOperand();
+
+    let mapped = map(reference, normalizeValue);
+    let cache = new ReferenceCache(mapped);
+    let value = cache.peek();
+
+    if (isConst(reference)) {
+      vm.stack().appendInsertion(value);
+    } else {
+      let bounds = vm.stack().appendInsertion(value);
+      vm.updateWith(new UpdatingContentOpcode<Insertion>('update-cautious-append', cache, bounds));
+    }
+  }
+
+  toJSON(): OpcodeJSON {
+    return {
+      guid: this._guid,
+      type: this.type,
+      args: ["$OPERAND"]
+    };
   }
 }
 
@@ -78,12 +106,13 @@ export class TrustingAppendOpcode extends Opcode {
   evaluate(vm: VM) {
     let reference = vm.frame.getOperand();
 
-    let mapped = map(reference, normalizeTextValue);
+    let mapped = map(reference, normalizeTrustedValue);
     let cache = new ReferenceCache(mapped);
-    let bounds = vm.stack().insertHTMLBefore(null, cache.peek());
+    let value = cache.peek();
+    let bounds = vm.stack().appendHTML(value);
 
     if (!isConst(reference)) {
-      vm.updateWith(new UpdateTrustingAppendOpcode(cache, bounds));
+      vm.updateWith(new UpdatingContentOpcode<TrustedInsertion>('update-trusting-append', cache, bounds));
     }
   }
 
@@ -93,37 +122,5 @@ export class TrustingAppendOpcode extends Opcode {
       type: this.type,
       args: ["$OPERAND"]
     };
-  }
-}
-
-export class UpdateTrustingAppendOpcode extends UpdatingContentOpcode {
-  type = 'update-trusting-append';
-  private cache: ReferenceCache<string>;
-  private bounds: Fragment;
-
-  constructor(cache: ReferenceCache<string>, bounds: Fragment) {
-    super();
-    this.cache = cache;
-    this.bounds = bounds;
-  }
-
-  evaluate(vm: UpdatingVM) {
-    let value = this.cache.revalidate();
-
-    if (isModified(value)) {
-      let parent = <HTMLElement>this.bounds.parentElement();
-      let nextSibling = clear(this.bounds);
-      this.bounds.update(vm.dom.insertHTMLBefore(parent, nextSibling, value));
-    }
-  }
-
-  toJSON(): OpcodeJSON {
-    let { _guid: guid, type } = this;
-
-    let details = dict<string>();
-
-    details["lastValue"] = JSON.stringify(this.cache.peek());
-
-    return { guid, type, details };
   }
 }

--- a/packages/glimmer-runtime/lib/dom.ts
+++ b/packages/glimmer-runtime/lib/dom.ts
@@ -1,4 +1,4 @@
-import { ConcreteBounds, Bounds } from './bounds';
+import { ConcreteBounds, SingleNodeBounds, Bounds } from './bounds';
 import applyTableElementFix from './compat/inner-html-fix';
 import applySVGElementFix from './compat/svg-inner-html-fix';
 
@@ -113,6 +113,12 @@ class DOMHelper {
 
     let first = prev ? prev.nextSibling : parent.firstChild;
     return new ConcreteBounds(parent, first, last);
+  }
+
+  insertTextBefore(parent: Element, nextSibling: Node, text: string): Text {
+    let textNode = this.createTextNode(text);
+    this.insertBefore(parent, textNode, nextSibling);
+    return textNode;
   }
 
   insertBefore(element: Element, node: Node, reference: Node) {

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -200,21 +200,30 @@ export abstract class Environment {
 
 export default Environment;
 
-// TS does not allow us to use computed properties for this, so inlining for now
-// import { TRUSTED_STRING } from './symbols';
+export interface SafeString {
+  toHTML(): string;
+}
 
-interface SafeString {
-  "trusted string [id=7d10c13d-cdf5-45f4-8859-b09ce16517c2]": boolean; // true
-  string: string;
+export function isSafeString(value: Opaque): value is SafeString {
+  return value && typeof value['toHTML'] === 'function';
+}
+
+export function isNode(value: Opaque): value is Node {
+  return value !== null && typeof value === 'object' && typeof value['nodeType'] === 'number';
+}
+
+export function isString(value: Opaque): value is string {
+  return typeof value === 'string';
 }
 
 export type Insertion = string | SafeString | Node;
+export type TrustedInsertion = string | Node;
 
 type PositionalArguments = Opaque[];
 type KeywordArguments = Dict<Opaque>;
 
 export interface Helper {
-  (args: EvaluatedArgs): PathReference<Opaque>;
+  (args: EvaluatedArgs): Reference<Opaque>;
 }
 
 export interface ParsedStatement {

--- a/packages/glimmer-runtime/lib/symbols.ts
+++ b/packages/glimmer-runtime/lib/symbols.ts
@@ -1,1 +1,0 @@
-export const TRUSTED_STRING = "trusted string [id=7d10c13d-cdf5-45f4-8859-b09ce16517c2]";

--- a/packages/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/glimmer-runtime/lib/syntax/core.ts
@@ -233,27 +233,6 @@ export class Append extends StatementSyntax {
   }
 }
 
-class HelperInvocationReference implements Reference<Insertion> {
-  private helper: EnvHelper;
-  private args: EvaluatedArgs;
-  public tag: RevisionTag;
-
-  constructor(helper: EnvHelper, args: EvaluatedArgs) {
-    this.helper = helper;
-    this.args = args;
-    this.tag = args.tag;
-  }
-
-  get(): PathReference<Opaque> {
-    throw new Error("Unimplemented: Yielding the result of a helper call.");
-  }
-
-  value(): Insertion {
-    let { args: { positional, named } }  = this;
-    return this.helper.call(undefined, positional.value(), named.value(), null);
-  }
-}
-
 /*
 export class Modifier implements StatementSyntax {
   static fromSpec(node) {
@@ -914,7 +893,7 @@ export class Helper extends ExpressionSyntax<Opaque> {
   compile(compiler: SymbolLookup, env: Environment): CompiledExpression<Opaque> {
     if (env.hasHelper(this.ref.parts)) {
       let { args, ref } = this;
-      return new CompiledHelper<Opaque>({ name: ref.parts, helper: env.lookupHelper(ref.parts), args: args.compile(compiler, env) });
+      return new CompiledHelper({ name: ref.parts, helper: env.lookupHelper(ref.parts), args: args.compile(compiler, env) });
     } else {
       throw new Error(`Compile Error: ${this.ref.prettyPrint()} is not a helper`);
     }

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -394,7 +394,7 @@ export class SimplePathReference<T> implements PathReference<T> {
 
 type UserHelper = (args: any[], named: Dict<any>) => any;
 
-class HelperReference implements PathReference<Opaque> {
+class HelperReference implements Reference<Opaque> {
   private helper: UserHelper;
   private args: EvaluatedArgs;
   public tag = VOLATILE_TAG;
@@ -408,10 +408,6 @@ class HelperReference implements PathReference<Opaque> {
     let { helper, args: { positional, named } } = this;
 
     return helper(positional.value(), named.value());
-  }
-
-  get(prop: InternedString): SimplePathReference<Opaque> {
-    return new SimplePathReference(this, prop);
   }
 }
 
@@ -428,6 +424,10 @@ export class TestEnvironment extends Environment {
 
   registerHelper(name: string, helper: UserHelper) {
     this.helpers[name] = (args: EvaluatedArgs) => new HelperReference(helper, args);
+  }
+
+  setHelper(name: string, helper: GlimmerHelper) {
+    this.helpers[name] = helper;
   }
 
   registerComponent(name: string, definition: ComponentDefinition<any>) {


### PR DESCRIPTION
This creates a new type of Append opcode that handles the value when it is a SafeString and also when it is a normal string. For SafeString it enters into "html" mode, and if the input changes into a normal string it switches into "text" mode. It can switch freely between the two modes and handles updates accordingly.

- The opcode also supports const expressions.
- New tests have been added which test the switching behavior of the opcode.
- Checked the code TypeScript errors (via `tslint` and `vscode-build`) and corrected them.

This change appears to fix #101 so I added a test that checks that case specifically.