### PR TITLE
Properly handle trailing whitespace controls.

### DIFF
--- a/packages/glimmer-syntax/tests/loc-node-test.ts
+++ b/packages/glimmer-syntax/tests/loc-node-test.ts
@@ -234,3 +234,33 @@ test("char references", function() {
   locEqual(p, 2, 17, 3, 31);
   locEqual(text2, 2, 20, 3, 27);
 });
+
+test("whitespace control - trailing", function() {
+  var ast = parse(`
+  {{#if foo~}}
+    <div></div>
+  {{else~}}
+    {{bar}}
+  {{/if}}`);
+
+  let [,ifBlock] = ast.body;
+  let [div] = ifBlock.program.body;
+
+  locEqual(ifBlock, 2, 2, 6, 9, 'if block');
+  locEqual(div, 3, 4, 3, 15, 'div inside truthy if block');
+});
+
+test("whitespace control - leading", function() {
+  var ast = parse(`
+  {{~#if foo}}
+    <div></div>
+  {{~else}}
+    {{bar}}
+  {{~/if}}`);
+
+  let [ifBlock] = ast.body;
+  let [,div] = ifBlock.program.body;
+
+  locEqual(ifBlock, 2, 2, 6, 10, 'if block');
+  locEqual(div, 3, 4, 3, 15, 'div inside truthy if block');
+});


### PR DESCRIPTION
Previously, we were only handling the Handlebars default "eating" of a newline after a block statement but did not properly handle `~}}` at the end of a block statement.

This updates to also calculate the column offsets (and adds tests).

Given the following:

```hbs
{{#if foo~}}
  <div></div>
{{/if}}
```

Before these changes, the `<div>` would have a starting column of `0`.

After these changes, the `<div>` has the correct starting column of `2`.

---

Corresponds with the changes made in https://github.com/tildeio/htmlbars/pull/458.