### PR TITLE
Re-export NULL_REFERENCE and return UNDEFINED_REFERENCE by default

### DIFF
--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -13,7 +13,7 @@ export { default as Template } from './lib/template';
 
 export { default as SymbolTable } from './lib/symbol-table';
 
-export { ConditionalReference, UNDEFINED_REFERENCE } from './lib/references';
+export { ConditionalReference, NULL_REFERENCE, UNDEFINED_REFERENCE } from './lib/references';
 
 export {
   Templates,

--- a/packages/glimmer-runtime/lib/references.ts
+++ b/packages/glimmer-runtime/lib/references.ts
@@ -5,7 +5,7 @@ type Primitive = string | number | boolean;
 
 export class PrimitiveReference extends ConstReference<any> implements PathReference<Primitive> {
   get(): PrimitiveReference {
-    return NULL_REFERENCE;
+    return UNDEFINED_REFERENCE;
   }
 }
 


### PR DESCRIPTION
Minor clean up. Export the NULL_REFERENCE.