### PR TITLE
Support meta for templates

### DIFF
--- a/packages/glimmer-compiler/lib/javascript-compiler.ts
+++ b/packages/glimmer-compiler/lib/javascript-compiler.ts
@@ -1,5 +1,5 @@
 import { assert } from "glimmer-util";
-import { Stack, DictSet, InternedString, dict } from "glimmer-util";
+import { Stack, DictSet, InternedString, dict, StatementMeta } from "glimmer-util";
 
 import {
   SerializedBlock,
@@ -32,11 +32,16 @@ export class Block {
 }
 
 export class Template extends Block {
-  public meta: Object = null;
+  public meta: StatementMeta = null;
 
   public yields = new DictSet();
   public named = new DictSet();
   public blocks: Block[] = [];
+
+  constructor(meta) {
+    super();
+    this.meta = meta;
+  }
 
   toJSON(): SerializedTemplate {
     return {
@@ -45,14 +50,14 @@ export class Template extends Block {
       named: this.named.toArray(),
       yields: this.yields.toArray(),
       blocks: this.blocks.map(b => b.toJSON()),
-      meta: null
+      meta: this.meta
     };
   }
 }
 
 export default class JavaScriptCompiler {
-  static process(opcodes): Template {
-    let compiler = new JavaScriptCompiler(opcodes);
+  static process(opcodes, options): Template {
+    let compiler = new JavaScriptCompiler(opcodes, options);
     return compiler.process();
   }
 
@@ -61,9 +66,12 @@ export default class JavaScriptCompiler {
   private opcodes: any[];
   private values: StackValue[] = [];
 
-  constructor(opcodes) {
+  constructor(opcodes, { moduleName }) {
+    let meta = {
+      moduleName
+    };
     this.opcodes = opcodes;
-    this.template = new Template();
+    this.template = new Template(meta);
   }
 
   process() {

--- a/packages/glimmer-compiler/lib/template-compiler.ts
+++ b/packages/glimmer-compiler/lib/template-compiler.ts
@@ -11,7 +11,7 @@ export default class TemplateCompiler {
 
     let compiler = new TemplateCompiler(options);
     let opcodes = compiler.process(templateVisitor.actions);
-    return JavaScriptCompiler.process(opcodes);
+    return JavaScriptCompiler.process(opcodes, options);
   }
 
   private options: Object;

--- a/packages/glimmer-compiler/tests/compile-options-test.ts
+++ b/packages/glimmer-compiler/tests/compile-options-test.ts
@@ -1,0 +1,19 @@
+import { compile } from "glimmer-test-helpers";
+import { TestEnvironment } from "glimmer-test-helpers";
+
+let env: TestEnvironment;
+
+QUnit.module('Compile options', {
+  setup() {
+    env = new TestEnvironment();
+  }
+});
+
+QUnit.test('moduleName option is passed into meta', function() {
+  let moduleName = 'It ain\'t hard to tell';
+  let template = compile('Hi, {{name}}!', {
+    env,
+    moduleName
+  });
+  equal(template.raw.meta.moduleName, moduleName, 'Template has the moduleName');
+});

--- a/packages/glimmer-object/lib/object.ts
+++ b/packages/glimmer-object/lib/object.ts
@@ -375,6 +375,7 @@ export default class GlimmerObject {
   _super = ROOT;
   _meta = null;
   _guid: number;
+  moduleName: String;
 
   init() {}
 

--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -18,6 +18,7 @@ export { ConditionalReference, NULL_REFERENCE, UNDEFINED_REFERENCE } from './lib
 export {
   Templates,
   Append,
+  Text,
   Unknown,
   StaticAttr,
   DynamicAttr,

--- a/packages/glimmer-runtime/lib/compiled/blocks.ts
+++ b/packages/glimmer-runtime/lib/compiled/blocks.ts
@@ -1,4 +1,4 @@
-import { InternedString } from 'glimmer-util';
+import { InternedString, StatementMeta } from 'glimmer-util';
 import { OpSeq } from '../opcodes';
 import { Program } from '../syntax';
 import { Environment } from '../environment';
@@ -13,6 +13,7 @@ export interface BlockOptions {
   children: InlineBlock[];
   program: Program;
   symbolTable: SymbolTable;
+  meta: StatementMeta;
 }
 
 export class CompiledBlock {
@@ -29,12 +30,14 @@ export abstract class Block {
   public children: InlineBlock[];
   public program: Program;
   public symbolTable: SymbolTable;
+  public meta: StatementMeta = null;
   protected compiled: CompiledBlock = null;
 
   constructor(options: BlockOptions) {
     this.symbolTable = options.symbolTable || null;
     this.children = options.children;
     this.program = options.program;
+    this.meta = options.meta;
   }
 }
 

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -31,6 +31,8 @@ import {
 
 import { EvaluatedArgs } from './compiled/expressions/args';
 
+import SymbolTable from './symbol-table';
+
 import { InlineBlock } from './compiled/blocks';
 
 import { Destroyable, Dict, Opaque } from 'glimmer-util';
@@ -130,11 +132,11 @@ export abstract class Environment {
     return intern(ensureGuid(object) + '');
   }
 
-  statement(statement: StatementSyntax): StatementSyntax {
-    return this.refineStatement(parseStatement(statement)) || statement;
+  statement(statement: StatementSyntax, symbolTable: SymbolTable): StatementSyntax {
+    return this.refineStatement(parseStatement(statement), symbolTable) || statement;
   }
 
-  protected refineStatement(statement: ParsedStatement): StatementSyntax {
+  protected refineStatement(statement: ParsedStatement, symbolTable?: SymbolTable): StatementSyntax {
     let {
       isSimple,
       isBlock,

--- a/packages/glimmer-runtime/lib/symbol-table.ts
+++ b/packages/glimmer-runtime/lib/symbol-table.ts
@@ -1,4 +1,4 @@
-import { InternedString, dict } from 'glimmer-util';
+import { InternedString, dict, StatementMeta } from 'glimmer-util';
 import { Block, InlineBlock, Layout, EntryPoint } from './compiled/blocks';
 
 export default class SymbolTable {
@@ -14,9 +14,11 @@ export default class SymbolTable {
     return block.symbolTable = new SymbolTable(parent, block).initBlock(block);
   }
 
+  private moduleName: String;
   private parent: SymbolTable;
   private top: SymbolTable;
   private template: Block;
+  private meta: StatementMeta;
   private locals   = dict<number>();
   private named    = dict<number>();
   private yields   = dict<number>();
@@ -26,6 +28,14 @@ export default class SymbolTable {
     this.parent = parent;
     this.top = parent ? parent.top : this;
     this.template = template;
+  }
+
+  setMeta(meta) {
+    this.meta = meta;
+  }
+
+  getModuleName() {
+    return this.meta.moduleName;
   }
 
   initEntryPoint(_: any): this {

--- a/packages/glimmer-runtime/lib/template.ts
+++ b/packages/glimmer-runtime/lib/template.ts
@@ -5,6 +5,7 @@ import { Environment, DynamicScope } from './environment';
 import { ElementStack } from './builder';
 import { VM } from './vm';
 import Scanner from './scanner';
+import { StatementMeta } from 'glimmer-util';
 
 interface TemplateOptions {
   raw: EntryPoint;
@@ -33,7 +34,7 @@ export default class Template {
   }
 
   raw: EntryPoint;
-  meta: Object;
+  meta: StatementMeta;
 
   constructor({ raw }: TemplateOptions) {
     this.raw = raw;

--- a/packages/glimmer-test-helpers/index.ts
+++ b/packages/glimmer-test-helpers/index.ts
@@ -10,7 +10,8 @@ export {
   isCheckedInputHTML,
   getTextContent,
   strip,
-  stripTight
+  stripTight,
+  CompileOptions
 } from './lib/helpers';
 
 export {
@@ -24,5 +25,6 @@ export {
   equalsElement,
   inspectHooks,
   regex,
-  classes
+  classes,
+  EnvironmentCompileOptions
 } from './lib/environment';

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -54,7 +54,8 @@ import {
 
   // Misc
   ElementOperations,
-  FunctionExpression
+  FunctionExpression,
+  SymbolTable
 } from "glimmer-runtime";
 
 import {
@@ -618,6 +619,10 @@ export class TestModifierManager implements ModifierManager<TestModifier> {
   }
 }
 
+export interface EnvironmentCompileOptions {
+  moduleName?: string
+}
+
 export class TestEnvironment extends Environment {
   private helpers = dict<GlimmerHelper>();
   private modifiers = dict<ModifierManager<Opaque>>();
@@ -681,7 +686,7 @@ export class TestEnvironment extends Environment {
     return new EmberishConditionalReference(reference);
   }
 
-  refineStatement(statement: ParsedStatement): StatementSyntax {
+  refineStatement(statement: ParsedStatement, symbolTable: SymbolTable): StatementSyntax {
     let {
       isSimple,
       isBlock,
@@ -767,8 +772,11 @@ export class TestEnvironment extends Environment {
     return modifier;
   }
 
-  compile(template: string) {
-    return rawCompile(template, { env: this });
+  compile(template: string, options?: EnvironmentCompileOptions) {
+    let moduleName = (options && options.moduleName) || '-top-level';
+    let rawOptions = { env: this, moduleName};
+
+    return rawCompile(template, rawOptions);
   }
 
   compileLayout(template: string) {

--- a/packages/glimmer-test-helpers/lib/helpers.ts
+++ b/packages/glimmer-test-helpers/lib/helpers.ts
@@ -19,9 +19,10 @@ function isMarker(node) {
   return false;
 }
 
-interface CompileOptions {
+export interface CompileOptions {
   buildMeta?: FIXME<'currently does nothing'>;
   env: Environment;
+  moduleName?: String;
 }
 
 export function compileRealSpec(string: string, options: CompileOptions): SerializedTemplate {

--- a/packages/glimmer-util/index.ts
+++ b/packages/glimmer-util/index.ts
@@ -22,3 +22,7 @@ export { Stack, Dict, DictWithNumberKeys, Set, DictSet, dict } from './lib/colle
 export { EMPTY_SLICE, LinkedList, LinkedListNode, ListNode, CloneableListNode, ListSlice, Slice } from './lib/list-utils';
 
 export type FIXME<T> = any;
+
+export interface StatementMeta {
+  moduleName?: String
+};

--- a/packages/glimmer-wire-format/index.ts
+++ b/packages/glimmer-wire-format/index.ts
@@ -1,4 +1,4 @@
-import { Dict, InternedString } from 'glimmer-util';
+import { Dict, InternedString, StatementMeta } from 'glimmer-util';
 
 type JsonValue =
     string
@@ -134,7 +134,7 @@ export interface SerializedTemplate {
   named: InternedString[];
   yields: InternedString[];
   blocks: SerializedBlock[];
-  meta: Object;
+  meta: StatementMeta;
 }
 
 export interface SerializedBlock {


### PR DESCRIPTION
Specifically support adding a moduleName to templates, which is turn passed back into [refineStatement](https://github.com/emberjs/ember.js/blob/master/packages/ember-glimmer/lib/environment.js#L50). Something like this is needed to support local lookup.