### PR TITLE
[WIP] Dynamic component currying support

### DIFF
--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -44,6 +44,7 @@ export {
 
 export {
   default as OpcodeBuilder,
+  DynamicComponent,
   DynamicComponentOptions,
   StaticComponentOptions
 } from './lib/opcode-builder';

--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -20,13 +20,16 @@ export class PutDynamicComponentDefinitionOpcode extends Opcode {
   }
 
   evaluate(vm: VM) {
-    let definitionRef = vm.frame.getOperand();
-    let cache = isConst(definitionRef) ? undefined : new ReferenceCache(definitionRef);
-    let definition = cache ? cache.peek() : definitionRef.value();
+    let metaDefinitionRef = vm.frame.getOperand();
+    let cache = isConst(metaDefinitionRef) ? undefined : new ReferenceCache(metaDefinitionRef);
+    let metaDefinition = cache ? cache.peek() : metaDefinitionRef.value();
 
     let args = this.args.evaluate(vm).withInternal();
+    // TODO: Insert the curried args if they exist
+    // metaDefinition.get('args').value()
     vm.frame.setArgs(args);
-    args.internal["definition"] = definition;
+
+    args.internal["definition"] = metaDefinition.definition; // should be a .get('definition').value()
 
     if (cache) {
       vm.updateWith(new Assert(cache));

--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -6,7 +6,7 @@ import { CompiledArgs, EvaluatedArgs } from '../../compiled/expressions/args';
 import { Templates } from '../../syntax/core';
 import { layoutFor } from '../../compiler';
 import { DynamicScope } from '../../environment';
-import { InternedString, Opaque } from 'glimmer-util';
+import { FIXME, InternedString, Opaque } from 'glimmer-util';
 import { ReferenceCache, Revision, combine, isConst } from 'glimmer-reference';
 
 export class PutDynamicComponentDefinitionOpcode extends Opcode {
@@ -21,8 +21,8 @@ export class PutDynamicComponentDefinitionOpcode extends Opcode {
 
   evaluate(vm: VM) {
     let metaDefinitionRef = vm.frame.getOperand();
-    let definitionRef = metaDefinitionRef.get('definition' as InternedString);
-    let curriedArgsRef = definitionRef.get('args' as InternedString);
+    let definitionRef = metaDefinitionRef.get('definition' as FIXME<'intern'>);
+    let curriedArgsRef = metaDefinitionRef.get('args' as FIXME<'intern'>);
 
     let cache = isConst(definitionRef) ? undefined : new ReferenceCache(definitionRef);
     let definition = cache ? cache.peek() : definitionRef.value();

--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -21,15 +21,18 @@ export class PutDynamicComponentDefinitionOpcode extends Opcode {
 
   evaluate(vm: VM) {
     let metaDefinitionRef = vm.frame.getOperand();
-    let cache = isConst(metaDefinitionRef) ? undefined : new ReferenceCache(metaDefinitionRef);
-    let metaDefinition = cache ? cache.peek() : metaDefinitionRef.value();
+    let definitionRef = metaDefinitionRef.get('definition' as InternedString);
+    let curriedArgsRef = definitionRef.get('args' as InternedString);
+
+    let cache = isConst(definitionRef) ? undefined : new ReferenceCache(definitionRef);
+    let definition = cache ? cache.peek() : definitionRef.value();
 
     let args = this.args.evaluate(vm).withInternal();
-    // TODO: Insert the curried args if they exist
-    // metaDefinition.get('args').value()
+
     vm.frame.setArgs(args);
 
-    args.internal["definition"] = metaDefinition.definition; // should be a .get('definition').value()
+    args.internal["definition"] = definition;
+    args.internal["args"] = curriedArgsRef.value();
 
     if (cache) {
       vm.updateWith(new Assert(cache));

--- a/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -4,7 +4,7 @@ import { CompiledArgs, EvaluatedArgs } from '../expressions/args';
 import { VM, UpdatingVM, BindDynamicScopeCallback } from '../../vm';
 import { Layout, InlineBlock, PartialBlock } from '../blocks';
 import { turbocharge } from '../../utils';
-import { NULL_REFERENCE } from '../../references';
+import { ConditionalReference, NULL_REFERENCE } from '../../references';
 import SymbolTable from '../../symbol-table';
 import { PathReference } from 'glimmer-reference';
 import { ValueReference } from '../expressions/value';
@@ -401,9 +401,7 @@ export class TestPropOpcode extends Opcode {
 
   evaluate(vm: VM) {
     let operand = vm.frame.getOperand();
-    // TODO: Use a simplified conversion to conditional. It should rely on basic
-    // truthiness and not be environment-specific.
-    vm.frame.setCondition(vm.env.toConditionalReference(operand.get(this.prop)));
+    vm.frame.setCondition(new ConditionalReference(operand.get(this.prop)));
   }
 
   toJSON(): OpcodeJSON {

--- a/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -390,6 +390,31 @@ export class TestOpcode extends Opcode {
   }
 }
 
+export class TestPropOpcode extends Opcode {
+  private prop: InternedString;
+  public type = "test-prop";
+
+  constructor(prop: InternedString) {
+    super();
+    this.prop = prop;
+  }
+
+  evaluate(vm: VM) {
+    let operand = vm.frame.getOperand();
+    // TODO: Use a simplified conversion to conditional. It should rely on basic
+    // truthiness and not be environment-specific.
+    vm.frame.setCondition(vm.env.toConditionalReference(operand.get(this.prop)));
+  }
+
+  toJSON(): OpcodeJSON {
+    return {
+      guid: this._guid,
+      type: this.type,
+      args: ["$OPERAND"]
+    };
+  }
+}
+
 export class JumpOpcode extends Opcode {
   public type = "jump";
 

--- a/packages/glimmer-runtime/lib/compiler.ts
+++ b/packages/glimmer-runtime/lib/compiler.ts
@@ -23,7 +23,8 @@ import {
   PutArgsOpcode,
   PutValueOpcode,
   JumpUnlessOpcode,
-  TestOpcode
+  TestOpcode,
+  TestPropOpcode
 } from './compiled/opcodes/vm';
 
 import * as Syntax from './syntax/core';
@@ -426,7 +427,7 @@ class ComponentBuilder {
     compiler.append(BEGIN);
     compiler.append(new PutArgsOpcode({ args: definitionArgs }));
     compiler.append(new PutValueOpcode({ expression: definition }));
-    compiler.append(new TestOpcode());
+    compiler.append(new TestPropOpcode("definition" as FIXME<'intern'>));
     compiler.append(new JumpUnlessOpcode({ target: END }));
     compiler.append(new PutDynamicComponentDefinitionOpcode({ args }));
     compiler.append(new OpenComponentOpcode({ shadow, templates }));

--- a/packages/glimmer-runtime/lib/opcode-builder.ts
+++ b/packages/glimmer-runtime/lib/opcode-builder.ts
@@ -27,9 +27,11 @@ export interface StaticComponentOptions {
   templates: Templates;
 }
 
+export type DynamicComponent = { definition: ComponentDefinition<Opaque>, args: EvaluatedArgs};
+
 export interface DynamicComponentOptions {
   definitionArgs: Args;
-  definition: FunctionExpression<{ definition: ComponentDefinition<Opaque>, args: EvaluatedArgs}>;
+  definition: FunctionExpression<DynamicComponent>;
   args: Args;
   shadow: InternedString[];
   templates: Templates;

--- a/packages/glimmer-runtime/lib/opcode-builder.ts
+++ b/packages/glimmer-runtime/lib/opcode-builder.ts
@@ -7,6 +7,10 @@ import {
 } from './compiled/expressions/function';
 
 import {
+  EvaluatedArgs
+} from './compiled/expressions/args';
+
+import {
   Args,
   Templates,
 } from './syntax/core';
@@ -25,7 +29,7 @@ export interface StaticComponentOptions {
 
 export interface DynamicComponentOptions {
   definitionArgs: Args;
-  definition: FunctionExpression<ComponentDefinition<Opaque>>;
+  definition: FunctionExpression<{ definition: ComponentDefinition<Opaque>, args: EvaluatedArgs}>;
   args: Args;
   shadow: InternedString[];
   templates: Templates;

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -997,7 +997,7 @@ QUnit.test('nested closure component with positional parameter currying', assert
   class FooBar extends EmberishCurlyComponent {
     public foo = 'foo';
     public bar = 'bar';
-    public baz = null;
+    public baz;
 
     constructor(attrs: Attrs) {
       super(attrs);
@@ -1014,6 +1014,40 @@ QUnit.test('nested closure component with positional parameter currying', assert
 
   assertEmberishElement('div', '<p>foo alpha bar</p>');
 
+  rerender();
+
+  assertEmberishElement('div', '<p>foo alpha bar</p>');
+});
+
+QUnit.test('nested closure component with positional parameter currying, bound positional', assert => {
+  class FooBar extends EmberishCurlyComponent {
+    public foo = 'foo';
+    public bar = 'bar';
+    public baz;
+
+    constructor(attrs: Attrs) {
+      super(attrs);
+    }
+  }
+
+  FooBar.reopenClass({
+    positionalParams: ['baz']
+  });
+
+  env.registerEmberishCurlyComponent('foo-bar', FooBar, `<p>{{foo}} {{baz}} {{bar}}</p>`);
+
+  appendViewFor('{{component (component "foo-bar" letter)}}', {
+    letter: 'alpha'
+  });
+
+  assertEmberishElement('div', '<p>foo alpha bar</p>');
+
+  set(view, 'letter', 'beta');
+  rerender();
+
+  assertEmberishElement('div', '<p>foo beta bar</p>');
+
+  set(view, 'letter', 'alpha');
   rerender();
 
   assertEmberishElement('div', '<p>foo alpha bar</p>');

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -959,20 +959,15 @@ QUnit.test('nested closure component', assert => {
     }
   }
 
-  env.registerBasicComponent('foo-bar', FooBar, `<p>{{foo}} {{bar}} {{baz}}</p>`);
+  env.registerEmberishCurlyComponent('foo-bar', FooBar, `<p>{{foo}} {{bar}} {{baz}}</p>`);
 
-  appendViewFor(
-    stripTight`
-      <div>
-        {{component (component "foo-bar")}}
-      </div>`
-  );
+  appendViewFor('{{component (component "foo-bar")}}');
 
-  equalsElement(view.element, 'div', {}, '<p>foo bar baz</p>');
+  assertEmberishElement('div', '<p>foo bar baz</p>');
 
   rerender();
 
-  equalsElement(view.element, 'div', {}, '<p>foo bar baz</p>');
+  assertEmberishElement('div', '<p>foo bar baz</p>');
 });
 
 QUnit.test('nested closure component with named parameter currying', assert => {
@@ -987,20 +982,15 @@ QUnit.test('nested closure component with named parameter currying', assert => {
     }
   }
 
-  env.registerBasicComponent('foo-bar', FooBar, `<p>{{foo}} {{bar}} {{baz}}</p>`);
+  env.registerEmberishCurlyComponent('foo-bar', FooBar, `<p>{{foo}} {{bar}} {{baz}}</p>`);
 
-  appendViewFor(
-    stripTight`
-      <div>
-        {{component (component "foo-bar" baz="alpha")}}
-      </div>`
-  );
+  appendViewFor('{{component (component "foo-bar" baz="alpha")}}');
 
-  equalsElement(view.element, 'div', {}, '<p>foo bar alpha</p>');
+  assertEmberishElement('div', '<p>foo bar alpha</p>');
 
   rerender();
 
-  equalsElement(view.element, 'div', {}, '<p>foo bar alpha</p>');
+  assertEmberishElement('div', '<p>foo bar alpha</p>');
 });
 
 QUnit.test('nested closure component with positional parameter currying', assert => {
@@ -1018,20 +1008,15 @@ QUnit.test('nested closure component with positional parameter currying', assert
     positionalParams: ['baz']
   });
 
-  env.registerBasicComponent('foo-bar', FooBar, `<p>{{foo}} {{baz}} {{bar}}</p>`);
+  env.registerEmberishCurlyComponent('foo-bar', FooBar, `<p>{{foo}} {{baz}} {{bar}}</p>`);
 
-  appendViewFor(
-    stripTight`
-      <div>
-        {{component (component "foo-bar" "alpha")}}
-      </div>`
-  );
+  appendViewFor('{{component (component "foo-bar" "alpha")}}');
 
-  equalsElement(view.element, 'div', {}, '<p>foo alpha bar</p>');
+  assertEmberishElement('div', '<p>foo alpha bar</p>');
 
   rerender();
 
-  equalsElement(view.element, 'div', {}, '<p>foo alpha bar</p>');
+  assertEmberishElement('div', '<p>foo alpha bar</p>');
 });
 
 module("Components - curlies - dynamic customizations");

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -948,7 +948,7 @@ QUnit.test('initially present, then missing, then present', assert => {
 });
 
 QUnit.test('nested closure component', assert => {
-  class FooBar extends BasicComponent {
+  class FooBar extends EmberishCurlyComponent {
     public foo = 'foo';
     public bar = 'bar';
     public baz = null;
@@ -973,6 +973,65 @@ QUnit.test('nested closure component', assert => {
   rerender();
 
   equalsElement(view.element, 'div', {}, '<p>foo bar baz</p>');
+});
+
+QUnit.test('nested closure component with named parameter currying', assert => {
+  class FooBar extends EmberishCurlyComponent {
+    public foo = 'foo';
+    public bar = 'bar';
+    public baz = null;
+
+    constructor(attrs: Attrs) {
+      super(attrs);
+      this.baz = attrs['baz'] || 'baz';
+    }
+  }
+
+  env.registerBasicComponent('foo-bar', FooBar, `<p>{{foo}} {{bar}} {{baz}}</p>`);
+
+  appendViewFor(
+    stripTight`
+      <div>
+        {{component (component "foo-bar" baz="alpha")}}
+      </div>`
+  );
+
+  equalsElement(view.element, 'div', {}, '<p>foo bar alpha</p>');
+
+  rerender();
+
+  equalsElement(view.element, 'div', {}, '<p>foo bar alpha</p>');
+});
+
+QUnit.test('nested closure component with positional parameter currying', assert => {
+  class FooBar extends EmberishCurlyComponent {
+    public foo = 'foo';
+    public bar = 'bar';
+    public baz = null;
+
+    constructor(attrs: Attrs) {
+      super(attrs);
+    }
+  }
+
+  FooBar.reopenClass({
+    positionalParams: ['baz']
+  });
+
+  env.registerBasicComponent('foo-bar', FooBar, `<p>{{foo}} {{baz}} {{bar}}</p>`);
+
+  appendViewFor(
+    stripTight`
+      <div>
+        {{component (component "foo-bar" "alpha")}}
+      </div>`
+  );
+
+  equalsElement(view.element, 'div', {}, '<p>foo alpha bar</p>');
+
+  rerender();
+
+  equalsElement(view.element, 'div', {}, '<p>foo alpha bar</p>');
 });
 
 module("Components - curlies - dynamic customizations");

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -947,6 +947,34 @@ QUnit.test('initially present, then missing, then present', assert => {
   equalsElement(view.element, 'div', {}, '<p>foo bar baz</p>');
 });
 
+QUnit.test('nested closure component', assert => {
+  class FooBar extends BasicComponent {
+    public foo = 'foo';
+    public bar = 'bar';
+    public baz = null;
+
+    constructor(attrs: Attrs) {
+      super(attrs);
+      this.baz = attrs['baz'] || 'baz';
+    }
+  }
+
+  env.registerBasicComponent('foo-bar', FooBar, `<p>{{foo}} {{bar}} {{baz}}</p>`);
+
+  appendViewFor(
+    stripTight`
+      <div>
+        {{component (component "foo-bar")}}
+      </div>`
+  );
+
+  equalsElement(view.element, 'div', {}, '<p>foo bar baz</p>');
+
+  rerender();
+
+  equalsElement(view.element, 'div', {}, '<p>foo bar baz</p>');
+});
+
 module("Components - curlies - dynamic customizations");
 
 QUnit.test('dynamic tagName', assert => {

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -51,6 +51,7 @@ import {
   // References
   ValueReference,
   ConditionalReference,
+  UNDEFINED_REFERENCE,
 
   // Misc
   ElementOperations,
@@ -837,31 +838,44 @@ class CurlyComponentSyntax extends StatementSyntax implements StaticComponentOpt
   }
 }
 
-class DynamicComponentReference implements PathReference<ComponentDefinition<Opaque>> {
+class DynamicComponentReference implements PathReference<{ definition: ComponentDefinition<Opaque>, args: EvaluatedArgs }> {
   private nameRef: PathReference<Opaque>;
   private env: Environment;
+  private definition: ComponentDefinition<Opaque>;
+  private args: EvaluatedArgs;
   public tag: RevisionTag;
 
-  constructor({ nameRef, env, args }: { nameRef: PathReference<Opaque>, env: Environment, args: EvaluatedArgs }) {
+  constructor({ nameRef, env, definition, args }: { nameRef: PathReference<Opaque>, env: Environment, definition?: ComponentDefinition<Opaque>, args?: EvaluatedArgs }) {
     this.nameRef = nameRef;
     this.env = env;
-    this.tag = args.tag;
+    this.definition = definition;
+    this.args = args;
+    this.tag = nameRef.tag;
   }
 
-  value(): ComponentDefinition<Opaque> {
+  value(): { definition: ComponentDefinition<Opaque>, args: EvaluatedArgs } {
     let { env, nameRef } = this;
 
     let name = nameRef.value();
 
     if (typeof name === 'string') {
-      return env.getComponentDefinition([name as FIXME<'user str InternedString'> as InternedString]);
+      return {
+        definition: env.getComponentDefinition([name as FIXME<'user str InternedString'> as InternedString]),
+        args: EvaluatedArgs.empty()
+      };
     } else {
       return null;
     }
   }
 
-  get() {
-    return null;
+  get(path) {
+    if ('definition' === path) {
+
+    } else if ('args' === path) {
+
+    }
+
+    return UNDEFINED_REFERENCE;
   }
 }
 
@@ -874,7 +888,7 @@ function dynamicComponentFor(vm: VM) {
 
 class DynamicComponentSyntax extends StatementSyntax implements DynamicComponentOptions {
   public definitionArgs: ArgsSyntax;
-  public definition: FunctionExpression<ComponentDefinition<Opaque>>;
+  public definition: FunctionExpression<{ definition: ComponentDefinition<Opaque>, args: EvaluatedArgs }>;
   public args: ArgsSyntax;
   public shadow: InternedString[] = null;
   public templates: Templates;

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -865,15 +865,13 @@ class DynamicComponentReference implements PathReference<DynamicComponent> {
 
   get(key: string): PathReference<Opaque> {
     if ('definition' === key) {
-      let name = <string>this.nameRef.value();
-
       if (isConst(this.nameRef)) {
-        return new ValueReference(this.getComponentDefinition(name));
+        return new ValueReference(this.getComponentDefinition(<string>this.nameRef.value()));
       } else {
-        return new SimplePathReference(this, <InternedString>'definition');
+        return new SimplePathReference(this, 'definition' as FIXME<InternedString>);
       }
     } else if ('args' === key) {
-      return new SimplePathReference(this, <InternedString>'args');
+      return new SimplePathReference(this, 'args' as FIXME<InternedString>);
     }
 
     return UNDEFINED_REFERENCE;
@@ -881,7 +879,7 @@ class DynamicComponentReference implements PathReference<DynamicComponent> {
 
   getComponentDefinition(name: string) : ComponentDefinition<Opaque> {
     if (typeof name === 'string') {
-      return this.env.getComponentDefinition([name as FIXME<'user str InternedString'> as InternedString]);
+      return this.env.getComponentDefinition([name as FIXME<'user str InternedString'>]);
     } else {
       return null;
     }
@@ -892,7 +890,7 @@ function dynamicComponentFor(vm: VM) {
   let args = vm.getArgs();
   let nameRef = args.positional.at(0);
   let env = vm.env;
-  return new DynamicComponentReference({ nameRef, env, args });
+  return new DynamicComponentReference({ nameRef, env, curriedArgs: args });
 };
 
 class DynamicComponentSyntax extends StatementSyntax implements DynamicComponentOptions {

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -32,6 +32,7 @@ import {
   ComponentManager,
   ComponentDefinition,
   ComponentLayoutBuilder,
+  DynamicComponent,
   DynamicComponentOptions,
   StaticComponentOptions,
 
@@ -838,7 +839,7 @@ class CurlyComponentSyntax extends StatementSyntax implements StaticComponentOpt
   }
 }
 
-class DynamicComponentReference implements PathReference<{ definition: ComponentDefinition<Opaque>, args: EvaluatedArgs }> {
+class DynamicComponentReference implements PathReference<DynamicComponent> {
   private nameRef: PathReference<Opaque>;
   private env: Environment;
   private args: EvaluatedArgs;
@@ -851,7 +852,7 @@ class DynamicComponentReference implements PathReference<{ definition: Component
     this.tag = nameRef.tag;
   }
 
-  value(): { definition: ComponentDefinition<Opaque>, args: EvaluatedArgs } {
+  value(): DynamicComponent {
     let { env, nameRef } = this;
 
     let name = nameRef.value();
@@ -896,7 +897,7 @@ function dynamicComponentFor(vm: VM) {
 
 class DynamicComponentSyntax extends StatementSyntax implements DynamicComponentOptions {
   public definitionArgs: ArgsSyntax;
-  public definition: FunctionExpression<{ definition: ComponentDefinition<Opaque>, args: EvaluatedArgs }>;
+  public definition: FunctionExpression<DynamicComponent>;
   public args: ArgsSyntax;
   public shadow: InternedString[] = null;
   public templates: Templates;


### PR DESCRIPTION
This adds support for dynamic components + currying of their args. Still a work in progress. Note: the actual currying and stuff doesn't happen here -- it would happen in Ember. This just adds machinery to support it without doing weird things.

The basic idea here is the separate the component definition from any args that need to be curried when instantiating it. This means that places that use to return a `ComponentDefinition` now need to return something like `{ definition: ComponentDefinition, args: EvaluatedArgs[] }`.

This applies only for dynamic components.

This also adds a new opcode for testing the property of a reference, called `TestPropOpcode`. This can be used to observe if/when the `definition` reference's value changes between truthy and falsy values (for cases where the component reference "disappears" and appears later as well as the converse).

The `TestPropOpcode` doesn't use Emberish truthiness -- it relies on Glimmerish truthiness.