### PR TITLE
Propagate moduleName to statement

### DIFF
--- a/packages/glimmer-compiler/index.ts
+++ b/packages/glimmer-compiler/index.ts
@@ -4,7 +4,8 @@ export {
 } from "./lib/compiler";
 
 export {
-  default as TemplateCompiler
+  default as TemplateCompiler,
+  CompileOptions
 } from './lib/template-compiler';
 
 export { default as TemplateVisitor } from './lib/template-visitor';

--- a/packages/glimmer-compiler/lib/javascript-compiler.ts
+++ b/packages/glimmer-compiler/lib/javascript-compiler.ts
@@ -2,6 +2,7 @@ import { assert } from "glimmer-util";
 import { Stack, DictSet, InternedString, dict } from "glimmer-util";
 
 import {
+  BlockMeta,
   SerializedBlock,
   SerializedTemplate,
   Core,
@@ -32,11 +33,16 @@ export class Block {
 }
 
 export class Template extends Block {
-  public meta: Object = null;
+  public meta: BlockMeta = null;
 
   public yields = new DictSet();
   public named = new DictSet();
   public blocks: Block[] = [];
+
+  constructor(meta) {
+    super();
+    this.meta = meta;
+  }
 
   toJSON(): SerializedTemplate {
     return {
@@ -45,14 +51,14 @@ export class Template extends Block {
       named: this.named.toArray(),
       yields: this.yields.toArray(),
       blocks: this.blocks.map(b => b.toJSON()),
-      meta: null
+      meta: this.meta
     };
   }
 }
 
 export default class JavaScriptCompiler {
-  static process(opcodes): Template {
-    let compiler = new JavaScriptCompiler(opcodes);
+  static process(opcodes, meta): Template {
+    let compiler = new JavaScriptCompiler(opcodes, meta);
     return compiler.process();
   }
 
@@ -61,9 +67,9 @@ export default class JavaScriptCompiler {
   private opcodes: any[];
   private values: StackValue[] = [];
 
-  constructor(opcodes) {
+  constructor(opcodes, meta) {
     this.opcodes = opcodes;
-    this.template = new Template();
+    this.template = new Template(meta);
   }
 
   process() {

--- a/packages/glimmer-compiler/lib/template-compiler.ts
+++ b/packages/glimmer-compiler/lib/template-compiler.ts
@@ -1,26 +1,35 @@
 import TemplateVisitor from "./template-visitor";
 import JavaScriptCompiler from "./javascript-compiler";
-import { getAttrNamespace } from "glimmer-util";
+import { FIXME, getAttrNamespace } from "glimmer-util";
 import { isHelper } from "glimmer-syntax";
 import { assert } from "glimmer-util";
+import { Environment } from "glimmer-runtime";
+
+export interface CompileOptions {
+  buildMeta?: FIXME<'currently does nothing'>;
+  moduleName?: string;
+}
 
 export default class TemplateCompiler {
-  static compile(options, ast) {
+  static compile(options: CompileOptions, ast) {
     let templateVisitor = new TemplateVisitor();
     templateVisitor.visit(ast);
 
     let compiler = new TemplateCompiler(options);
     let opcodes = compiler.process(templateVisitor.actions);
-    return JavaScriptCompiler.process(opcodes);
+    let meta = {
+      moduleName: options.moduleName
+    };
+    return JavaScriptCompiler.process(opcodes, meta);
   }
 
-  private options: Object;
+  private options: CompileOptions;
   private templateId = 0;
   private templateIds: number[] = [];
   private opcodes: any[] = [];
   private includeMeta = false;
 
-  constructor(options: Object = {}) {
+  constructor(options: CompileOptions = {}) {
     this.options = options;
   }
 

--- a/packages/glimmer-compiler/tests/compile-options-test.ts
+++ b/packages/glimmer-compiler/tests/compile-options-test.ts
@@ -1,0 +1,19 @@
+import { compile } from "glimmer-test-helpers";
+import { TestEnvironment } from "glimmer-test-helpers";
+
+let env: TestEnvironment;
+
+QUnit.module('Compile options', {
+  setup() {
+    env = new TestEnvironment();
+  }
+});
+
+QUnit.test('moduleName option is passed into meta', function() {
+  let moduleName = 'It ain\'t hard to tell';
+  let template = compile('Hi, {{name}}!', {
+    env,
+    moduleName
+  });
+  equal(template.raw.meta.moduleName, moduleName, 'Template has the moduleName');
+});

--- a/packages/glimmer-runtime/lib/compiled/blocks.ts
+++ b/packages/glimmer-runtime/lib/compiled/blocks.ts
@@ -3,6 +3,9 @@ import { OpSeq } from '../opcodes';
 import { Program } from '../syntax';
 import { Environment } from '../environment';
 import SymbolTable from '../symbol-table';
+import {
+  BlockMeta
+} from 'glimmer-wire-format';
 
 import {
   EntryPointCompiler,
@@ -13,6 +16,7 @@ export interface BlockOptions {
   children: InlineBlock[];
   program: Program;
   symbolTable: SymbolTable;
+  meta: BlockMeta;
 }
 
 export class CompiledBlock {
@@ -26,6 +30,7 @@ export class CompiledBlock {
 }
 
 export abstract class Block {
+  public meta: BlockMeta;
   public children: InlineBlock[];
   public program: Program;
   public symbolTable: SymbolTable;
@@ -35,6 +40,7 @@ export abstract class Block {
     this.symbolTable = options.symbolTable || null;
     this.children = options.children;
     this.program = options.program;
+    this.meta = options.meta;
   }
 }
 

--- a/packages/glimmer-runtime/lib/scanner.ts
+++ b/packages/glimmer-runtime/lib/scanner.ts
@@ -17,21 +17,22 @@ export default class Scanner {
 
   scanEntryPoint(): EntryPoint {
     return this.scanTop<EntryPoint>(({ program, children }) => {
-      return EntryPoint.create({ children, program, symbolTable: null });
+      let { meta } = this.spec;
+      return EntryPoint.create({ children, program, symbolTable: null, meta });
     });
   }
 
   scanLayout(): Layout {
     return this.scanTop<Layout>(({ program, children }) => {
-      let { named, yields } = this.spec;
-      return Layout.create({ children, program, named, yields, symbolTable: null });
+      let { named, yields, meta } = this.spec;
+      return Layout.create({ children, program, named, yields, symbolTable: null, meta });
     });
   }
 
   scanPartial(symbolTable: SymbolTable): PartialBlock {
     return this.scanTop<PartialBlock>(({ program, children }) => {
-      let { locals } = this.spec;
-      return new PartialBlock({ children, program, locals, symbolTable });
+      let { locals, meta } = this.spec;
+      return new PartialBlock({ children, program, locals, symbolTable, meta });
     });
   }
 
@@ -50,7 +51,7 @@ export default class Scanner {
 
   private buildBlock(block: SerializedBlock, blocks: InlineBlock[]): InlineBlock{
     let { program, children } = this.buildStatements(block, blocks);
-    return new InlineBlock({ children, locals: block.locals, program, symbolTable: null });
+    return new InlineBlock({ children, locals: block.locals, program, symbolTable: null, meta: null });
   }
 
   private buildStatements({ statements }: SerializedBlock, blocks: InlineBlock[]): ScanResults {
@@ -97,7 +98,7 @@ export class BlockScanner {
 
   endBlock(): InlineBlock {
     let { children, program } = this.stack.pop();
-    let block = new InlineBlock({ children, program, symbolTable: null, locals: [] });
+    let block = new InlineBlock({ children, program, symbolTable: null, meta: null, locals: [] });
     this.addChild(block);
     return block;
   }

--- a/packages/glimmer-test-helpers/lib/helpers.ts
+++ b/packages/glimmer-test-helpers/lib/helpers.ts
@@ -2,7 +2,7 @@ import { tokenize } from "simple-html-tokenizer";
 import { FIXME, forEach } from "glimmer-util";
 import { SerializedTemplate } from 'glimmer-wire-format';
 import { Environment, Template, Layout } from "glimmer-runtime";
-import { TemplateSpec, compileSpec } from "glimmer-compiler";
+import { TemplateSpec, compileSpec, CompileOptions } from "glimmer-compiler";
 
 const TextNode = (<any>window).Text;
 const Comment = (<any>window).Comment;
@@ -19,12 +19,11 @@ function isMarker(node) {
   return false;
 }
 
-interface CompileOptions {
-  buildMeta?: FIXME<'currently does nothing'>;
+interface TestCompileOptions extends CompileOptions {
   env: Environment;
 }
 
-export function compileRealSpec(string: string, options: CompileOptions): SerializedTemplate {
+export function compileRealSpec(string: string, options: TestCompileOptions): SerializedTemplate {
   return template(compileSpec(string, options));
 }
 
@@ -59,11 +58,11 @@ export function compileRealSpec(string: string, options: CompileOptions): Serial
  * @param {Object} options A set of options to provide to the compiler
  * @return {Template} A function for rendering the template
  */
-export function compile(string: string, options: CompileOptions): Template {
+export function compile(string: string, options: TestCompileOptions): Template {
   return Template.fromSpec(compileRealSpec(string, options), options.env);
 }
 
-export function compileLayout(string: string, options: CompileOptions): Layout {
+export function compileLayout(string: string, options: TestCompileOptions): Layout {
   return Template.layoutFromSpec(compileRealSpec(string, options), options.env);
 }
 

--- a/packages/glimmer-wire-format/index.ts
+++ b/packages/glimmer-wire-format/index.ts
@@ -128,13 +128,17 @@ export namespace Statements {
 
 export type Statement = Statements.Statement;
 
+export interface BlockMeta {
+  moduleName?: string;
+}
+
 export interface SerializedTemplate {
   statements: Statements.Statement[];
   locals: InternedString[];
   named: InternedString[];
   yields: InternedString[];
   blocks: SerializedBlock[];
-  meta: Object;
+  meta: BlockMeta;
 }
 
 export interface SerializedBlock {


### PR DESCRIPTION
- Needed for local lookup
- Supports moduleName property for compile options
- Add moduleName to statement on runtime template re-inflatation
- Tested against ember.js local lookup tests

cc @krisselden @chadhietala @wycats 

Would like some validation that this is the right approach before I add tests to glimmer itself