### PR TITLE
Better dynamic component infrastructure

### DIFF
--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -21,7 +21,8 @@ export class PutComponentDefinitionOpcode extends Opcode {
   }
 
   evaluate(vm: VM) {
-    let reference = this.factory.call(undefined, vm.frame.getArgs(), vm);
+    let { factory } = this;
+    let reference = factory(vm.frame.getArgs(), vm);
     vm.frame.setDynamicComponent(reference);
   }
 }

--- a/packages/glimmer-runtime/lib/compiler.ts
+++ b/packages/glimmer-runtime/lib/compiler.ts
@@ -375,12 +375,14 @@ class ComponentBuilder {
     let BEGIN = new LabelOpcode({ label: "BEGIN" });
     let END = new LabelOpcode({ label: "END" });
 
-    let args = rawArgs.compile(compiler, env);
+    let definitionArgs = definition.args.compile(compiler, env);
+    let componentArgs = rawArgs.compile(compiler, env);
 
     compiler.append(new EnterOpcode({ begin: BEGIN, end: END }));
     compiler.append(BEGIN);
-    compiler.append(new PutArgsOpcode({ args }));
-    compiler.append(new PutComponentDefinitionOpcode({ factory: definition }));
+    compiler.append(new PutArgsOpcode({ args: definitionArgs }));
+    compiler.append(new PutComponentDefinitionOpcode(definition));
+    compiler.append(new PutArgsOpcode({ args: componentArgs }));
     compiler.append(new OpenDynamicComponentOpcode({ shadow, templates }));
     compiler.append(new CloseComponentOpcode());
     compiler.append(END);

--- a/packages/glimmer-runtime/lib/opcode-builder.ts
+++ b/packages/glimmer-runtime/lib/opcode-builder.ts
@@ -23,8 +23,13 @@ export interface StaticComponentOptions {
   templates: Templates;
 }
 
+export interface DynamicComponentDefinition<T> {
+  args: Args;
+  factory: DynamicComponentFactory<T>;
+}
+
 export interface DynamicComponentOptions {
-  definition: DynamicComponentFactory<Opaque>;
+  definition: DynamicComponentDefinition<Opaque>;
   args: Args;
   shadow: InternedString[];
   templates: Templates;

--- a/packages/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/glimmer-runtime/lib/syntax/core.ts
@@ -1060,9 +1060,8 @@ export class PositionalArgs {
     this.length = exprs.length;
   }
 
-  push(expr: ExpressionSyntax<Opaque>) {
-    this.values.push(expr);
-    this.length = this.values.length;
+  slice(start?: number, end?: number): PositionalArgs {
+    return PositionalArgs.build(this.values.slice(start, end));
   }
 
   at(index: number): ExpressionSyntax<Opaque> {


### PR DESCRIPTION
When transforming syntax into a dynamic component invocation, it is often the case that you also need to control over what the args the component should be invoked with. For example, in Ember:

```
{{component dynamicName some extra="..." args=foo}}
```

Here, the first positional arg (`dynamicName`) is only used internally to lookup the component definition and should not be seen by the component in its invocation args. This change allows the host to separate the args for the component lookup and the component invocation.