### PR TITLE
Eat falsy component definitions and invalidate if their ref changes

### DIFF
--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -871,6 +871,81 @@ testComponent('parameterized has-block-params (concatted attr, default) when blo
   expected: '<button data-has-block-params="is-false"></button>'
 });
 
+module("Components - curlies - dynamic component");
+
+QUnit.test('initially missing, then present, then missing', assert => {
+  class FooBar extends BasicComponent {
+    public foo = 'foo';
+    public bar = 'bar';
+    public baz = null;
+
+    constructor(attrs: Attrs) {
+      super(attrs);
+      this.baz = attrs['baz'] || 'baz';
+    }
+  }
+
+  env.registerBasicComponent('foo-bar', FooBar, `<p>{{foo}} {{bar}} {{baz}}</p>`);
+
+  appendViewFor(
+    stripTight`
+      <div>
+        {{component something}}
+      </div>`,
+    {
+      something: undefined
+    }
+  );
+
+  equalsElement(view.element, 'div', {}, '<!---->');
+
+  set(view, 'something', 'foo-bar');
+  rerender();
+
+  equalsElement(view.element, 'div', {}, '<p>foo bar baz</p>');
+
+  set(view, 'something', undefined);
+  rerender();
+
+  equalsElement(view.element, 'div', {}, '<!---->');
+});
+
+QUnit.test('initially present, then missing, then present', assert => {
+  class FooBar extends BasicComponent {
+    public foo = 'foo';
+    public bar = 'bar';
+    public baz = null;
+
+    constructor(attrs: Attrs) {
+      super(attrs);
+      this.baz = attrs['baz'] || 'baz';
+    }
+  }
+
+  env.registerBasicComponent('foo-bar', FooBar, `<p>{{foo}} {{bar}} {{baz}}</p>`);
+
+  appendViewFor(
+    stripTight`
+      <div>
+        {{component something}}
+      </div>`,
+    {
+      something: "foo-bar"
+    }
+  );
+
+  equalsElement(view.element, 'div', {}, '<p>foo bar baz</p>');
+
+  set(view, 'something', undefined);
+  rerender();
+
+  equalsElement(view.element, 'div', {}, '<!---->');
+
+  set(view, 'something', 'foo-bar');
+  rerender();
+
+  equalsElement(view.element, 'div', {}, '<p>foo bar baz</p>');
+});
 
 module("Components - curlies - dynamic customizations");
 

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -798,7 +798,7 @@ class DynamicComponentReference implements Reference<ComponentDefinition<Opaque>
     if (typeof name === 'string') {
       return env.getComponentDefinition([name as FIXME<'user str InternedString'> as InternedString]);
     } else {
-      throw new Error(`Cannot render ${name} as a component`);
+      return null;
     }
   }
 }


### PR DESCRIPTION
If the `definition` of a component resolves to `undefined`/`null` or another falsy value it should be a signal that there is no component to render. In that case, we can just wait for the value to change since there may be a component definition in the future.

This change makes it possible to implement the behavior tested in https://github.com/emberjs/ember.js/blob/b418b95ea3d31e3a3656906e6ad784422f648c31/packages/ember-glimmer/tests/integration/components/dynamic-components-test.js#L489 where there is a definition initially, but then the value changes to `undefined` and there is no longer a definition. The only requirement here is that the thing providing the value for the definition returns a falsy value. Currently in Ember it will just `throw` in this case, but returning `null` makes this work.