### PR TITLE
Adds a CommonJS build

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -94,10 +94,11 @@ module.exports = function() {
   // SimpleHTMLTokenizer ships as either ES6 or a single AMD-ish file, so we have to
   // compile it from ES6 modules to CJS using TypeScript. broccoli-typescript-compiler
   // only works with `.ts` files, so we rename the `.js` files to `.ts` first.
-  var simpleHTMLTokenizerLib = rename('node_modules/simple-html-tokenizer/lib', '.js', '.ts');
+  var simpleHTMLTokenizerPath = path.join(__dirname, 'node_modules/simple-html-tokenizer/lib');
+  var simpleHTMLTokenizerLib = rename(simpleHTMLTokenizerPath, '.js', '.ts');
   var simpleHTMLTokenizerJSTree = typescript(simpleHTMLTokenizerLib, tsOptions);
 
-  cjsTree = merge([cjsTree, simpleHTMLTokenizerJSTree, 'node_modules/handlebars/dist/cjs/']);
+  cjsTree = merge([cjsTree, simpleHTMLTokenizerJSTree, path.join(__dirname, 'node_modules/handlebars/dist/cjs/')]);
 
   // Glimmer packages require other Glimmer packages using non-relative module names
   // (e.g., `glimmer-compiler` may import `glimmer-util` instead of `../glimmer-util`),

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -16,11 +16,7 @@ function transpile(tree, label) {
   return transpileES6(tree, label, { sourceMaps: 'inline' });
 }
 
-module.exports = function() {
-  var packages = __dirname + '/packages';
-  var bower = __dirname + '/bower_components';
-  var hasBower = existsSync(bower);
-
+function buildTSOptions(compilerOptions) {
   var tsOptions = {
     tsconfig: {
       compilerOptions: {
@@ -35,6 +31,18 @@ module.exports = function() {
       }
     }
   };
+
+  Object.assign(tsOptions.tsconfig.compilerOptions, compilerOptions);
+
+  return tsOptions;
+}
+
+module.exports = function() {
+  var packages = __dirname + '/packages';
+  var bower = __dirname + '/bower_components';
+  var hasBower = existsSync(bower);
+
+  var tsOptions = buildTSOptions();
 
   var demoTrees = [
     find(__dirname + '/demos', {
@@ -87,7 +95,10 @@ module.exports = function() {
   /*
    * CommonJS Build
    */
-  tsOptions.tsconfig.compilerOptions.module = "commonjs";
+  tsOptions = buildTSOptions({
+    module: "commonjs",
+    target: "es5"
+  });
 
   var cjsTree = typescript(tsTree, tsOptions);
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "glimmer-engine",
   "version": "0.5.0",
   "description": "Glimmer compiles Handlebars templates into document fragments rather than string buffers",
-  "main": "dist/es6/glimmer/index.js",
+  "esnext:main": "dist/es6/glimmer/index.js",
+  "main": "dist/node_modules/glimmer/index.js",
   "scripts": {
     "prepublish": "bower install && ember build",
     "build": "ember build",
@@ -23,6 +24,7 @@
   "author": "Tilde, Inc.",
   "license": "MIT",
   "readmeFilename": "README.md",
+  "files": ["dist"],
   "dependencies": {
     "broccoli-concat": "^2.1.0",
     "broccoli-funnel": "^1.0.1",
@@ -44,7 +46,6 @@
     "ember-cli": "^2.4.2",
     "ember-cli-release": "^0.2.2",
     "ember-cli-sauce": "^1.3.0",
-    "tslint": "next",
-    "typescript": "next"
+    "tslint": "next"
   }
 }


### PR DESCRIPTION
This PR adds a CommonJS build for consumption by Node tools (like, say, a Broccoli plugin for compiling templates).

There are a couple weird things here that could use explanation.

First, rather than building into `dist/cjs/` (like `htmlbars` does), this puts the CJS files inside `dist/node_modules/`. This is because inside Glimmer we require across packages via top-level names rather than relative paths. For example, you might see something like `import { preprocess } from "glimmer-syntax";` instead of `import { preprocess } from "../../glimmer-syntax";`.

Node doesn't handle this case if we put it in a `cjs` directory, because it only looks for non-relative packages inside directories called `node_modules`. We should either publish each Glimmer package as a separate npm package, or maybe just use relative module names.

The other unusual thing is that Glimmer relies on SimpleHTMLTokenizer, which ships as either ES6 or an AMD-ish file (which does indeed support CommonJS consumption as well). When compiled from ES6 to AMD-ish, though, everything gets concatenated into a single file. Glimmer imports just pieces of SHT, like `import EventedTokenizer from "simple-html-tokenizer/evented-tokenizer"`; when compiled to CJS by TypeScript, that becomes `require('simple-html-tokenizer/evented-tokenizer')`. In order to support these modules in Node, we need to maintain separate files rather than concatenating everything together.

To that end, this PR uses TypeScript as a poor man's ES6-to-CommonJS compiler, converting from ES6 modules to CommonJS modules and colocating them with Glimmer's CommonJS modules in `dist/node_modules`.

This PR also removes the duplicate `typescript` dev dependency, and adds `esnext:main` and `main` entries to `package.json`.