### PR TITLE
#139 + Upsert refactor

### DIFF
--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -130,13 +130,14 @@ export {
 
 export { PublicVM as VM, UpdatingVM, RenderResult } from './lib/vm';
 
+export { SafeString } from './lib/upsert';
+
 export {
   Scope,
   default as Environment,
   Helper,
   ParsedStatement,
   DynamicScope,
-  SafeString
 } from './lib/environment';
 
 export {

--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -135,7 +135,8 @@ export {
   default as Environment,
   Helper,
   ParsedStatement,
-  DynamicScope
+  DynamicScope,
+  SafeString
 } from './lib/environment';
 
 export {

--- a/packages/glimmer-runtime/lib/bounds.ts
+++ b/packages/glimmer-runtime/lib/bounds.ts
@@ -5,6 +5,10 @@ export interface Bounds {
   lastNode(): Node;
 }
 
+export class Cursor {
+  constructor(public element: Element, public nextSibling: Node) {}
+}
+
 export default Bounds;
 
 export class ConcreteBounds implements Bounds {
@@ -62,7 +66,7 @@ export function move(bounds: Bounds, reference: Node) {
   return null;
 }
 
-export function clear(bounds: Bounds) {
+export function clear(bounds: Bounds): Node {
   let parent = bounds.parentElement();
   let first = bounds.firstNode();
   let last = bounds.lastNode();

--- a/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
@@ -1,11 +1,11 @@
 import { CompiledExpression } from '../expressions';
 import { CompiledArgs } from './args';
 import VM from '../../vm/append';
-import { Helper } from '../../environment';
+import { Helper, Insertion } from '../../environment';
 import { PathReference } from 'glimmer-reference';
-import { Opaque, InternedString } from 'glimmer-util';
+import { InternedString } from 'glimmer-util';
 
-export default class CompiledHelper<T> extends CompiledExpression<T> {
+export default class CompiledHelper extends CompiledExpression<Insertion> {
   public type = "helper";
   public name: InternedString[];
   public helper: Helper;
@@ -18,7 +18,7 @@ export default class CompiledHelper<T> extends CompiledExpression<T> {
     this.args = args;
   }
 
-  evaluate(vm: VM): PathReference<T> {
+  evaluate(vm: VM): PathReference<Insertion> {
     return this.helper.call(undefined, this.args.evaluate(vm));
   }
 

--- a/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
@@ -19,7 +19,8 @@ export default class CompiledHelper extends CompiledExpression<Opaque> {
   }
 
   evaluate(vm: VM): PathReference<Opaque> {
-    return this.helper.call(undefined, this.args.evaluate(vm));
+    let { helper } = this;
+    return helper(this.args.evaluate(vm));
   }
 
   toJSON(): string {

--- a/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
@@ -1,11 +1,11 @@
 import { CompiledExpression } from '../expressions';
 import { CompiledArgs } from './args';
 import VM from '../../vm/append';
-import { Helper, Insertion } from '../../environment';
+import { Helper } from '../../environment';
 import { PathReference } from 'glimmer-reference';
-import { InternedString } from 'glimmer-util';
+import { InternedString, Opaque } from 'glimmer-util';
 
-export default class CompiledHelper extends CompiledExpression<Insertion> {
+export default class CompiledHelper extends CompiledExpression<Opaque> {
   public type = "helper";
   public name: InternedString[];
   public helper: Helper;
@@ -18,7 +18,7 @@ export default class CompiledHelper extends CompiledExpression<Insertion> {
     this.args = args;
   }
 
-  evaluate(vm: VM): PathReference<Insertion> {
+  evaluate(vm: VM): PathReference<Opaque> {
     return this.helper.call(undefined, this.args.evaluate(vm));
   }
 

--- a/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
@@ -2,63 +2,64 @@ import { Opcode, OpcodeJSON, UpdatingOpcode } from '../../opcodes';
 import { VM, UpdatingVM } from '../../vm';
 import { ReferenceCache, isModified, isConst, map } from 'glimmer-reference';
 import { Opaque, dict } from 'glimmer-util';
-import { clear } from '../../bounds';
-import { Fragment } from '../../builder';
+import { Bounds, clear, SingleNodeBounds } from '../../bounds';
+import { FragmentBounds } from '../../builder';
+import { Insertion, TrustedInsertion, SafeString, isSafeString, isNode, isString } from '../../environment';
 
-export function normalizeTextValue(value: Opaque): string {
-  if (value === null || value === undefined || typeof value['toString'] !== 'function') {
-    return '';
-  } else {
-    return String(value);
-  }
+function isEmpty(value: Opaque): boolean {
+  return value === null || value === undefined || typeof value['toString'] !== 'function';
 }
 
-abstract class UpdatingContentOpcode extends UpdatingOpcode {
-  public type: string;
+export function normalizeTextValue(value: Opaque): string {
+  if (isEmpty(value)) {
+    return '';
+  }
+  return String(value);
+}
+
+export function normalizeTrustedValue(value: Opaque): TrustedInsertion {
+  if (isEmpty(value)) {
+    return '';
+  }
+  if (isString(value)) {
+    return value;
+  }
+  if (isSafeString(value)) {
+    return value.toHTML();
+  }
+  if (isNode(value)) {
+    return value;
+  }
+  return String(value);
+}
+
+export function normalizeValue(value: Opaque): Insertion {
+  if (isEmpty(value)) {
+    return '';
+  }
+  if (isString(value)) {
+    return value;
+  }
+  if (isSafeString(value) || isNode(value)) {
+    return value;
+  }
+  return String(value);
+}
+
+class UpdatingContentOpcode<T> extends UpdatingOpcode {
   public next = null;
   public prev = null;
 
-  abstract evaluate(vm: UpdatingVM);
-}
-
-export class AppendOpcode extends Opcode {
-  type = 'append';
-
-  evaluate(vm: VM) {
-    let reference = vm.frame.getOperand();
-
-    let mapped = map(reference, normalizeTextValue);
-    let cache = new ReferenceCache(mapped);
-    let node = vm.stack().appendText(cache.peek());
-
-    if (!isConst(reference)) {
-      vm.updateWith(new UpdateAppendOpcode(cache, node));
-    }
-  }
-
-  toJSON(): OpcodeJSON {
-    return {
-      guid: this._guid,
-      type: this.type,
-      args: ["$OPERAND"]
-    };
-  }
-}
-
-export class UpdateAppendOpcode extends UpdatingContentOpcode {
-  type = 'update-append';
-  private cache: ReferenceCache<string>;
-  private textNode: Text;
-
-  constructor(cache: ReferenceCache<string>, textNode: Text) {
+  constructor(public type: string, private cache: ReferenceCache<T>, private bounds: FragmentBounds<T>) {
     super();
-    this.cache = cache;
-    this.textNode = textNode;
   }
 
-  evaluate() {
+  evaluate(vm: UpdatingVM) {
     let value = this.cache.revalidate();
-    if (isModified(value)) this.textNode.nodeValue = value;
+
+    if (isModified(value)) {
+      this.bounds.update(vm.dom, value);
+    }
   }
 
   toJSON(): OpcodeJSON {
@@ -69,6 +70,33 @@ export class UpdateAppendOpcode extends UpdatingContentOpcode {
     details["lastValue"] = JSON.stringify(this.cache.peek());
 
     return { guid, type, details };
+  }
+}
+
+export class AppendOpcode extends Opcode {
+  type = 'append';
+
+  evaluate(vm: VM) {
+    let reference = vm.frame.getOperand();
+
+    let mapped = map(reference, normalizeValue);
+    let cache = new ReferenceCache(mapped);
+    let value = cache.peek();
+
+    if (isConst(reference)) {
+      vm.stack().appendInsertion(value);
+    } else {
+      let bounds = vm.stack().appendInsertion(value);
+      vm.updateWith(new UpdatingContentOpcode<Insertion>('update-cautious-append', cache, bounds));
+    }
+  }
+
+  toJSON(): OpcodeJSON {
+    return {
+      guid: this._guid,
+      type: this.type,
+      args: ["$OPERAND"]
+    };
   }
 }
 
@@ -78,12 +106,13 @@ export class TrustingAppendOpcode extends Opcode {
   evaluate(vm: VM) {
     let reference = vm.frame.getOperand();
 
-    let mapped = map(reference, normalizeTextValue);
+    let mapped = map(reference, normalizeTrustedValue);
     let cache = new ReferenceCache(mapped);
-    let bounds = vm.stack().insertHTMLBefore(null, cache.peek());
+    let value = cache.peek();
+    let bounds = vm.stack().appendHTML(value);
 
     if (!isConst(reference)) {
-      vm.updateWith(new UpdateTrustingAppendOpcode(cache, bounds));
+      vm.updateWith(new UpdatingContentOpcode<TrustedInsertion>('update-trusting-append', cache, bounds));
     }
   }
 
@@ -93,37 +122,5 @@ export class TrustingAppendOpcode extends Opcode {
       type: this.type,
       args: ["$OPERAND"]
     };
-  }
-}
-
-export class UpdateTrustingAppendOpcode extends UpdatingContentOpcode {
-  type = 'update-trusting-append';
-  private cache: ReferenceCache<string>;
-  private bounds: Fragment;
-
-  constructor(cache: ReferenceCache<string>, bounds: Fragment) {
-    super();
-    this.cache = cache;
-    this.bounds = bounds;
-  }
-
-  evaluate(vm: UpdatingVM) {
-    let value = this.cache.revalidate();
-
-    if (isModified(value)) {
-      let parent = <HTMLElement>this.bounds.parentElement();
-      let nextSibling = clear(this.bounds);
-      this.bounds.update(vm.dom.insertHTMLBefore(parent, nextSibling, value));
-    }
-  }
-
-  toJSON(): OpcodeJSON {
-    let { _guid: guid, type } = this;
-
-    let details = dict<string>();
-
-    details["lastValue"] = JSON.stringify(this.cache.peek());
-
-    return { guid, type, details };
   }
 }

--- a/packages/glimmer-runtime/lib/dom.ts
+++ b/packages/glimmer-runtime/lib/dom.ts
@@ -115,6 +115,17 @@ class DOMHelper {
     return new ConcreteBounds(parent, first, last);
   }
 
+  insertNodeBefore(parent: Element, node: Node, reference: Node): Bounds {
+    if (isDocumentFragment(node)) {
+      let { firstChild, lastChild } = node;
+      this.insertBefore(parent, node, reference);
+      return new ConcreteBounds(parent, firstChild, lastChild);
+    } else {
+      this.insertBefore(parent, node, reference);
+      return new SingleNodeBounds(parent, node);
+    }
+  }
+
   insertTextBefore(parent: Element, nextSibling: Node, text: string): Text {
     let textNode = this.createTextNode(text);
     this.insertBefore(parent, textNode, nextSibling);
@@ -128,6 +139,10 @@ class DOMHelper {
   insertAfter(element: Element, node: Node, reference: Node) {
     this.insertBefore(element, node, reference.nextSibling);
   }
+}
+
+function isDocumentFragment(node: Node): node is DocumentFragment {
+  return node.nodeType === Node.DOCUMENT_FRAGMENT_NODE;
 }
 
 let helper = DOMHelper;

--- a/packages/glimmer-runtime/lib/dom.ts
+++ b/packages/glimmer-runtime/lib/dom.ts
@@ -1,4 +1,4 @@
-import { ConcreteBounds, Bounds } from './bounds';
+import { ConcreteBounds, SingleNodeBounds, Bounds } from './bounds';
 import applyTableElementFix from './compat/inner-html-fix';
 import applySVGElementFix from './compat/svg-inner-html-fix';
 
@@ -113,6 +113,12 @@ class DOMHelper {
 
     let first = prev ? prev.nextSibling : parent.firstChild;
     return new ConcreteBounds(parent, first, last);
+  }
+
+  insertTextBefore(parent: Element, nextSibling: Node, text: string): Text {
+    let textNode = this.createTextNode(text);
+    this.insertBefore(parent, textNode, nextSibling);
+    return textNode;
   }
 
   insertBefore(element: Element, node: Node, reference: Node) {

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -200,21 +200,30 @@ export abstract class Environment {
 
 export default Environment;
 
-// TS does not allow us to use computed properties for this, so inlining for now
-// import { TRUSTED_STRING } from './symbols';
+export interface SafeString {
+  toHTML(): string;
+}
 
-interface SafeString {
-  "trusted string [id=7d10c13d-cdf5-45f4-8859-b09ce16517c2]": boolean; // true
-  string: string;
+export function isSafeString(value: Opaque): value is SafeString {
+  return value && typeof value['toHTML'] === 'function';
+}
+
+export function isNode(value: Opaque): value is Node {
+  return value !== null && typeof value === 'object' && typeof value['nodeType'] === 'number';
+}
+
+export function isString(value: Opaque): value is string {
+  return typeof value === 'string';
 }
 
 export type Insertion = string | SafeString | Node;
+export type TrustedInsertion = string | Node;
 
 type PositionalArguments = Opaque[];
 type KeywordArguments = Dict<Opaque>;
 
 export interface Helper {
-  (args: EvaluatedArgs): PathReference<Opaque>;
+  (args: EvaluatedArgs): Reference<Opaque>;
 }
 
 export interface ParsedStatement {

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -200,25 +200,6 @@ export abstract class Environment {
 
 export default Environment;
 
-export interface SafeString {
-  toHTML(): string;
-}
-
-export function isSafeString(value: Opaque): value is SafeString {
-  return value && typeof value['toHTML'] === 'function';
-}
-
-export function isNode(value: Opaque): value is Node {
-  return value !== null && typeof value === 'object' && typeof value['nodeType'] === 'number';
-}
-
-export function isString(value: Opaque): value is string {
-  return typeof value === 'string';
-}
-
-export type Insertion = string | SafeString | Node;
-export type TrustedInsertion = string | Node;
-
 type PositionalArguments = Opaque[];
 type KeywordArguments = Dict<Opaque>;
 

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -204,7 +204,7 @@ type PositionalArguments = Opaque[];
 type KeywordArguments = Dict<Opaque>;
 
 export interface Helper {
-  (args: EvaluatedArgs): Reference<Opaque>;
+  (args: EvaluatedArgs): PathReference<Opaque>;
 }
 
 export interface ParsedStatement {

--- a/packages/glimmer-runtime/lib/symbols.ts
+++ b/packages/glimmer-runtime/lib/symbols.ts
@@ -1,1 +1,0 @@
-export const TRUSTED_STRING = "trusted string [id=7d10c13d-cdf5-45f4-8859-b09ce16517c2]";

--- a/packages/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/glimmer-runtime/lib/syntax/core.ts
@@ -37,7 +37,6 @@ import {
   CompiledArgs,
   CompiledNamedArgs,
   CompiledPositionalArgs,
-  EvaluatedArgs
 } from '../compiled/expressions/args';
 
 import CompiledValue from '../compiled/expressions/value';
@@ -60,13 +59,7 @@ import {
   CompiledExpression
 } from '../compiled/expressions';
 
-import {
-  RevisionTag,
-  PathReference,
-  Reference
-} from 'glimmer-reference';
-
-import { Environment, Insertion, Helper as EnvHelper } from '../environment';
+import { Environment } from '../environment';
 
 import {
   Opaque,
@@ -88,7 +81,7 @@ import {
 } from '../compiled/opcodes/dom';
 
 import {
-  AppendOpcode,
+  CautiousAppendOpcode,
   TrustingAppendOpcode
 } from '../compiled/opcodes/content';
 
@@ -97,12 +90,6 @@ import {
   Expressions as SerializedExpressions,
   Core as SerializedCore
 } from 'glimmer-wire-format';
-
-interface Bounds {
-  parentNode(): Node;
-  firstNode(): Node;
-  lastNode(): Node;
-}
 
 export interface BlockOptions {
 
@@ -180,7 +167,7 @@ export class Unknown extends ExpressionSyntax<any> {
     this.trustingMorph = !!options.unsafe;
   }
 
-  compile(compiler: SymbolLookup, env: Environment): CompiledExpression<any> {
+  compile(compiler: SymbolLookup, env: Environment): CompiledExpression<Opaque> {
     let { ref } = this;
 
     if (env.hasHelper(ref.parts)) {
@@ -228,7 +215,7 @@ export class Append extends StatementSyntax {
     if (this.trustingMorph) {
       compiler.append(new TrustingAppendOpcode());
     } else {
-      compiler.append(new AppendOpcode());
+      compiler.append(new CautiousAppendOpcode());
     }
   }
 }

--- a/packages/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/glimmer-runtime/lib/syntax/core.ts
@@ -233,27 +233,6 @@ export class Append extends StatementSyntax {
   }
 }
 
-class HelperInvocationReference implements Reference<Insertion> {
-  private helper: EnvHelper;
-  private args: EvaluatedArgs;
-  public tag: RevisionTag;
-
-  constructor(helper: EnvHelper, args: EvaluatedArgs) {
-    this.helper = helper;
-    this.args = args;
-    this.tag = args.tag;
-  }
-
-  get(): PathReference<Opaque> {
-    throw new Error("Unimplemented: Yielding the result of a helper call.");
-  }
-
-  value(): Insertion {
-    let { args: { positional, named } }  = this;
-    return this.helper.call(undefined, positional.value(), named.value(), null);
-  }
-}
-
 /*
 export class Modifier implements StatementSyntax {
   static fromSpec(node) {
@@ -914,7 +893,7 @@ export class Helper extends ExpressionSyntax<Opaque> {
   compile(compiler: SymbolLookup, env: Environment): CompiledExpression<Opaque> {
     if (env.hasHelper(this.ref.parts)) {
       let { args, ref } = this;
-      return new CompiledHelper<Opaque>({ name: ref.parts, helper: env.lookupHelper(ref.parts), args: args.compile(compiler, env) });
+      return new CompiledHelper({ name: ref.parts, helper: env.lookupHelper(ref.parts), args: args.compile(compiler, env) });
     } else {
       throw new Error(`Compile Error: ${this.ref.prettyPrint()} is not a helper`);
     }

--- a/packages/glimmer-runtime/lib/upsert.ts
+++ b/packages/glimmer-runtime/lib/upsert.ts
@@ -1,0 +1,152 @@
+import { Opaque } from 'glimmer-util';
+import { DOMHelper } from './dom';
+import { Bounds, Cursor, SingleNodeBounds, clear } from './bounds';
+
+export interface SafeString {
+  toHTML(): string;
+}
+
+export function isSafeString(value: Opaque): value is SafeString {
+  return value && typeof value['toHTML'] === 'function';
+}
+
+export function isNode(value: Opaque): value is Node {
+  return value !== null && typeof value === 'object' && typeof value['nodeType'] === 'number';
+}
+
+export function isString(value: Opaque): value is string {
+  return typeof value === 'string';
+}
+
+export type Insertion = CautiousInsertion | TrustingInsertion;
+export type CautiousInsertion = string | SafeString | Node;
+export type TrustingInsertion = string | Node;
+
+abstract class Upsert {
+  constructor(public bounds: Bounds) {
+  }
+
+  abstract update(dom: DOMHelper, value: Insertion): boolean;
+}
+
+export default Upsert;
+
+ export function cautiousInsert(dom: DOMHelper, cursor: Cursor, value: CautiousInsertion): Upsert {
+  if (isString(value)) {
+    return TextUpsert.insert(dom, cursor, value);
+  }
+  if (isSafeString(value)) {
+    return SafeStringUpsert.insert(dom, cursor, value);
+  }
+  if (isNode(value)) {
+    return NodeUpsert.insert(dom, cursor, value);
+  }
+}
+
+export function trustingInsert(dom: DOMHelper, cursor: Cursor, value: TrustingInsertion): Upsert {
+  if (isString(value)) {
+    return HTMLUpsert.insert(dom, cursor, value);
+  }
+  if (isNode(value)) {
+    return NodeUpsert.insert(dom, cursor, value);
+  }
+}
+
+class TextUpsert extends Upsert {
+  static insert(dom: DOMHelper, cursor: Cursor, value: string): Upsert {
+    let textNode = dom.insertTextBefore(cursor.element, cursor.nextSibling, value);
+    let bounds = new SingleNodeBounds(cursor.element, textNode);
+    return new TextUpsert(bounds, textNode);
+  }
+
+  constructor(bounds: Bounds, private textNode: Text) {
+    super(bounds);
+  }
+
+  update(dom: DOMHelper, value: Insertion): boolean {
+    if (isString(value)) {
+      let { textNode } = this;
+      textNode.nodeValue = value;
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+class HTMLUpsert extends Upsert {
+  static insert(dom: DOMHelper, cursor: Cursor, value: string): Upsert {
+    let bounds = dom.insertHTMLBefore(cursor.element, cursor.nextSibling, value);
+    return new HTMLUpsert(bounds);
+  }
+
+  update(dom: DOMHelper, value: Insertion): boolean {
+    if (isString(value)) {
+      let { bounds } = this;
+
+      let parentElement = bounds.parentElement();
+      let nextSibling = clear(bounds);
+
+      this.bounds = dom.insertHTMLBefore(parentElement, nextSibling, value);
+
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+class SafeStringUpsert extends Upsert {
+  static insert(dom: DOMHelper, cursor: Cursor, value: SafeString): Upsert {
+    let stringValue = value.toHTML();
+    let bounds = dom.insertHTMLBefore(cursor.element, cursor.nextSibling, stringValue);
+    return new SafeStringUpsert(bounds, stringValue);
+  }
+
+  constructor(bounds: Bounds, private lastStringValue: string) {
+    super(bounds);
+  }
+
+  update(dom: DOMHelper, value: Insertion): boolean {
+    if (isSafeString(value)) {
+      let stringValue = value.toHTML();
+
+      if (stringValue !== this.lastStringValue) {
+        let { bounds } = this;
+
+        let parentElement = bounds.parentElement();
+        let nextSibling = clear(bounds);
+
+        this.bounds = dom.insertHTMLBefore(parentElement, nextSibling, stringValue);
+        this.lastStringValue = stringValue;
+      }
+
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+class NodeUpsert extends Upsert {
+  static insert(dom: DOMHelper, cursor: Cursor, node: Node): Upsert {
+    let bounds = dom.insertNodeBefore(cursor.element, node, cursor.nextSibling);
+    return new NodeUpsert(bounds);
+  }
+
+  update(dom: DOMHelper, value: Insertion): boolean {
+    if (isNode(value)) {
+      let { bounds } = this;
+
+      let parentElement = bounds.parentElement();
+      let nextSibling = clear(bounds);
+
+      this.bounds = dom.insertNodeBefore(parentElement, value, nextSibling);
+
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+

--- a/packages/glimmer-runtime/tests/updating-test.ts
+++ b/packages/glimmer-runtime/tests/updating-test.ts
@@ -1,6 +1,6 @@
-import { EvaluatedArgs, Template, RenderResult, SafeString } from "glimmer-runtime";
+import { EvaluatedArgs, Template, RenderResult, SafeString, ValueReference } from "glimmer-runtime";
 import { TestEnvironment, TestDynamicScope, equalTokens, stripTight } from "glimmer-test-helpers";
-import { PathReference, ConstReference } from "glimmer-reference";
+import { PathReference } from "glimmer-reference";
 import { UpdatableReference } from "glimmer-object-reference";
 import { Opaque } from "glimmer-util";
 
@@ -409,8 +409,8 @@ test("triple curlies with empty string initial value", assert => {
 test("double curlies with const SafeString", assert => {
   let rawString = '<b>bold</b> and spicy';
 
-  env.setHelper('const-foobar', (args: EvaluatedArgs) => {
-    return new ConstReference<Opaque>(makeSafeString(rawString));
+  env.registerInternalHelper('const-foobar', (args: EvaluatedArgs) => {
+    return new ValueReference<Opaque>(makeSafeString(rawString));
   });
 
   let template = compile('<div>{{const-foobar}}</div>');
@@ -430,8 +430,8 @@ test("double curlies with const SafeString", assert => {
 test("double curlies with const Node", assert => {
   let rawString = '<b>bold</b> and spicy';
 
-  env.setHelper('const-foobar', (args: EvaluatedArgs) => {
-    return new ConstReference<Opaque>(document.createTextNode(rawString));
+  env.registerInternalHelper('const-foobar', (args: EvaluatedArgs) => {
+    return new ValueReference<Opaque>(document.createTextNode(rawString));
   });
 
   let template = compile('<div>{{const-foobar}}</div>');
@@ -451,8 +451,8 @@ test("double curlies with const Node", assert => {
 test("triple curlies with const SafeString", assert => {
   let rawString = '<b>bold</b> and spicy';
 
-  env.setHelper('const-foobar', (args: EvaluatedArgs) => {
-    return new ConstReference<Opaque>(makeSafeString(rawString));
+  env.registerInternalHelper('const-foobar', (args: EvaluatedArgs) => {
+    return new ValueReference<Opaque>(makeSafeString(rawString));
   });
 
   let template = compile('<div>{{{const-foobar}}}</div>');
@@ -472,8 +472,8 @@ test("triple curlies with const SafeString", assert => {
 test("triple curlies with const Node", assert => {
   let rawString = '<b>bold</b> and spicy';
 
-  env.setHelper('const-foobar', (args: EvaluatedArgs) => {
-    return new ConstReference<Opaque>(document.createTextNode(rawString));
+  env.registerInternalHelper('const-foobar', (args: EvaluatedArgs) => {
+    return new ValueReference<Opaque>(document.createTextNode(rawString));
   });
 
   let template = compile('<div>{{{const-foobar}}}</div>');

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -394,7 +394,7 @@ export class SimplePathReference<T> implements PathReference<T> {
 
 type UserHelper = (args: any[], named: Dict<any>) => any;
 
-class HelperReference implements PathReference<Opaque> {
+class HelperReference implements Reference<Opaque> {
   private helper: UserHelper;
   private args: EvaluatedArgs;
   public tag = VOLATILE_TAG;
@@ -408,10 +408,6 @@ class HelperReference implements PathReference<Opaque> {
     let { helper, args: { positional, named } } = this;
 
     return helper(positional.value(), named.value());
-  }
-
-  get(prop: InternedString): SimplePathReference<Opaque> {
-    return new SimplePathReference(this, prop);
   }
 }
 
@@ -428,6 +424,10 @@ export class TestEnvironment extends Environment {
 
   registerHelper(name: string, helper: UserHelper) {
     this.helpers[name] = (args: EvaluatedArgs) => new HelperReference(helper, args);
+  }
+
+  setHelper(name: string, helper: GlimmerHelper) {
+    this.helpers[name] = helper;
   }
 
   registerComponent(name: string, definition: ComponentDefinition<any>) {

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -394,7 +394,7 @@ export class SimplePathReference<T> implements PathReference<T> {
 
 type UserHelper = (args: any[], named: Dict<any>) => any;
 
-class HelperReference implements Reference<Opaque> {
+class HelperReference implements PathReference<Opaque> {
   private helper: UserHelper;
   private args: EvaluatedArgs;
   public tag = VOLATILE_TAG;
@@ -408,6 +408,10 @@ class HelperReference implements Reference<Opaque> {
     let { helper, args: { positional, named } } = this;
 
     return helper(positional.value(), named.value());
+  }
+
+  get(prop: InternedString): SimplePathReference<Opaque> {
+    return new SimplePathReference(this, prop);
   }
 }
 
@@ -426,7 +430,7 @@ export class TestEnvironment extends Environment {
     this.helpers[name] = (args: EvaluatedArgs) => new HelperReference(helper, args);
   }
 
-  setHelper(name: string, helper: GlimmerHelper) {
+  registerInternalHelper(name: string, helper: GlimmerHelper) {
     this.helpers[name] = helper;
   }
 


### PR DESCRIPTION
Merged in the latest (4148235) changes in #139 with the upsert refactor: 

Move all the upset code into objects in a new file: each object only need to know how to update within the same type (e.g. html -> html, Node -> Node). If they fail to update because the type has changed, the parent can simply clear the rendered content and make a new upsert object of the appropriate type.

Also fixed CompiledHelpers claiming to correctly return a `PathReference<Opaque>`.

/cc @zackthehuman @krisselden 