### PR TITLE
Add UNDEFINED_REFERENCE and return it for missing named args

### DIFF
--- a/packages/glimmer-runtime/lib/compiled/expressions/named-args.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/named-args.ts
@@ -1,4 +1,4 @@
-import { NULL_REFERENCE } from '../../references';
+import { UNDEFINED_REFERENCE } from '../../references';
 import { CompiledExpression } from '../expressions';
 import VM from '../../vm/append';
 import { CONSTANT_TAG, PathReference, RevisionTag, combine } from 'glimmer-reference';
@@ -113,7 +113,7 @@ class NonEmptyEvaluatedNamedArgs extends EvaluatedNamedArgs {
   }
 
   get(key: InternedString): PathReference<any> {
-    return this.map[<string>key];
+    return this.map[<string>key] || UNDEFINED_REFERENCE;
   }
 
   has(key: InternedString): boolean {
@@ -139,7 +139,7 @@ export const EVALUATED_EMPTY_NAMED_ARGS = new (class extends EvaluatedNamedArgs 
   public keys = [];
 
   get(): PathReference<any> {
-    return NULL_REFERENCE;
+    return UNDEFINED_REFERENCE;
   }
 
   has(key: InternedString): boolean {

--- a/packages/glimmer-runtime/lib/references.ts
+++ b/packages/glimmer-runtime/lib/references.ts
@@ -28,3 +28,4 @@ export class ConditionalReference implements Reference<boolean> {
 }
 
 export const NULL_REFERENCE = new PrimitiveReference(null);
+export const UNDEFINED_REFERENCE = new PrimitiveReference(undefined);


### PR DESCRIPTION
Created `UNDEFINED_REFERENCE` which is similar to `NULL_REFERENCE` to be used when indexing properties that don't exist. I updated `NonEmptyEvaluatedNamedArgs` to return this value when indexing a missing key rather than returning `undefined`.