### PR TITLE
Include TypeScript source in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+bower_components
+/node_modules
+tmp
+npm-debug.log
+sauce-example.log
+
+testem.log
+
+.vscode

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
   "author": "Tilde, Inc.",
   "license": "MIT",
   "readmeFilename": "README.md",
-  "files": [
-    "dist"
-  ],
   "dependencies": {
     "broccoli-concat": "^2.1.0",
     "broccoli-funnel": "^1.0.1",


### PR DESCRIPTION
This is useful for TypeScript apps that want to consume Glimmer directly