### PR TITLE
remove out of date comments

### DIFF
--- a/packages/glimmer-test-helpers/lib/helpers.ts
+++ b/packages/glimmer-test-helpers/lib/helpers.ts
@@ -23,41 +23,6 @@ interface TestCompileOptions extends CompileOptions {
   env: Environment;
 }
 
-export function compileRealSpec(string: string, options: TestCompileOptions): SerializedTemplate {
-  return template(compileSpec(string, options));
-}
-
-/*
- * Compile a string into a template rendering function
- *
- * Example usage:
- *
- *     // Template is the hydration portion of the compiled template
- *     let template = compile("Howdy {{name}}");
- *
- *     // Template accepts three arguments:
- *     //
- *     //   1. A context object
- *     //   2. An env object
- *     //   3. A contextualElement (optional, document.body is the default)
- *     //
- *     // The env object *must* have at least these two properties:
- *     //
- *     //   1. `hooks` - Basic hooks for rendering a template
- *     //   2. `dom` - An instance of DOMHelper
- *     //
- *     import {hooks} from 'glimmer-runtime';
- *     import {DOMHelper} from 'morph';
- *     let context = {name: 'whatever'},
- *         env = {hooks: hooks, dom: new DOMHelper()},
- *         contextualElement = document.body;
- *     let domFragment = template(context, env, contextualElement);
- *
- * @method compile
- * @param {String} string An Glimmer template string
- * @param {Object} options A set of options to provide to the compiler
- * @return {Template} A function for rendering the template
- */
 export function compile(string: string, options: TestCompileOptions): Template {
   return Template.fromSpec(compileRealSpec(string, options), options.env);
 }
@@ -66,11 +31,10 @@ export function compileLayout(string: string, options: TestCompileOptions): Layo
   return Template.layoutFromSpec(compileRealSpec(string, options), options.env);
 }
 
-/*
- * @method template
- * @param {TemplateSpec} templateSpec A precompiled template
- * @return {Template} A template spec string
- */
+export function compileRealSpec(string: string, options: TestCompileOptions): SerializedTemplate {
+  return template(compileSpec(string, options));
+}
+
 export function template(templateSpec: TemplateSpec): SerializedTemplate {
   return JSON.parse(templateSpec);
 }


### PR DESCRIPTION
These comments are our of date so I've removed them. I've also removed the function params and return statement docs as they are also out of date, this code is internal and the functions are self explanatory.

I reordered the three compile functions from higher to lower level:

 1. `compile`
 2. `compileLayout`
 3. `compileRealSpec`

I also removed the `export function template` which doesn't seem to be used anywhere and inlined the `JSON.parse`