### PR TITLE
Pass DynamicScope to modifier install hook

### DIFF
--- a/packages/glimmer-runtime/lib/modifier/interfaces.ts
+++ b/packages/glimmer-runtime/lib/modifier/interfaces.ts
@@ -1,5 +1,6 @@
 import { EvaluatedArgs } from '../compiled/expressions/args';
 import { DOMHelper } from '../dom';
+import { DynamicScope } from '../environment';
 import { Destroyable } from 'glimmer-util';
 
 export interface ModifierManager<T> {
@@ -7,11 +8,11 @@ export interface ModifierManager<T> {
   // element it is managing. It can also return a bucket of state that
   // it could use at update time. From the perspective of Glimmer, this
   // is an opaque token.
-  install(element: Element, args: EvaluatedArgs, dom: DOMHelper): T;
+  install(element: Element, args: EvaluatedArgs, dom: DOMHelper, dynamicScope: DynamicScope): T;
 
   // When the args have changed, the modifier's `update` hook is called
   // with its state bucket as well as the updated args.
-  update(modifier: T, element: Element, args: EvaluatedArgs, dom: DOMHelper);
+  update(modifier: T, element: Element, args: EvaluatedArgs, dom: DOMHelper, dynamicScope: DynamicScope);
 
   // Convert the opaque token into an object that implements Destroyable.
   // If it returns null, the modifier will not be destroyed.


### PR DESCRIPTION
It turns out that having the DyntamicScope is pretty handy for real-world modifiers. This updates the interface so that the scope is passed when a modifier is installed.