### PR TITLE
[wip] only concat attribute values when there are multiple values

### DIFF
--- a/packages/glimmer-compiler/lib/template-compiler.ts
+++ b/packages/glimmer-compiler/lib/template-compiler.ts
@@ -17,6 +17,7 @@ export default class TemplateCompiler {
 
     let compiler = new TemplateCompiler(options);
     let opcodes = compiler.process(templateVisitor.actions);
+
     let meta = {
       moduleName: options.moduleName
     };
@@ -93,7 +94,7 @@ export default class TemplateCompiler {
       this.opcode('staticAttr', action, name, namespace);
     } else if (action.value.type === 'MustacheStatement') {
       assert(name.indexOf(':') === -1, `Namespaced attributes cannot be set as props. Perhaps you meant ${name}="{{title}}"`);
-      this.opcode('dynamicProp', action, name);
+      this.opcode('dynamicAttr', action, name);
     } else {
       this.opcode('dynamicAttr', action, name, namespace);
     }

--- a/packages/glimmer-compiler/lib/template-compiler.ts
+++ b/packages/glimmer-compiler/lib/template-compiler.ts
@@ -96,9 +96,9 @@ export default class TemplateCompiler {
 
       if (action.value.isQuoted) {
         this.opcode('dynamicAttr', action, name);
-       } else {
-         this.opcode('dynamicProp', action, name);
-       }
+      } else {
+        this.opcode('dynamicProp', action, name);
+      }
     } else {
       this.opcode('dynamicAttr', action, name, namespace);
     }

--- a/packages/glimmer-compiler/lib/template-compiler.ts
+++ b/packages/glimmer-compiler/lib/template-compiler.ts
@@ -17,7 +17,6 @@ export default class TemplateCompiler {
 
     let compiler = new TemplateCompiler(options);
     let opcodes = compiler.process(templateVisitor.actions);
-
     let meta = {
       moduleName: options.moduleName
     };
@@ -94,7 +93,12 @@ export default class TemplateCompiler {
       this.opcode('staticAttr', action, name, namespace);
     } else if (action.value.type === 'MustacheStatement') {
       assert(name.indexOf(':') === -1, `Namespaced attributes cannot be set as props. Perhaps you meant ${name}="{{title}}"`);
-      this.opcode('dynamicAttr', action, name);
+
+      if (action.value.isQuoted) {
+        this.opcode('dynamicAttr', action, name);
+       } else {
+         this.opcode('dynamicProp', action, name);
+       }
     } else {
       this.opcode('dynamicAttr', action, name, namespace);
     }

--- a/packages/glimmer-syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/glimmer-syntax/lib/parser/tokenizer-event-handlers.ts
@@ -190,6 +190,7 @@ export default {
 };
 
 function assembleAttributeValue(parts, isQuoted, isDynamic, line) {
+  //TODO: GJ: remove differences between quoted and unquoted
   if (isDynamic) {
     if (isQuoted) {
       return assembleConcatenatedValue(parts);
@@ -222,7 +223,11 @@ function assembleConcatenatedValue(parts) {
     }
   }
 
-  return b.concat(parts);
+  if(parts.length === 1) {
+    return parts[0];
+  } else {
+    return b.concat(parts);
+  }
 }
 
 function validateEndTag(tag, element, selfClosing) {

--- a/packages/glimmer-syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/glimmer-syntax/lib/parser/tokenizer-event-handlers.ts
@@ -193,7 +193,13 @@ function assembleAttributeValue(parts, isQuoted, isDynamic, line) {
   //TODO: GJ: remove differences between quoted and unquoted
   if (isDynamic) {
     if (isQuoted) {
-      return assembleConcatenatedValue(parts);
+      // return assembleConcatenatedValue(parts);
+      if (parts.length === 1) {
+        parts[0].isQuoted = true;
+        return parts[0];
+      } else {
+        return assembleConcatenatedValue(parts);
+      }
     } else {
       if (parts.length === 1) {
         return parts[0];
@@ -223,11 +229,7 @@ function assembleConcatenatedValue(parts) {
     }
   }
 
-  if(parts.length === 1) {
-    return parts[0];
-  } else {
-    return b.concat(parts);
-  }
+  return b.concat(parts);
 }
 
 function validateEndTag(tag, element, selfClosing) {


### PR DESCRIPTION
**WIP**: Dipping my toes into glimmer land.

TODO:

 * [ ] Investigate `<button data-has-block=\"true\"></button>` test failures
 * [ ] Write Tests
 * [ ] Remove differences between quoted vs non-quoted attributes?

---

A template such as:

```hbs
<h1 class="{{foo}}">hi {{name}}</h1>
<h2 class="{{foo}} {{bar}}">hi {{name}}</h2>
```

Compiles to:

```
["openElement","h1",[]]
["dynamicAttr","class",["concat",[["unknown",["foo"]]]]]
["text","hi "]
["append",["unknown",["name"]],false]
["closeElement"]
["text","\n"]
["openElement","h2",[]]
["dynamicAttr","class",["concat",[["unknown",["foo"]]," ",["unknown",["bar"]]]]]
["text","hi "]
["append",["unknown",["name"]],false]
["closeElement"]
```

The `concat` for the `class` attribute of the `h1` isn't needed, this would be optimal:

```
["openElement","h1",[]]
["dynamicAttr","class",["unknown",["foo"]]]
["text","hi "]
["append",["unknown",["name"]],false]
["closeElement"]
["text","\n"]
["openElement","h2",[]]
["dynamicAttr","class",["concat",[["unknown",["foo"]]," ",["unknown",["bar"]]]]]
["text","hi "]
["append",["unknown",["name"]],false]
["closeElement"]
```

Some discussion with @rwjblue on [#dev-glimmer](https://embercommunity.slack.com/archives/dev-glimmer/p1467382257001006):

<img width="995" alt="screen shot 2016-07-01 at 15 29 54" src="https://cloud.githubusercontent.com/assets/2526/16524627/b37793f6-3fa0-11e6-80a9-6ded562b0a3a.png">

