### PR TITLE
Propagate curly trustworthiness

### DIFF
--- a/packages/glimmer-benchmarks/index.ts
+++ b/packages/glimmer-benchmarks/index.ts
@@ -4,4 +4,4 @@ import suites from './lib/bench-suites';
 
 export const Benchmark = benchmark;
 export const Stats = stats;
-export const Suites = suites
+export const Suites = suites;

--- a/packages/glimmer-compiler/lib/javascript-compiler.ts
+++ b/packages/glimmer-compiler/lib/javascript-compiler.ts
@@ -143,9 +143,14 @@ export default class JavaScriptCompiler {
     this.push(['staticAttr', name, value, namespace]);
   }
 
-  dynamicAttr(name: string, namespace: string) {
+  dynamicAttr(name: str, namespace: str) {
     let value = this.popValue<Expression>();
     this.push(['dynamicAttr', name, value, namespace]);
+  }
+
+  trustingAttr(name: str, namespace: str) {
+    let value = this.popValue<Expression>();
+    this.push(['trustingAttr', name, value, namespace]);
   }
 
   staticArg(name: str) {

--- a/packages/glimmer-compiler/lib/template-compiler.ts
+++ b/packages/glimmer-compiler/lib/template-compiler.ts
@@ -10,6 +10,10 @@ export interface CompileOptions {
   moduleName?: string;
 }
 
+function isTrustedValue(value) {
+  return value.escaped !== undefined && !value.escaped;
+}
+
 export default class TemplateCompiler {
   static compile(options: CompileOptions, ast) {
     let templateVisitor = new TemplateVisitor();
@@ -99,8 +103,12 @@ export default class TemplateCompiler {
         this.opcode('dynamicArg', action, name);
       }
     } else {
+      let isTrusting = isTrustedValue(value);
+
       if (isStatic) {
         this.opcode('staticAttr', action, name, namespace);
+      } else if (isTrusting) {
+        this.opcode('trustingAttr', action, name, namespace);
       } else if (action.value.type === 'MustacheStatement') {
         this.opcode('dynamicAttr', action, name);
       } else {

--- a/packages/glimmer-runtime/lib/builder.ts
+++ b/packages/glimmer-runtime/lib/builder.ts
@@ -62,8 +62,8 @@ class BlockStackElement {
 }
 
 export interface ElementOperations {
-  addAttribute(name: InternedString, value: PathReference<string>);
-  addAttributeNS(namespace: InternedString, name: InternedString, value: PathReference<string>);
+  addAttribute(name: InternedString, value: PathReference<string>, isTrusting: boolean);
+  addAttributeNS(namespace: InternedString, name: InternedString, value: PathReference<string>, isTrusting: boolean);
 }
 
 class GroupedElementOperations implements ElementOperations {
@@ -85,14 +85,14 @@ class GroupedElementOperations implements ElementOperations {
     this.groups.push(group);
   }
 
-  addAttribute(name: InternedString, reference: PathReference<string>) {
-    let attributeManager = this.env.attributeFor(this.element, name, reference);
+  addAttribute(name: InternedString, reference: PathReference<string>, isTrusting: boolean) {
+    let attributeManager = this.env.attributeFor(this.element, name, reference, isTrusting);
     let attribute = new Attribute(this.element, attributeManager, name, reference);
     this.group.push(attribute);
   }
 
-  addAttributeNS(namespace: InternedString, name: InternedString, reference: PathReference<string>) {
-    let attributeManager = this.env.attributeFor(this.element, name, reference, namespace);
+  addAttributeNS(namespace: InternedString, name: InternedString, reference: PathReference<string>, isTrusting: boolean) {
+    let attributeManager = this.env.attributeFor(this.element, name, reference,isTrusting, namespace);
     let nsAttribute = new Attribute(this.element, attributeManager, name, reference, namespace);
 
     this.group.push(nsAttribute);
@@ -270,12 +270,12 @@ export class ElementStack implements Cursor {
     return comment;
   }
 
-  setAttribute(name: InternedString, reference: PathReference<string>) {
-    this.elementOperations.addAttribute(name, reference);
+  setAttribute(name: InternedString, reference: PathReference<string>, isTrusting: boolean) {
+    this.elementOperations.addAttribute(name, reference, isTrusting);
   }
 
-  setAttributeNS(namespace: InternedString, name: InternedString, reference: PathReference<string>) {
-    this.elementOperations.addAttributeNS(namespace, name, reference);
+  setAttributeNS(namespace: InternedString, name: InternedString, reference: PathReference<string>, isTrusting: boolean) {
+    this.elementOperations.addAttributeNS(namespace, name, reference, isTrusting);
   }
 
   closeElement() {

--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -190,7 +190,7 @@ export class ShadowAttributesOpcode extends Opcode {
     if (!shadow) return;
 
     shadow.forEach(name => {
-      vm.stack().setAttribute(name, named.get(name));
+      vm.stack().setAttribute(name, named.get(name), false);
     });
   }
 

--- a/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
@@ -164,7 +164,7 @@ export class CloseElementOpcode extends Opcode {
 
     let className = classList.toReference();
     let attr = 'class' as InternedString;
-    let attributeManager = vm.env.attributeFor(element, attr, className);
+    let attributeManager = vm.env.attributeFor(element, attr, className, false);
     let attribute = new Attribute(element, attributeManager, attr, className);
     let opcode = attribute.flush(dom);
 
@@ -187,7 +187,7 @@ export class StaticAttrOpcode extends Opcode {
   public name: InternedString;
   public value: ValueReference<string>;
 
-  constructor({ namespace, name, value,  }: { namespace: InternedString, name: InternedString, value: InternedString }) {
+  constructor({ namespace, name, value }: { namespace: InternedString, name: InternedString, value: InternedString }) {
     super();
     this.namespace = namespace;
     this.name = name;
@@ -197,9 +197,9 @@ export class StaticAttrOpcode extends Opcode {
   evaluate(vm: VM) {
     let { name, value, namespace } = this;
     if (namespace) {
-      vm.stack().setAttributeNS(namespace, name, value);
+      vm.stack().setAttributeNS(namespace, name, value, false);
     } else {
-      vm.stack().setAttribute(name, value);
+      vm.stack().setAttribute(name, value, false);
     }
   }
 
@@ -386,17 +386,19 @@ export class DynamicAttrNSOpcode extends Opcode {
   public type = "dynamic-attr";
   public name: InternedString;
   public namespace: InternedString;
+  public isTrusting: boolean;
 
-  constructor({ name, namespace }: { name: InternedString, namespace: InternedString }) {
+  constructor({ name, namespace, isTrusting }: { name: InternedString, namespace: InternedString, isTrusting: boolean }) {
     super();
     this.name = name;
     this.namespace = namespace;
+    this.isTrusting = isTrusting;
   }
 
   evaluate(vm: VM) {
     let { name, namespace } = this;
     let reference = vm.frame.getOperand();
-    vm.stack().setAttributeNS(namespace, name, reference);
+    vm.stack().setAttributeNS(namespace, name, reference, this.isTrusting);
   }
 
   toJSON(): OpcodeJSON {
@@ -418,16 +420,18 @@ export class DynamicAttrNSOpcode extends Opcode {
 export class DynamicAttrOpcode extends Opcode {
   public type = "dynamic-attr";
   public name: InternedString;
+  public isTrusting: boolean;
 
-  constructor({ name }: { name: InternedString }) {
+  constructor({ name, isTrusting }: { name: InternedString, isTrusting: boolean }) {
     super();
     this.name = name;
+    this.isTrusting = isTrusting;
   }
 
   evaluate(vm: VM) {
     let { name } = this;
     let reference = vm.frame.getOperand();
-    vm.stack().setAttribute(name, reference);
+    vm.stack().setAttribute(name, reference, this.isTrusting);
   }
 
   toJSON(): OpcodeJSON {

--- a/packages/glimmer-runtime/lib/compiler.ts
+++ b/packages/glimmer-runtime/lib/compiler.ts
@@ -390,7 +390,7 @@ class ComponentAttrsBuilder implements Component.ComponentAttrsBuilder {
   }
 
   dynamic(name: string, value: FunctionExpression<string>) {
-    this.buffer.push(new Syntax.DynamicAttr({ name: name as FIXME<'intern'>, value: makeFunctionExpression(value) }));
+    this.buffer.push(new Syntax.DynamicAttr({ name: name as FIXME<'intern'>, value: makeFunctionExpression(value), isTrusting: false }));
   }
 }
 

--- a/packages/glimmer-runtime/lib/dom/change-lists.ts
+++ b/packages/glimmer-runtime/lib/dom/change-lists.ts
@@ -11,7 +11,7 @@ export interface IChangeList {
   updateAttribute(dom: DOMHelper, element: Element, attr: string, value: any, namespace?: string): void;
 }
 
-export function defaultChangeLists(element: Element, attr: string, namespace: string) {
+export function defaultChangeLists(element: Element, attr: string, isTrusting: boolean, namespace: string) {
   let tagName = element.tagName;
   let isSVG = element.namespaceURI === SVG_NAMESPACE;
 

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -224,8 +224,8 @@ export abstract class Environment {
   abstract hasHelper(helperName: InternedString[], blockMeta: BlockMeta): boolean;
   abstract lookupHelper(helperName: InternedString[], blockMeta: BlockMeta): Helper;
 
-  attributeFor(element: Element, attr: InternedString, reference: Reference<Opaque>, namespace?: InternedString): IChangeList {
-    return defaultChangeLists(element, attr, namespace);
+  attributeFor(element: Element, attr: InternedString, reference: Reference<Opaque>, isTrusting: boolean, namespace?: InternedString): IChangeList {
+    return defaultChangeLists(element, attr, isTrusting, namespace);
   }
 
   abstract hasPartial(partialName: InternedString[]): boolean;

--- a/packages/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/glimmer-runtime/lib/syntax/core.ts
@@ -352,13 +352,32 @@ export class DynamicArg extends ArgumentSyntax<Opaque> {
   }
 }
 
+export class TrustingAttr {
+  static fromSpec(sexp: SerializedStatements.TrustingAttr): DynamicAttr {
+    let [, name, value, namespace] = sexp;
+    return new DynamicAttr({
+      name: name as InternedString,
+      namespace: namespace as InternedString,
+      isTrusting: true,
+      value: buildExpression(value)
+    });
+  }
+
+  static build(_name: string, value: ExpressionSyntax<string>, isTrusting: boolean, _namespace: string=null): DynamicAttr {
+    let name = intern(_name);
+    let namespace = _namespace ? intern(_namespace) : null;
+    return new DynamicAttr({ name, value, namespace, isTrusting });
+  }
+
+  compile() { throw new Error('Attempting to compile a TrustingAttr which is just a delegate for DynamicAttr.'); }
+}
+
 export class StaticAttr extends AttributeSyntax<string> {
   "e1185d30-7cac-4b12-b26a-35327d905d92" = true;
   type = "static-attr";
 
   static fromSpec(node: SerializedStatements.StaticAttr): StaticAttr {
     let [, name, value, namespace] = node;
-
     return new StaticAttr({ name: name as InternedString, value: value as InternedString, namespace: namespace as InternedString });
   }
 
@@ -369,6 +388,7 @@ export class StaticAttr extends AttributeSyntax<string> {
   name: InternedString;
   value: InternedString;
   namespace: InternedString;
+  isTrusting = false;
 
   constructor({ name, value, namespace = null }: { name: InternedString, value: InternedString, namespace?: InternedString }) {
     super();
@@ -402,7 +422,6 @@ export class DynamicAttr extends AttributeSyntax<string> {
 
   static fromSpec(sexp: SerializedStatements.DynamicAttr): DynamicAttr {
     let [, name, value, namespace] = sexp;
-
     return new DynamicAttr({
       name: name as InternedString,
       namespace: namespace as InternedString,
@@ -410,21 +429,23 @@ export class DynamicAttr extends AttributeSyntax<string> {
     });
   }
 
-  static build(_name: string, value: ExpressionSyntax<string>, _namespace: string=null): DynamicAttr {
+  static build(_name: string, value: ExpressionSyntax<string>, isTrusting: boolean = false, _namespace: string=null): DynamicAttr {
     let name = intern(_name);
     let namespace = _namespace ? intern(_namespace) : null;
-    return new this({ name, value, namespace });
+    return new this({ name, value, namespace, isTrusting });
   }
 
   name: InternedString;
   value: ExpressionSyntax<string>;
   namespace: InternedString;
+  isTrusting: boolean;
 
-  constructor({ name, value, namespace = null }: { name: InternedString, value: ExpressionSyntax<string>, namespace?: InternedString }) {
+  constructor({ name, value, isTrusting = false, namespace = null }: { name: InternedString, isTrusting?: boolean, value: ExpressionSyntax<string>, namespace?: InternedString }) {
     super();
     this.name = name;
     this.value = value;
     this.namespace = namespace;
+    this.isTrusting = isTrusting;
   }
 
   prettyPrint() {

--- a/packages/glimmer-runtime/tests/initial-render-test.ts
+++ b/packages/glimmer-runtime/tests/initial-render-test.ts
@@ -800,12 +800,12 @@ const StyleAttribute = {
 QUnit.module('Style attributes', {
   setup() {
     class StyleEnv extends TestEnvironment {
-      attributeFor(element, attr, reference) {
-        if (attr === 'style') {
+      attributeFor(element, attr, reference, isTrusting) {
+        if (attr === 'style' && !isTrusting) {
           return StyleAttribute;
         }
 
-        return super.attributeFor(element, attr, reference);
+        return super.attributeFor(element, attr, reference, isTrusting);
       }
     }
 
@@ -822,6 +822,13 @@ test(`using an inline style on an element gives you a warning`, function(assert)
   render(template, {});
 
   assert.equal(warnings, 1);
+});
+
+test(`triple curlies are trusted`, function(assert) {
+  let template = compile(`<div foo={{foo}} style={{{styles}}}>Thing</div>`);
+  render(template, {styles: 'background: red'});
+
+  assert.equal(warnings, 0);
 });
 
 test(`using an inline style on an namespaced element gives you a warning`, function(assert) {

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -458,7 +458,7 @@ class EmberishCurlyComponentManager implements ComponentManager<EmberishCurlyCom
         let attribute = bindings[i] as InternedString;
         let reference = rootRef.get(attribute) as PathReference<string>;
 
-        operations.addAttribute(attribute, reference);
+        operations.addAttribute(attribute, reference, false);
       }
     }
   }

--- a/packages/glimmer-wire-format/index.ts
+++ b/packages/glimmer-wire-format/index.ts
@@ -99,6 +99,7 @@ export namespace Statements {
   export type Yield         = ['yield', YieldTo, Params];
   export type DynamicArg    = ['dynamicArg', str, Expression];
   export type StaticArg     = ['staticArg', str, Expression];
+  export type TrustingAttr  = ['trustingAttr', str, Expression, str];
 
   export const isText         = is<Text>('text');
   export const isAppend       = is<Append>('append');
@@ -112,6 +113,7 @@ export namespace Statements {
   export const isYield        = is<Yield>('yield');
   export const isDynamicArg   = is<DynamicArg>('dynamicArg');
   export const isStaticArg    = is<StaticArg>('staticArg');
+  export const isTrustingAttr = is<TrustingAttr>('trustingAttr');
 
   export type Statement =
       Text
@@ -126,6 +128,7 @@ export namespace Statements {
     | Yield
     | StaticArg
     | DynamicArg
+    | TrustingAttr
     ;
 }
 


### PR DESCRIPTION
We need to know the calling side of the ref e.g. either double or triple
curlies.

To keep the wire-format as small as possible we actually do want a `TrustingAttr` type. This type is just a  delegate to `DynamicAttr`, but slots the `isTrusting` field as "true". This is a tradeoff that I think makes sense as we pay the cost of an additional type, but we don't bloat the wire-format with bools for each attribute's trustworthiness. I suspect that cost of the additional type in Glimmer outweighs the amount of dynamic attributes used in a real application.