### PR TITLE
Use relative paths for embedded ember-cli-build.js usage.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -105,11 +105,11 @@ module.exports = function() {
   // SimpleHTMLTokenizer ships as either ES6 or a single AMD-ish file, so we have to
   // compile it from ES6 modules to CJS using TypeScript. broccoli-typescript-compiler
   // only works with `.ts` files, so we rename the `.js` files to `.ts` first.
-  var simpleHTMLTokenizerPath = path.join(__dirname, 'node_modules/simple-html-tokenizer/lib');
-  var simpleHTMLTokenizerLib = rename(simpleHTMLTokenizerPath, '.js', '.ts');
+  var simpleHTMLTokenizerLib = rename(tokenizerPath, '.js', '.ts');
   var simpleHTMLTokenizerJSTree = typescript(simpleHTMLTokenizerLib, tsOptions);
+  var handlebarsPath = path.join(require.resolve('handlebars'), '..', '..', 'dist', 'cjs');
 
-  cjsTree = merge([cjsTree, simpleHTMLTokenizerJSTree, path.join(__dirname, 'node_modules/handlebars/dist/cjs/')]);
+  cjsTree = merge([cjsTree, simpleHTMLTokenizerJSTree, handlebarsPath]);
 
   // Glimmer packages require other Glimmer packages using non-relative module names
   // (e.g., `glimmer-compiler` may import `glimmer-util` instead of `../glimmer-util`),


### PR DESCRIPTION
Assuming that these dependencies are always at `./node_modules` will only work with npm@2.  On npm@3 the deps will generally be all flattened at some parent consuming application's `node_modules` directory.