### PR TITLE
Create sanitized attribute and property classes

### DIFF
--- a/packages/glimmer-runtime/lib/builder.ts
+++ b/packages/glimmer-runtime/lib/builder.ts
@@ -94,12 +94,13 @@ class GroupedElementOperations implements ElementOperations {
     let { element } = this;
     let { tagName } = element;
 
-    if (SanitizedProperty.requiresSanitization(tagName, name)) {
+    if (SanitizedNonNamespacedAttribute.requiresSanitization(tagName, name)) {
       this.group.push(new SanitizedNonNamespacedAttribute(element, name, reference));
     } else if (tagName === 'INPUT' && name === 'value') {
       this.group.push(new EmptyStringResetingProperty(element, name, reference));
+    } else {
+      this.group.push(new NonNamespacedAttribute(element, name, reference));
     }
-    this.group.push(new NonNamespacedAttribute(element, name, reference));
   }
 
   addAttributeNS(namespace: InternedString, name: InternedString, reference: PathReference<string>) {

--- a/packages/glimmer-runtime/lib/builder.ts
+++ b/packages/glimmer-runtime/lib/builder.ts
@@ -15,7 +15,9 @@ import {
   EmptyStringResetingProperty,
   NamespacedAttribute,
   NonNamespacedAttribute,
-  Property
+  Property,
+  SanitizedProperty,
+  SanitizedNonNamespacedAttribute
 } from './compiled/opcodes/dom';
 
 interface FirstNode {
@@ -89,10 +91,15 @@ class GroupedElementOperations implements ElementOperations {
   }
 
   addAttribute(name: InternedString, reference: PathReference<string>) {
-    if (this.element.tagName === 'INPUT' && name === 'value') {
-      this.group.push(new EmptyStringResetingProperty(this.element, name, reference));
+    let { element } = this;
+    let { tagName } = element;
+
+    if (SanitizedProperty.requiresSanitization(tagName, name)) {
+      this.group.push(new SanitizedNonNamespacedAttribute(element, name, reference));
+    } else if (tagName === 'INPUT' && name === 'value') {
+      this.group.push(new EmptyStringResetingProperty(element, name, reference));
     }
-    this.group.push(new NonNamespacedAttribute(this.element, name, reference));
+    this.group.push(new NonNamespacedAttribute(element, name, reference));
   }
 
   addAttributeNS(namespace: InternedString, name: InternedString, reference: PathReference<string>) {
@@ -100,7 +107,14 @@ class GroupedElementOperations implements ElementOperations {
   }
 
   addProperty(name: InternedString, reference: PathReference<any>) {
-    this.group.push(new Property(this.element, name, reference));
+    let { element } = this;
+    let { tagName } = element;
+
+    if (SanitizedProperty.requiresSanitization(tagName, name)) {
+      this.group.push(new SanitizedProperty(element, name, reference));
+    } else {
+      this.group.push(new Property(element, name, reference));
+    }
   }
 }
 

--- a/packages/glimmer-runtime/lib/dom.ts
+++ b/packages/glimmer-runtime/lib/dom.ts
@@ -46,11 +46,21 @@ class DOMHelper {
   private document: HTMLDocument;
   private namespace: string;
   private uselessElement: HTMLElement;
+  private anchorElement: HTMLAnchorElement;
 
   constructor(document) {
     this.document = document;
     this.namespace = null;
     this.uselessElement = this.document.createElement('div');
+    this.anchorElement = this.document.createElement('a');
+  }
+
+  protocolForURL(url: string): string {
+    let { anchorElement } = this;
+
+    anchorElement.href = url;
+
+    return anchorElement.protocol;
   }
 
   setAttribute(element: Element, name: string, value: string) {

--- a/packages/glimmer-runtime/lib/sanitize-attribute-value.ts
+++ b/packages/glimmer-runtime/lib/sanitize-attribute-value.ts
@@ -1,0 +1,66 @@
+import { FIXME, InternedString, Opaque } from 'glimmer-util';
+import { SafeString, isSafeString } from './upsert';
+import { DOMHelper } from './dom';
+
+const badProtocols = {
+  'javascript:': true,
+  'vbscript:': true
+};
+
+const badTags = {
+  'A': true,
+  'BODY': true,
+  'LINK': true,
+  'IMG': true,
+  'IFRAME': true,
+  'BASE': true,
+  'FORM': true
+};
+
+const badTagsForDataURI = {
+  'EMBED': true
+};
+
+export const badAttributes = {
+  'href': true,
+  'src': true,
+  'background': true,
+  'action': true
+};
+
+const badAttributesForDataURI = {
+  'src': true
+};
+
+type StringType = string | SafeString;
+
+export function requiresSanitization(tagName: string, attribute: string): boolean {
+  return (((tagName === null || badTags[tagName]) && badAttributes[attribute]) || (badTagsForDataURI[tagName] && badAttributesForDataURI[attribute]));
+}
+
+export function sanitizeAttributeValue(dom: DOMHelper, element: Element, attribute: string, value: Opaque): Opaque {
+  let tagName;
+
+  if (!element) {
+    tagName = null;
+  } else {
+    tagName = element.tagName.toUpperCase();
+  }
+
+  if (isSafeString(value)) {
+    return value.toHTML();
+  }
+
+  if ((tagName === null || badTags[tagName]) && badAttributes[attribute]) {
+    var protocol = dom.protocolForURL(value as FIXME<string>);
+    if (badProtocols[protocol] === true) {
+      return `unsafe:${value}`;
+    }
+  }
+
+  if (badTagsForDataURI[tagName] && badAttributesForDataURI[attribute]) {
+    return `unsafe:${value}`;
+  }
+
+  return value;
+}

--- a/packages/glimmer-runtime/tests/attributes-test.ts
+++ b/packages/glimmer-runtime/tests/attributes-test.ts
@@ -45,6 +45,62 @@ QUnit.module("Attributes", {
   setup: commonSetup
 });
 
+test("a[href] marks javascript: protocol as unsafe", () => {
+  let template = compile('<a href="{{foo}}"></a>');
+
+  let context = { foo: 'javascript:foo()' };
+  render(template, context);
+
+  equalTokens(root, '<a href="unsafe:javascript:foo()"></a>');
+
+  rerender();
+
+  equalTokens(root, '<a href="unsafe:javascript:foo()"></a>');
+});
+
+test("a[href] marks javascript: protocol as unsafe, http as safe", () => {
+  let template = compile('<a href="{{foo}}"></a>');
+
+  let context = { foo: 'javascript:foo()' };
+  render(template, context);
+
+  equalTokens(root, '<a href="unsafe:javascript:foo()"></a>');
+
+  rerender({ foo: 'http://foo.bar' });
+
+  equalTokens(root, '<a href="http://foo.bar"></a>');
+
+  rerender({ foo: 'javascript:foo()' });
+
+  equalTokens(root, '<a href="unsafe:javascript:foo()"></a>');
+});
+
+test("a[href] marks vbscript: protocol as unsafe", () => {
+  let template = compile('<a href="{{foo}}"></a>');
+
+  let context = { foo: 'vbscript:foo()' };
+  render(template, context);
+
+  equalTokens(root, '<a href="unsafe:vbscript:foo()"></a>');
+
+  rerender();
+
+  equalTokens(root, '<a href="unsafe:vbscript:foo()"></a>');
+});
+
+test("div[href] is not not marked as unsafe", () => {
+  let template = compile('<div href="{{foo}}"></div>');
+
+  let context = { foo: 'javascript:foo()' };
+  render(template, context);
+
+  equalTokens(root, '<div href="javascript:foo()"></div>');
+
+  rerender();
+
+  equalTokens(root, '<div href="javascript:foo()"></div>');
+});
+
 test("helpers shadow self", () => {
   env.registerHelper('foo', function() {
     return "hello";


### PR DESCRIPTION
This creates "sanitized" subclasses of `Property` and `NonNamespacedAttribute` which enforce sanitization of known dangerous tag/attribute combinations. This also makes https://github.com/emberjs/ember.js/blob/1be0354068d933065ac542f49d42d73409366a47/packages/ember-glimmer/tests/integration/components/attribute-bindings-test.js#L456 and https://github.com/emberjs/ember.js/blob/3cfc9614bbd92ee8e80b6c4894b024f2e14bffae/packages/ember-glimmer/tests/integration/helpers/unbound-test.js#L98 pass.