### PR TITLE
Update simple-html-tokenizer and fix AttrNode.value loc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "git-repo-version": "^0.1.2",
     "handlebars": "^3.0.2",
     "qunit": "^0.7.2",
-    "simple-html-tokenizer": "^0.2.3",
+    "simple-html-tokenizer": "^0.2.5",
     "typescript": "next"
   },
   "devDependencies": {

--- a/packages/glimmer-syntax/tests/loc-node-test.ts
+++ b/packages/glimmer-syntax/tests/loc-node-test.ts
@@ -205,17 +205,26 @@ test("element attribute", function() {
   let ast = parse(`
     <div data-foo="blah"
       data-derp="lolol"
-data-barf="herpy">
+data-barf="herpy"
+  data-qux=lolnoquotes
+    data-hurky="some {{thing}} here">
       Hi, fivetanley!
     </div>
   `);
 
   let [,div] = ast.body;
-  let [dataFoo,dataDerp,dataBarf] = div.attributes;
+  let [dataFoo,dataDerp,dataBarf, dataQux, dataHurky] = div.attributes;
 
   locEqual(dataFoo, 2, 9, 2, 24);
   locEqual(dataDerp, 3, 6, 3, 23);
   locEqual(dataBarf, 4, 0, 4, 17);
+  locEqual(dataQux, 5, 2, 5, 22);
+
+  locEqual(dataFoo.value, 2, 18, 2, 24);
+  locEqual(dataDerp.value, 3, 16, 3, 23);
+  locEqual(dataBarf.value, 4, 10, 4, 17);
+  locEqual(dataQux.value, 5, 11, 5, 22);
+  locEqual(dataHurky.value, 6, 15, 6, 36);
 });
 
 test("char references", function() {


### PR DESCRIPTION
* Add tests for unquoted attribute location info.
* Use `tagOpen` hook to handle tag start loc tracking.
* Rely on simple-html-tokenizer calling `beginAttribute` correctly.
* Update simple-html-tokenizer.
* Track AttrNode value location info.

See the following:

* https://github.com/tildeio/htmlbars/pull/459
* https://github.com/tildeio/htmlbars/pull/464
* https://github.com/tildeio/simple-html-tokenizer/pull/31
* https://github.com/tildeio/simple-html-tokenizer/pull/33