### PR TITLE
Fix package name in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "htmlbars",
+  "name": "glimmer-engine",
   "devDependencies": {
     "loader.js": "~3.5.0",
     "qunit": "~1.20.0",


### PR DESCRIPTION
In favor of the name in [package.json](https://github.com/tildeio/glimmer/blob/d4d1e3a86/package.json#L2).