### PR TITLE
Ensure partial re-renders are stable

### DIFF
--- a/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -329,7 +329,8 @@ export class EvaluatePartialOpcode extends Opcode {
 
   evaluate(vm: VM) {
     let reference: PathReference<any> = this.name.evaluate(vm);
-    let name: InternedString = reference.value();
+    let referenceCache = new ReferenceCache(reference);
+    let name: InternedString = referenceCache.revalidate();
 
     let block = this.cache[name];
     if (!block) {
@@ -341,8 +342,7 @@ export class EvaluatePartialOpcode extends Opcode {
     vm.invokeBlock(block, EvaluatedArgs.empty());
 
     if (!isConst(reference)) {
-      let cache = new ReferenceCache(reference);
-      vm.updateWith(new Assert(cache));
+      vm.updateWith(new Assert(referenceCache));
     }
   }
 
@@ -360,13 +360,13 @@ export class NameToPartialOpcode extends Opcode {
 
   evaluate(vm: VM) {
     let reference = vm.frame.getOperand();
-    let name: InternedString = reference.value();
+    let referenceCache = new ReferenceCache(reference);
+    let name: InternedString = referenceCache.revalidate();
     let partial = name && vm.env.hasPartial([name]) ? vm.env.lookupPartial([name]) : false;
     vm.frame.setOperand(new ValueReference(partial));
 
     if (!isConst(reference)) {
-      let cache = new ReferenceCache(reference);
-      vm.updateWith(new Assert(cache));
+      vm.updateWith(new Assert(referenceCache));
     }
   }
 

--- a/packages/glimmer-test-helpers/index.ts
+++ b/packages/glimmer-test-helpers/index.ts
@@ -4,6 +4,8 @@ export {
   equalInnerHTML,
   equalHTML,
   equalTokens,
+  generateSnapshot,
+  equalSnapshots,
   normalizeInnerHTML,
   isCheckedInputHTML,
   getTextContent,

--- a/packages/glimmer-test-helpers/lib/helpers.ts
+++ b/packages/glimmer-test-helpers/lib/helpers.ts
@@ -4,6 +4,21 @@ import { SerializedTemplate } from 'glimmer-wire-format';
 import { Environment, Template, Layout } from "glimmer-runtime";
 import { TemplateSpec, compileSpec } from "glimmer-compiler";
 
+const TextNode = (<any>window).Text;
+const Comment = (<any>window).Comment;
+
+function isMarker(node) {
+  if (node instanceof Comment && node.textContent === '') {
+    return true;
+  }
+
+  if (node instanceof TextNode && node.textContent === '') {
+    return true;
+  }
+
+  return false;
+}
+
 interface CompileOptions {
   buildMeta?: FIXME<'currently does nothing'>;
   env: Environment;
@@ -128,6 +143,27 @@ export function equalTokens(fragment, html, message=null) {
   }
 
   // deepEqual(fragTokens.tokens, htmlTokens.tokens, msg);
+}
+
+export function generateSnapshot(element) {
+  let snapshot = [];
+  let node = element.firstChild;
+
+  while (node) {
+    if (!isMarker(node)) {
+      snapshot.push(node);
+    }
+    node = node.nextSibling;
+  }
+
+  return snapshot;
+}
+
+export function equalSnapshots(a, b) {
+  strictEqual(a.length, b.length, 'Same number of nodes');
+  for (let i = 0; i < b.length; i++) {
+    strictEqual(a[i], b[i], 'Nodes are the same');
+  }
 }
 
 // detect side-effects of cloning svg elements in IE9-11


### PR DESCRIPTION
Addresses https://github.com/tildeio/glimmer/issues/174

Next, I'll refactor so that you get the stable DOM test for free with `rerender()`, which will address https://github.com/tildeio/glimmer/issues/175

Tested the changes in Ember and confirmed that they make the partial tests pass.

cc @mmun 