### PR TITLE
Export UNDEFINED_REFERENCE from glimmer-runtime

### DIFF
--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -13,7 +13,7 @@ export { default as Template } from './lib/template';
 
 export { default as SymbolTable } from './lib/symbol-table';
 
-export { ConditionalReference } from './lib/references';
+export { ConditionalReference, UNDEFINED_REFERENCE } from './lib/references';
 
 export {
   Templates,


### PR DESCRIPTION
Exporting the `UNDEFINED_REFERENCE` so that it can be used inside of Ember.