### PR TITLE
Allow iterators to return current position (index) during {{#each}}

### DIFF
--- a/packages/glimmer-reference/lib/iterable.ts
+++ b/packages/glimmer-reference/lib/iterable.ts
@@ -160,9 +160,9 @@ export class ReferenceIterator {
 }
 
 export interface IteratorSynchronizerDelegate {
-  retain(key: InternedString, item: PathReference<any>, memo: PathReference<any>);
-  insert(key: InternedString, item: PathReference<any>, memo: PathReference<any>, before: InternedString);
-  move(key: InternedString, item: PathReference<any>, memo: PathReference<any>, before: InternedString);
+  retain(key: InternedString, item: PathReference<Opaque>, memo: PathReference<Opaque>);
+  insert(key: InternedString, item: PathReference<Opaque>, memo: PathReference<Opaque>, before: InternedString);
+  move(key: InternedString, item: PathReference<Opaque>, memo: PathReference<Opaque>, before: InternedString);
   delete(key: InternedString);
   done();
 }

--- a/packages/glimmer-reference/lib/iterable.ts
+++ b/packages/glimmer-reference/lib/iterable.ts
@@ -9,7 +9,7 @@ export interface IterationItem<T> {
 
 export interface AbstractIterator<T, U extends IterationItem<T>> {
   isEmpty(): boolean;
-  getPosition(): number;
+  getPosition(): number | FIXME<'user str to InternedString'>;
   next(): U;
 }
 
@@ -140,7 +140,7 @@ export class ReferenceIterator {
     this.artifacts = artifacts;
   }
 
-  getPosition(): ConstReference<number> {
+  getPosition(): ConstReference< number | FIXME<'user str to InternedString'>> {
     return new ConstReference(this.iterator.getPosition());
   }
 

--- a/packages/glimmer-reference/lib/iterable.ts
+++ b/packages/glimmer-reference/lib/iterable.ts
@@ -1,5 +1,6 @@
 import { FIXME, LinkedList, ListNode, InternedString, Opaque, dict } from 'glimmer-util';
 import { VersionedPathReference as PathReference } from './validators';
+import { ConstReference } from './const';
 
 export interface IterationItem<T> {
   key: string;
@@ -8,6 +9,7 @@ export interface IterationItem<T> {
 
 export interface AbstractIterator<T, U extends IterationItem<T>> {
   isEmpty(): boolean;
+  getPosition(): number;
   next(): U;
 }
 
@@ -136,6 +138,10 @@ export class ReferenceIterator {
   constructor(iterable: OpaqueIterable) {
     let artifacts = new IterationArtifacts(iterable);
     this.artifacts = artifacts;
+  }
+
+  getPosition(): ConstReference<number> {
+    return new ConstReference(this.iterator.getPosition());
   }
 
   next(): IterationItem<PathReference<Opaque>> {

--- a/packages/glimmer-reference/tests/iterable-test.ts
+++ b/packages/glimmer-reference/tests/iterable-test.ts
@@ -85,7 +85,8 @@ class TestIterationItem implements IterationItem<Opaque> {
 
 class TestIterator implements Iterator<Opaque> {
   private array: TestItem[];
-  private position = 0;
+  private position;
+  private nextPosition = 0;
 
   constructor(array: TestItem[]) {
     this.array = array;
@@ -95,14 +96,20 @@ class TestIterator implements Iterator<Opaque> {
     return this.array.length === 0;
   }
 
+  getPosition(): number {
+    return this.position;
+  }
+
   next(): IterationItem<Opaque> {
-    let { position, array } = this;
+    let { nextPosition, array } = this;
 
-    if (position >= array.length) return null;
+    if (nextPosition >= array.length) return null;
 
-    let value = array[position];
+    this.position = nextPosition;
 
-    this.position++;
+    let value = array[nextPosition];
+
+    this.nextPosition++;
 
     return new TestIterationItem(value.key, value);
   }

--- a/packages/glimmer-reference/tests/iterable-test.ts
+++ b/packages/glimmer-reference/tests/iterable-test.ts
@@ -18,11 +18,11 @@ import { Opaque, LinkedList, ListNode, dict } from 'glimmer-util';
 QUnit.module("Reference iterables");
 
 class Target implements IteratorSynchronizerDelegate {
-  private map = dict<ListNode<BasicReference<any>>>();
-  private list = new LinkedList<ListNode<BasicReference<any>>>();
+  private map = dict<ListNode<BasicReference<Opaque>>>();
+  private list = new LinkedList<ListNode<BasicReference<Opaque>>>();
   public tag = VOLATILE_TAG;
 
-  retain(key: string, item: BasicReference<any>, memo: BasicReference<any>) {
+  retain(key: string, item: BasicReference<Opaque>, memo: BasicReference<Opaque>) {
     if (item !== this.map[key].value) {
       throw new Error("unstable reference");
     }
@@ -30,18 +30,18 @@ class Target implements IteratorSynchronizerDelegate {
 
   done() {}
 
-  append(key: string, item: BasicReference<any>, memo: BasicReference<any>) {
+  append(key: string, item: BasicReference<Opaque>, memo: BasicReference<Opaque>) {
     let node = this.map[key] = new ListNode(item);
     this.list.append(node);
   }
 
-  insert(key: string, item: BasicReference<any>, memo: BasicReference<any>, before: string) {
+  insert(key: string, item: BasicReference<Opaque>, memo: BasicReference<Opaque>, before: string) {
     let referenceNode = before ? this.map[before] : null;
     let node = this.map[key] = new ListNode(item);
     this.list.insertBefore(node, referenceNode);
   }
 
-  move(key: string, item: BasicReference<any>, memo: BasicReference<any>, before: string) {
+  move(key: string, item: BasicReference<Opaque>, memo: BasicReference<Opaque>, before: string) {
     let referenceNode = before ? this.map[before] : null;
     let node = this.map[key];
 
@@ -59,11 +59,11 @@ class Target implements IteratorSynchronizerDelegate {
     this.list.remove(node);
   }
 
-  toArray(): BasicReference<any>[] {
+  toArray(): BasicReference<Opaque>[] {
     return this.list.toArray().map(node => node.value);
   }
 
-  toValues(): any[] {
+  toValues(): Opaque[] {
     return this.toArray().map(ref => ref.value());
   }
 }
@@ -78,7 +78,7 @@ class TestIterationItem implements IterationItem<Opaque, Opaque> {
   public value: Opaque;
   public memo: Opaque;
 
-  constructor(key: string, value: any, memo: any) {
+  constructor(key: string, value: Opaque, memo: Opaque) {
     this.key = key;
     this.value = value;
     this.memo = memo;

--- a/packages/glimmer-runtime/lib/compiled/opcodes/lists.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/lists.ts
@@ -117,12 +117,13 @@ export class NextIterOpcode extends Opcode {
 
   evaluate(vm: VM) {
     let item = vm.frame.getIterator().next();
+    let position = vm.frame.getIterator().getPosition();
 
     if (item) {
       vm.frame.setCondition(TRUE_REF);
       vm.frame.setKey(item.key as FIXME<'user str to InternedString'>);
       vm.frame.setOperand(item.value);
-      vm.frame.setArgs(EvaluatedArgs.positional([item.value]));
+      vm.frame.setArgs(EvaluatedArgs.positional([item.value, <any>position]));
     } else {
       vm.frame.setCondition(FALSE_REF);
       vm.goto(this.end);

--- a/packages/glimmer-runtime/lib/compiled/opcodes/lists.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/lists.ts
@@ -122,7 +122,7 @@ export class NextIterOpcode extends Opcode {
       vm.frame.setCondition(TRUE_REF);
       vm.frame.setKey(item.key as FIXME<'user str to InternedString'>);
       vm.frame.setOperand(item.value);
-      vm.frame.setArgs(EvaluatedArgs.positional([item.value, item.position]));
+      vm.frame.setArgs(EvaluatedArgs.positional([item.value, item.memo]));
     } else {
       vm.frame.setCondition(FALSE_REF);
       vm.goto(this.end);

--- a/packages/glimmer-runtime/lib/compiled/opcodes/lists.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/lists.ts
@@ -117,13 +117,12 @@ export class NextIterOpcode extends Opcode {
 
   evaluate(vm: VM) {
     let item = vm.frame.getIterator().next();
-    let position = vm.frame.getIterator().getPosition();
 
     if (item) {
       vm.frame.setCondition(TRUE_REF);
       vm.frame.setKey(item.key as FIXME<'user str to InternedString'>);
       vm.frame.setOperand(item.value);
-      vm.frame.setArgs(EvaluatedArgs.positional([item.value, <any>position]));
+      vm.frame.setArgs(EvaluatedArgs.positional([item.value, item.position]));
     } else {
       vm.frame.setCondition(FALSE_REF);
       vm.goto(this.end);

--- a/packages/glimmer-runtime/lib/vm/update.ts
+++ b/packages/glimmer-runtime/lib/vm/update.ts
@@ -1,7 +1,8 @@
 import { Scope, DynamicScope, Environment } from '../environment';
 import { Bounds, clear, move as moveBounds } from '../bounds';
 import { ElementStack, Tracker } from '../builder';
-import { LOGGER, Destroyable, Stack, LinkedList, InternedString, Dict, dict } from 'glimmer-util';
+import { LOGGER, Destroyable, Stack, FIXME, LinkedList, InternedString, Dict, dict } from 'glimmer-util';
+import { UpdatableReference } from 'glimmer-object-reference';
 import {
   ConstReference,
   PathReference,
@@ -218,7 +219,7 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     this.marker = marker;
   }
 
-  insert(key: InternedString, item: PathReference<any>, before: InternedString) {
+  insert(key: InternedString, item: PathReference<any>, before: InternedString, position: UpdatableReference<number | FIXME<'user string to InternedString'>>) {
     let { map, opcode, updating } = this;
     let nextSibling: Node = null;
     let reference = null;
@@ -234,7 +235,7 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     let tryOpcode;
 
     vm.execute(opcode.ops, vm => {
-      vm.frame.setArgs(EvaluatedArgs.positional([item]));
+      vm.frame.setArgs(EvaluatedArgs.positional([item, position]));
       vm.frame.setOperand(item);
       vm.frame.setCondition(new ConstReference(true));
       vm.frame.setKey(key);

--- a/packages/glimmer-runtime/lib/vm/update.ts
+++ b/packages/glimmer-runtime/lib/vm/update.ts
@@ -1,8 +1,7 @@
 import { Scope, DynamicScope, Environment } from '../environment';
 import { Bounds, clear, move as moveBounds } from '../bounds';
 import { ElementStack, Tracker } from '../builder';
-import { LOGGER, Destroyable, Stack, FIXME, LinkedList, InternedString, Dict, dict } from 'glimmer-util';
-import { UpdatableReference } from 'glimmer-object-reference';
+import { LOGGER, Destroyable, Opaque, Stack, LinkedList, InternedString, Dict, dict } from 'glimmer-util';
 import {
   ConstReference,
   PathReference,
@@ -11,7 +10,6 @@ import {
   IteratorSynchronizerDelegate,
 
   // Tags
-  Revision,
   UpdatableTag,
   combineSlice,
   CONSTANT_TAG
@@ -219,7 +217,7 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     this.marker = marker;
   }
 
-  insert(key: InternedString, item: PathReference<any>, memo: PathReference<any>, before: InternedString) {
+  insert(key: InternedString, item: PathReference<Opaque>, memo: PathReference<Opaque>, before: InternedString) {
     let { map, opcode, updating } = this;
     let nextSibling: Node = null;
     let reference = null;
@@ -256,10 +254,10 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     this.didInsert = true;
   }
 
-  retain(key: InternedString, item: PathReference<any>, memo: PathReference<any>) {
+  retain(key: InternedString, item: PathReference<Opaque>, memo: PathReference<Opaque>) {
   }
 
-  move(key: InternedString, item: PathReference<any>, memo: PathReference<any>, before: InternedString) {
+  move(key: InternedString, item: PathReference<Opaque>, memo: PathReference<Opaque>, before: InternedString) {
     let { map, updating } = this;
 
     let entry = map[<string>key];

--- a/packages/glimmer-runtime/lib/vm/update.ts
+++ b/packages/glimmer-runtime/lib/vm/update.ts
@@ -219,7 +219,7 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     this.marker = marker;
   }
 
-  insert(key: InternedString, item: PathReference<any>, before: InternedString, position: UpdatableReference<number | FIXME<'user string to InternedString'>>) {
+  insert(key: InternedString, item: PathReference<any>, memo: PathReference<any>, before: InternedString) {
     let { map, opcode, updating } = this;
     let nextSibling: Node = null;
     let reference = null;
@@ -235,7 +235,7 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     let tryOpcode;
 
     vm.execute(opcode.ops, vm => {
-      vm.frame.setArgs(EvaluatedArgs.positional([item, position]));
+      vm.frame.setArgs(EvaluatedArgs.positional([item, memo]));
       vm.frame.setOperand(item);
       vm.frame.setCondition(new ConstReference(true));
       vm.frame.setKey(key);
@@ -256,10 +256,10 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     this.didInsert = true;
   }
 
-  retain(key: InternedString, item: PathReference<any>) {
+  retain(key: InternedString, item: PathReference<any>, memo: PathReference<any>) {
   }
 
-  move(key: InternedString, item: PathReference<any>, before: InternedString) {
+  move(key: InternedString, item: PathReference<any>, memo: PathReference<any>, before: InternedString) {
     let { map, updating } = this;
 
     let entry = map[<string>key];

--- a/packages/glimmer-runtime/tests/updating-test.ts
+++ b/packages/glimmer-runtime/tests/updating-test.ts
@@ -59,7 +59,6 @@ function getNodeByClassName(className) {
 }
 
 function getFirstChildOfNode(className) {
-  // {{item.name}}
   let itemNode = getNodeByClassName(className);
   ok(itemNode, "Expected child node of node with class='" + className + "', but no parent node found");
 

--- a/packages/glimmer-runtime/tests/updating-test.ts
+++ b/packages/glimmer-runtime/tests/updating-test.ts
@@ -1310,7 +1310,7 @@ test('The each helper with inverse', function () {
   }
 });
 
-test('The each helper yields the index of the current item', function () {
+test('The each helper yields the index of the current item current item when using the @index key', function () {
   let tom = { name: "Tom Dale", "class": "tomdale" };
   let yehuda = { name: "Yehuda Katz", "class": "wycats" };
   let object = { list: [tom, yehuda] };
@@ -1337,6 +1337,254 @@ test('The each helper yields the index of the current item', function () {
   equalTokens(root, "<ul><li class='wycats'>Yehuda Katz<p class='index-0'>0</p></li><li class='tomdale'>Tom Dale<p class='index-1'>1</p></li></ul>", "After changing list order");
   strictEqual(getNodeByClassName(`index-0`), indexNode, "The index node has not changed after changing list order");
 
+  object = { list: [
+    { name: "Martin Muñoz", class: "mmun" },
+    { name: "Kris Selden", class: "krisselden" }
+  ]};
+  rerender(object);
+  assertStableNodes('mmun', 0, "after changing the list entries, but with stable keys");
+  equalTokens(
+    root,
+    `<ul><li class='mmun'>Martin Muñoz<p class='index-0'>0</p></li><li class='krisselden'>Kris Selden<p class='index-1'>1</p></li></ul>`,
+    `After changing the list entries, but with stable keys`
+  );
+
+  object = { list: [
+    { name: "Martin Muñoz", class: "mmun" },
+    { name: "Kristoph Selden", class: "krisselden" },
+    { name: "Matthew Beale", class: "mixonic" }
+  ]};
+
+  rerender(object);
+  assertStableNodes('mmun', 0, "after adding an additional entry");
+  equalTokens(
+    root,
+    stripTight`<ul>
+      <li class='mmun'>Martin Muñoz<p class='index-0'>0</p></li>
+      <li class='krisselden'>Kristoph Selden<p class='index-1'>1</p></li>
+      <li class='mixonic'>Matthew Beale<p class='index-2'>2</p></li></ul>`,
+    `After adding an additional entry`
+  );
+
+  object = { list: [
+    { name: "Martin Muñoz", class: "mmun" },
+    { name: "Matthew Beale", class: "mixonic" }
+  ]};
+
+  rerender(object);
+  assertStableNodes('mmun', 0, "after removing the middle entry");
+  equalTokens(
+    root,
+    "<ul><li class='mmun'>Martin Muñoz<p class='index-0'>0</p></li><li class='mixonic'>Matthew Beale<p class='index-1'>1</p></li></ul>",
+    "after removing the middle entry"
+   );
+
+  object = { list: [
+    { name: "Martin Muñoz", class: "mmun" },
+    { name: "Stefan Penner", class: "stefanpenner" },
+    { name: "Robert Jackson", class: "rwjblue" }
+  ]};
+
+  rerender(object);
+  assertStableNodes('mmun', 0, "after adding two more entries");
+  equalTokens(
+    root,
+    stripTight`<ul>
+      <li class='mmun'>Martin Muñoz<p class='index-0'>0</p></li>
+      <li class='stefanpenner'>Stefan Penner<p class='index-1'>1</p></li>
+      <li class='rwjblue'>Robert Jackson<p class='index-2'>2</p></li></ul>`,
+    `After adding two more entries`
+  );
+
+  // New node for stability check
+  itemNode = getNodeByClassName('rwjblue');
+  nameNode = getFirstChildOfNode('rwjblue');
+  indexNode = getNodeByClassName('index-2');
+
+  object = { list: [
+    { name: "Robert Jackson", class: "rwjblue" }
+  ]};
+
+  rerender(object);
+  equalTokens(root, "<ul><li class='rwjblue'>Robert Jackson<p class='index-0'>0</p></li></ul>", "After removing two entries");
+
+  object = { list: [
+    { name: "Martin Muñoz", class: "mmun" },
+    { name: "Stefan Penner", class: "stefanpenner" },
+    { name: "Robert Jackson", class: "rwjblue" }
+  ]};
+
+  rerender(object);
+  equalTokens(
+    root,
+    stripTight`<ul>
+      <li class='mmun'>Martin Muñoz<p class='index-0'>0</p></li>
+      <li class='stefanpenner'>Stefan Penner<p class='index-1'>1</p></li>
+      <li class='rwjblue'>Robert Jackson<p class='index-2'>2</p></li></ul>`,
+    `After adding back entries`
+  );
+
+  // New node for stability check
+  itemNode = getNodeByClassName('mmun');
+  nameNode = getFirstChildOfNode('mmun');
+  indexNode = getNodeByClassName('index-0');
+
+  object = { list: [
+    { name: "Martin Muñoz", class: "mmun" }
+  ]};
+
+  rerender(object);
+  assertStableNodes('mmun', 0, "after removing from the back");
+  equalTokens(root, "<ul><li class='mmun'>Martin Muñoz<p class='index-0'>0</p></li></ul>", "After removing from the back");
+
+  object = { list: [] };
+
+  rerender(object);
+  strictEqual(root.firstChild.firstChild.nodeType, 8, "there are no li's after removing the remaining entry");
+  equalTokens(root, "<ul><!----></ul>", "After removing the remaining entries");
+
+
+  function assertStableNodes(className, index, message) {
+    strictEqual(getNodeByClassName(className), itemNode, "The item node has not changed " + message);
+    strictEqual(getNodeByClassName(`index-${index}`), indexNode, "The index node has not changed " + message);
+    strictEqual(getFirstChildOfNode(className), nameNode, "The name node has not changed " + message);
+  }
+});
+
+test('The each helper yields the index of the current item when using a non-@index key', function () {
+  let tom = { key: "1", name: "Tom Dale", class: "tomdale" };
+  let yehuda = { key: "2", name: "Yehuda Katz", class: "wycats" };
+  let object = { list: [tom, yehuda] };
+  let template = compile("<ul>{{#each list key='key' as |item index|}}<li class='{{item.class}}'>{{item.name}}<p class='index-{{index}}'>{{index}}</p></li>{{/each}}</ul>");
+
+  render(template, object);
+
+  let itemNode = getNodeByClassName('tomdale');
+  let indexNode = getNodeByClassName('index-0');
+  let nameNode = getFirstChildOfNode('tomdale');
+
+  equalTokens(root, "<ul><li class='tomdale'>Tom Dale<p class='index-0'>0</p></li><li class='wycats'>Yehuda Katz<p class='index-1'>1</p></li></ul>", "Initial render");
+
+  rerender();
+  assertStableNodes('tomdale', 0, 'after no-op rerender');
+  equalTokens(root, "<ul><li class='tomdale'>Tom Dale<p class='index-0'>0</p></li><li class='wycats'>Yehuda Katz<p class='index-1'>1</p></li></ul>", "After no-op render");
+
+  rerender();
+  assertStableNodes('tomdale', 0, 'after non-dirty rerender');
+  equalTokens(root, "<ul><li class='tomdale'>Tom Dale<p class='index-0'>0</p></li><li class='wycats'>Yehuda Katz<p class='index-1'>1</p></li></ul>", "After non-dirty render");
+
+  object = { list: [yehuda, tom] };
+  rerender(object);
+  equalTokens(root, "<ul><li class='wycats'>Yehuda Katz<p class='index-0'>0</p></li><li class='tomdale'>Tom Dale<p class='index-1'>1</p></li></ul>", "After changing list order");
+  strictEqual(getNodeByClassName('index-1'), indexNode, "The index node has been moved after changing list order");
+
+  object = { list: [
+    { key: "1", name: "Martin Muñoz", class: "mmun" },
+    { key: "2", name: "Kris Selden", class: "krisselden" }
+  ]};
+  rerender(object);
+  assertStableNodes('mmun', 0, "after changing the list entries, but with stable keys");
+  equalTokens(
+    root,
+    `<ul><li class='mmun'>Martin Muñoz<p class='index-0'>0</p></li><li class='krisselden'>Kris Selden<p class='index-1'>1</p></li></ul>`,
+    `After changing the list entries, but with stable keys`
+  );
+
+  object = { list: [
+    { key: "1", name: "Martin Muñoz", class: "mmun" },
+    { key: "2", name: "Kristoph Selden", class: "krisselden" },
+    { key: "3", name: "Matthew Beale", class: "mixonic" }
+  ]};
+
+  rerender(object);
+  assertStableNodes('mmun', 0, "after adding an additional entry");
+  equalTokens(
+    root,
+    stripTight`<ul>
+      <li class='mmun'>Martin Muñoz<p class='index-0'>0</p></li>
+      <li class='krisselden'>Kristoph Selden<p class='index-1'>1</p></li>
+      <li class='mixonic'>Matthew Beale<p class='index-2'>2</p></li></ul>`,
+    `After adding an additional entry`
+  );
+
+  object = { list: [
+    { key: "1", name: "Martin Muñoz", class: "mmun" },
+    { key: "3", name: "Matthew Beale", class: "mixonic" }
+  ]};
+
+  rerender(object);
+  assertStableNodes('mmun', 0, "after removing the middle entry");
+  equalTokens(
+    root,
+    "<ul><li class='mmun'>Martin Muñoz<p class='index-0'>0</p></li><li class='mixonic'>Matthew Beale<p class='index-1'>1</p></li></ul>",
+    "after removing the middle entry"
+   );
+
+  object = { list: [
+    { key: "1", name: "Martin Muñoz", class: "mmun" },
+    { key: "4", name: "Stefan Penner", class: "stefanpenner" },
+    { key: "5", name: "Robert Jackson", class: "rwjblue" }
+  ]};
+
+  rerender(object);
+  assertStableNodes('mmun', 0, "after adding two more entries");
+  equalTokens(
+    root,
+    stripTight`<ul>
+      <li class='mmun'>Martin Muñoz<p class='index-0'>0</p></li>
+      <li class='stefanpenner'>Stefan Penner<p class='index-1'>1</p></li>
+      <li class='rwjblue'>Robert Jackson<p class='index-2'>2</p></li></ul>`,
+    `After adding two more entries`
+  );
+
+  // New node for stability check
+  itemNode = getNodeByClassName('rwjblue');
+  nameNode = getFirstChildOfNode('rwjblue');
+  indexNode = getNodeByClassName('index-2');
+
+  object = { list: [
+    { key: "5", name: "Robert Jackson", class: "rwjblue" }
+  ]};
+
+  rerender(object);
+  assertStableNodes('rwjblue', 0, "after removing two entries");
+  equalTokens(root, "<ul><li class='rwjblue'>Robert Jackson<p class='index-0'>0</p></li></ul>", "After removing two entries");
+
+  object = { list: [
+    { key: "1", name: "Martin Muñoz", class: "mmun" },
+    { key: "4", name: "Stefan Penner", class: "stefanpenner" },
+    { key: "5", name: "Robert Jackson", class: "rwjblue" }
+  ]};
+
+  rerender(object);
+  assertStableNodes('rwjblue', 2, "after adding back entries");
+  equalTokens(
+    root,
+    stripTight`<ul>
+      <li class='mmun'>Martin Muñoz<p class='index-0'>0</p></li>
+      <li class='stefanpenner'>Stefan Penner<p class='index-1'>1</p></li>
+      <li class='rwjblue'>Robert Jackson<p class='index-2'>2</p></li></ul>`,
+    `After adding back entries`
+  );
+
+  // New node for stability check
+  itemNode = getNodeByClassName('mmun');
+  nameNode = getFirstChildOfNode('mmun');
+  indexNode = getNodeByClassName('index-0');
+
+  object = { list: [
+    { key: "1", name: "Martin Muñoz", class: "mmun" }
+  ]};
+
+  rerender(object);
+  assertStableNodes('mmun', 0, "after removing from the back");
+  equalTokens(root, "<ul><li class='mmun'>Martin Muñoz<p class='index-0'>0</p></li></ul>", "After removing from the back");
+
+  object = { list: [] };
+
+  rerender(object);
+  strictEqual(root.firstChild.firstChild.nodeType, 8, "there are no li's after removing the remaining entry");
+  equalTokens(root, "<ul><!----></ul>", "After removing the remaining entries");
 
   function assertStableNodes(className, index, message) {
     strictEqual(getNodeByClassName(className), itemNode, "The item node has not changed " + message);
@@ -1348,8 +1596,8 @@ test('The each helper yields the index of the current item', function () {
 function testEachHelper(testName, templateSource, testMethod=QUnit.test) {
   testMethod(testName, function() {
     let template = compile(templateSource);
-    let tom = { key: "1", name: "Tom Dale", "class": "tomdale" };
-    let yehuda = { key: "2", name: "Yehuda Katz", "class": "wycats" };
+    let tom = { key: "1", name: "Tom Dale", class: "tomdale" };
+    let yehuda = { key: "2", name: "Yehuda Katz", class: "wycats" };
     let object = { list: [ tom, yehuda ] };
 
     render(template, object);

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -85,7 +85,8 @@ type KeyFor = (item: Opaque, index: number) => string;
 class ArrayIterator implements OpaqueIterator {
   private array: Opaque[];
   private keyFor: KeyFor;
-  private position = 0;
+  private nextPosition = 0;
+  private position;
 
   constructor(array: any[], keyFor: KeyFor) {
     this.array = array;
@@ -96,15 +97,21 @@ class ArrayIterator implements OpaqueIterator {
     return this.array.length === 0;
   }
 
+  getPosition(): number {
+    return this.position;
+  }
+
   next(): IterationItem<Opaque> {
-    let { position, array, keyFor } = this;
+    let { nextPosition, array, keyFor } = this;
 
-    if (position >= array.length) return null;
+    if (nextPosition >= array.length) return null;
 
-    let value = array[position];
-    let key = keyFor(value, position);
+    this.position = nextPosition;
 
-    this.position++;
+    let value = array[nextPosition];
+    let key = keyFor(value, nextPosition);
+
+    this.nextPosition++;
 
     return { key, value };
   }
@@ -113,6 +120,10 @@ class ArrayIterator implements OpaqueIterator {
 class EmptyIterator implements OpaqueIterator {
   isEmpty(): boolean {
     return true;
+  }
+
+  getPosition(): number {
+    return undefined;
   }
 
   next(): IterationItem<Opaque> {

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -88,7 +88,7 @@ class ArrayIterator implements OpaqueIterator {
   private nextPosition = 0;
   private position;
 
-  constructor(array: any[], keyFor: KeyFor) {
+  constructor(array: Opaque[], keyFor: KeyFor) {
     this.array = array;
     this.keyFor = keyFor;
   }
@@ -140,7 +140,7 @@ class ObjectKeysIterator implements OpaqueIterator {
     return this.array.length === 0;
   }
 
-  getPosition(): FIXME<'user str to InternedString'> {
+  getPosition(): string {
     return this.array[this.position].key;
   }
 

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -128,7 +128,7 @@ class KVPair implements IterationItem<Opaque> {
 };
 
 class ObjectKeysIterator implements OpaqueIterator {
-  private array: IterationItem<Opaque>[];
+  private array: KVPair[];
   private nextPosition = 0;
   private position;
 

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -97,7 +97,7 @@ class ArrayIterator implements OpaqueIterator {
     return this.array.length === 0;
   }
 
-  getPosition(): number | FIXME<'user str to InternedString'> {
+  getPosition(): number {
     return this.position;
   }
 
@@ -118,8 +118,8 @@ class ArrayIterator implements OpaqueIterator {
 }
 
 class KVPair implements IterationItem<Opaque> {
-  key: string;
-  value: Opaque;
+  public key: string;
+  public value: Opaque;
 
   constructor(key: string, value: Opaque) {
     this.key = key;
@@ -140,7 +140,7 @@ class ObjectKeysIterator implements OpaqueIterator {
     return this.array.length === 0;
   }
 
-  getPosition(): number | FIXME<'user str to InternedString'> {
+  getPosition(): FIXME<'user str to InternedString'> {
     return this.array[this.position].key;
   }
 


### PR DESCRIPTION
In the `opcodes/lists.ts` positional params only takes PathReferences. Not entirely sure if I should convert it to take any kind of reference, or if my casting to <any> is acceptable.