### PR TITLE
Add getAttribute method to DOMHelper

### DIFF
--- a/packages/glimmer-runtime/lib/dom.ts
+++ b/packages/glimmer-runtime/lib/dom.ts
@@ -53,6 +53,10 @@ class DOMHelper {
     this.uselessElement = this.document.createElement('div');
   }
 
+  getAttribute(element: Element, name: string) {
+    return element.getAttribute(name);
+  }
+
   setAttribute(element: Element, name: string, value: string) {
     element.setAttribute(name, value);
   }


### PR DESCRIPTION
Adds a method to `getAttribute` as a compliment to `setAttribute`. This helper is needed for element actions since they'll need to get/set the `data-ember-action` attribute.