### PR TITLE
Implement slice() for EvaluatedPositionalArgs and concrete classes

### DIFF
--- a/packages/glimmer-runtime/lib/compiled/expressions/positional-args.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/positional-args.ts
@@ -82,6 +82,7 @@ export abstract class EvaluatedPositionalArgs {
 
   abstract at(index: number): PathReference<any>;
   abstract value(): any[];
+  abstract slice(begin?: number, end?: number): EvaluatedPositionalArgs;
 }
 
 class NonEmptyEvaluatedPositionalArgs extends EvaluatedPositionalArgs {
@@ -106,6 +107,12 @@ class NonEmptyEvaluatedPositionalArgs extends EvaluatedPositionalArgs {
 
     return ret;
   }
+
+  slice(begin?: number, end?: number): EvaluatedPositionalArgs {
+    return EvaluatedPositionalArgs.create({
+      values: this.values.slice(begin, end)
+    });
+  }
 }
 
 export const EVALUATED_EMPTY_POSITIONAL_ARGS = new (class extends EvaluatedPositionalArgs {
@@ -119,5 +126,9 @@ export const EVALUATED_EMPTY_POSITIONAL_ARGS = new (class extends EvaluatedPosit
 
   value(): any[] {
     return [];
+  }
+
+  slice(begin?: number, end?: number): EvaluatedPositionalArgs {
+    return this;
   }
 });


### PR DESCRIPTION
Adds `slice()` to the interface and implements it for the concrete classes. I'm using this for closure components but until now was doing it by ripping positional args apart and creating a new one. This cleans things up nicely.