### PR TITLE
Basic Modifier support

### DIFF
--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -149,5 +149,9 @@ export {
   ComponentAttrsBuilder
 } from './lib/component/interfaces';
 
+export {
+  ModifierManager
+} from './lib/modifier/interfaces';
+
 export { default as DOMHelper, DOMHelper as IDOMHelper, isWhitespace } from './lib/dom';
 export { ElementStack, ElementOperations } from './lib/builder';

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -11,6 +11,10 @@ import {
 } from './component/interfaces';
 
 import {
+  ModifierManager
+} from './modifier/interfaces';
+
+import {
   PathReference
 } from 'glimmer-reference';
 
@@ -196,6 +200,9 @@ export abstract class Environment {
   abstract lookupHelper(helperName: InternedString[]): Helper;
   abstract hasComponentDefinition(tagName: InternedString[]): boolean;
   abstract getComponentDefinition(tagName: InternedString[]): ComponentDefinition<Opaque>;
+
+  abstract hasModifier(modifierName: InternedString[]): boolean;
+  abstract lookupModifier(modifierName: InternedString[]): ModifierManager<Opaque>;
 }
 
 export default Environment;
@@ -214,6 +221,7 @@ export interface ParsedStatement {
   args: Syntax.Args;
   isInline: boolean;
   isBlock: boolean;
+  isModifier: boolean;
   templates: Syntax.Templates;
 }
 
@@ -221,6 +229,7 @@ function parseStatement(statement: StatementSyntax): ParsedStatement {
     let type = statement.type;
     let block = type === 'block' ? <Syntax.Block>statement : null;
     let append = type === 'append' ? <Syntax.Append>statement : null;
+    let modifier = type === 'modifier' ? <Syntax.Modifier>statement : null;
 
     let named: Syntax.NamedArgs;
     let args: Syntax.Args;
@@ -242,6 +251,9 @@ function parseStatement(statement: StatementSyntax): ParsedStatement {
       args = helper.args;
       named = args.named;
       path = helper.ref.path();
+    } else if (modifier) {
+      path = modifier.path;
+      args = modifier.args;
     }
 
     let key: InternedString, isSimple: boolean;
@@ -258,6 +270,7 @@ function parseStatement(statement: StatementSyntax): ParsedStatement {
       args,
       isInline: !!append,
       isBlock: !!block,
+      isModifier: !!modifier,
       templates: block && block.templates
     };
 }

--- a/packages/glimmer-runtime/lib/modifier/interfaces.ts
+++ b/packages/glimmer-runtime/lib/modifier/interfaces.ts
@@ -1,0 +1,19 @@
+import { EvaluatedArgs } from '../compiled/expressions/args';
+import { DOMHelper } from '../dom';
+import { Destroyable } from 'glimmer-util';
+
+export interface ModifierManager<T> {
+  // At initial render, the modifier gets a chance to install itself on the
+  // element it is managing. It can also return a bucket of state that
+  // it could use at update time. From the perspective of Glimmer, this
+  // is an opaque token.
+  install(element: Element, args: EvaluatedArgs, dom: DOMHelper): T;
+
+  // When the args have changed, the modifier's `update` hook is called
+  // with its state bucket as well as the updated args.
+  update(modifier: T, element: Element, args: EvaluatedArgs, dom: DOMHelper);
+
+  // Convert the opaque token into an object that implements Destroyable.
+  // If it returns null, the modifier will not be destroyed.
+  getDestructor(modifier: T): Destroyable;
+}

--- a/packages/glimmer-runtime/lib/syntax/statements.ts
+++ b/packages/glimmer-runtime/lib/syntax/statements.ts
@@ -8,7 +8,8 @@ import {
   Comment,
   OpenElement,
   CloseElement,
-  StaticAttr
+  StaticAttr,
+  Modifier
 } from './core';
 
 import { InlineBlock } from '../compiled/blocks';
@@ -28,7 +29,8 @@ const {
   isComment,
   isOpenElement,
   isCloseElement,
-  isStaticAttr
+  isStaticAttr,
+  isModifier
 } = SerializedStatements;
 
 export default function(sexp: SerializedStatement, blocks: InlineBlock[]): StatementSyntax {
@@ -42,4 +44,5 @@ export default function(sexp: SerializedStatement, blocks: InlineBlock[]): State
   if (isOpenElement(sexp)) return OpenElement.fromSpec(sexp);
   if (isCloseElement(sexp)) return CloseElement.fromSpec();
   if (isStaticAttr(sexp)) return StaticAttr.fromSpec(sexp);
+  if (isModifier(sexp)) return Modifier.fromSpec(sexp);
 };

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -1831,6 +1831,14 @@ styles.forEach(style => {
 
 });
 
+QUnit.test(`Glimmer component with element modifier`, function(assert) {
+  env.registerEmberishGlimmerComponent('non-block', null, `  <div>In layout</div>  `);
+
+  assert.throws(() => {
+    let view = appendViewFor('<non-block {{action}} />');
+  }, new Error("Compile Error: Element modifiers are not allowed in components"), "should throw error");
+});
+
 QUnit.skip('block without properties', function() {
   env.registerEmberishGlimmerComponent('with-block', EmberishGlimmerComponent, '<with-block>In layout - {{yield}}</with-block>');
 

--- a/packages/glimmer-runtime/tests/initial-render-test.ts
+++ b/packages/glimmer-runtime/tests/initial-render-test.ts
@@ -1,5 +1,5 @@
 import { forEach } from "glimmer-util";
-import { TestEnvironment, TestDynamicScope, normalizeInnerHTML, getTextContent, equalTokens } from "glimmer-test-helpers";
+import { TestEnvironment, TestDynamicScope, TestModifierManager, normalizeInnerHTML, getTextContent, equalTokens } from "glimmer-test-helpers";
 import { Template } from 'glimmer-runtime';
 import { UpdatableReference } from 'glimmer-object-reference';
 

--- a/packages/glimmer-test-helpers/index.ts
+++ b/packages/glimmer-test-helpers/index.ts
@@ -16,6 +16,7 @@ export {
   BasicComponent,
   EmberishCurlyComponent,
   EmberishGlimmerComponent,
+  TestModifierManager,
   TestEnvironment,
   TestDynamicScope,
   equalsElement,


### PR DESCRIPTION
This adds both a `Modifier` syntax and a `ModifierOpcode`. The opcode basically does nothing, but it's nice because it shows up in the visualizer.

This work is needed to start working on more ambitious things like `{{action}}`s and the like.

- [x] Figure out how this composes with Glimmer components.
- [x] Update `Environment` with `hasModifier` and `lookupModifier`.
- [x] Check if modifier exists when compiling `Modifier` syntax. Throw if there isn't one.
- [x] Create the `ModifierManager` interface.
- [x] Create `UpdateModifierOpcode` and emit it after installing inside of `ModifierOpcode`.
- [x] Handle created `Modifier`'s destructor.
- [x] Implement `UpdateModifierOpcode` to actually perform updating.
- [x] Write a test that tests the ins and outs of this feature.