### PR TITLE
Fix comment and attribute start column.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "git-repo-version": "^0.1.2",
     "handlebars": "^3.0.2",
     "qunit": "^0.7.2",
-    "simple-html-tokenizer": "^0.2.1",
+    "simple-html-tokenizer": "^0.2.2",
     "typescript": "1.9.0-dev.20160407"
   },
   "devDependencies": {

--- a/packages/glimmer-syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/glimmer-syntax/lib/parser/tokenizer-event-handlers.ts
@@ -13,7 +13,8 @@ export default {
     this.currentNode = b.comment("");
     this.currentNode.loc = {
       source: null,
-      start: b.pos(this.tokenizer.line, this.tokenizer.column),
+      // beginComment isn't called until after the `<!--` is consumed
+      start: b.pos(this.tokenizer.line, this.tokenizer.column - 4),
       end: null
     };
   },
@@ -139,7 +140,8 @@ export default {
       parts: [],
       isQuoted: false,
       isDynamic: false,
-      start: b.pos(this.tokenizer.line, this.tokenizer.column)
+      // beginAttribute isn't called until after the first char is consumed
+      start: b.pos(this.tokenizer.line, this.tokenizer.column - 1)
     };
   },
 

--- a/packages/glimmer-syntax/tests/loc-node-test.ts
+++ b/packages/glimmer-syntax/tests/loc-node-test.ts
@@ -188,26 +188,32 @@ test("text", function() {
 
 test("comment", function() {
   let ast = parse(`
-    <div><!-- blah blah blah blah --></div>
+    <div><!-- blah blah blah blah -->
+      <!-- derp herky --><div></div>
+    </div>
   `);
 
   let [,div] = ast.body;
-  let [comment] = div.children;
+  let [comment1,,comment2,trailingDiv] = div.children;
 
-  locEqual(comment, 2, 12, 2, 36);
+  locEqual(comment1, 2, 9, 2, 37);
+  locEqual(comment2, 3, 6, 3, 25);
+  locEqual(trailingDiv, 3, 25, 3, 36);
 });
 
 test("element attribute", function() {
   let ast = parse(`
     <div data-foo="blah"
-      data-derp="lolol">
+      data-derp="lolol"
+data-barf="herpy">
       Hi, fivetanley!
     </div>
   `);
 
   let [,div] = ast.body;
-  let [dataFoo, dataDerp] = div.attributes;
+  let [dataFoo,dataDerp,dataBarf] = div.attributes;
 
-  locEqual(dataFoo, 2, 10, 2, 24);
-  locEqual(dataDerp, 3, 7, 3, 23);
+  locEqual(dataFoo, 2, 9, 2, 24);
+  locEqual(dataDerp, 3, 6, 3, 23);
+  locEqual(dataBarf, 4, 0, 4, 17);
 });


### PR DESCRIPTION
The EventedTokenizer only invokes the `beginComment` and `beginAttribute` methods **after** it has consumed the identifying chars.

Corresponding HTMLBars fix: https://github.com/tildeio/htmlbars/pull/456