### PR TITLE
Let the host (e.g. Ember) handle layout caching

### DIFF
--- a/packages/glimmer-benchmarks/lib/benchmarks/components.ts
+++ b/packages/glimmer-benchmarks/lib/benchmarks/components.ts
@@ -5,14 +5,14 @@ class NestedEmberishCurleyTaglessComponentsScenario extends TemplateBenchmarkSce
   description = "10 outer components, each with 10 inner components";
 
   start() {
-    this.glimmerEnv.registerEmberishCurlyTaglessComponent("parent-component", null,
+    this.glimmerEnv.registerStaticTaglessComponent("parent-component", null,
       `<h1>{{parent.name}}</h1>
         <ul>
           {{#each parent.children key="@index" as |child|}}
             {{child-component child=child parent=parent}}
           {{/each}}
         </ul>`);
-    this.glimmerEnv.registerEmberishCurlyTaglessComponent("child-component", null,
+    this.glimmerEnv.registerStaticTaglessComponent("child-component", null,
       `<li>{{child.name}} (from {{parent.name}})</li>`);
 
     super.start();

--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -39,8 +39,7 @@ export {
   default as Compiler,
   Compilable,
   CompileIntoList,
-  compileLayout,
-  layoutFor
+  compileLayout
 } from './lib/compiler';
 
 export {

--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -37,6 +37,7 @@ export {
 
 export {
   default as Compiler,
+  Compilable,
   CompileIntoList,
   compileLayout,
   layoutFor

--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -38,6 +38,7 @@ export {
 export {
   default as Compiler,
   CompileIntoList,
+  compileLayout,
   layoutFor
 } from './lib/compiler';
 
@@ -50,6 +51,7 @@ export {
 export {
   Block,
   BlockOptions,
+  CompiledBlock,
   Layout,
   LayoutOptions,
   InlineBlock,

--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -4,7 +4,6 @@ import { Component, ComponentManager, ComponentDefinition } from '../../componen
 import { VM, UpdatingVM } from '../../vm';
 import { CompiledArgs, EvaluatedArgs } from '../../compiled/expressions/args';
 import { Templates } from '../../syntax/core';
-import { layoutFor } from '../../compiler';
 import { DynamicScope } from '../../environment';
 import { InternedString, Opaque } from 'glimmer-util';
 import { ReferenceCache, Revision, combine, isConst } from 'glimmer-reference';
@@ -89,11 +88,11 @@ export class OpenComponentOpcode extends Opcode {
     let destructor = manager.getDestructor(component);
     if (destructor) vm.newDestroyable(destructor);
     args.internal["component"] = component;
-    args.internal["definition"] = definition = manager.ensureCompilable(definition, component, vm.env);
+    args.internal["definition"] = definition;
     args.internal["shadow"] = shadow;
 
     vm.beginCacheGroup();
-    let layout = layoutFor(definition, vm.env);
+    let layout = manager.layoutFor(definition, component, vm.env);
     let callerScope = vm.scope();
     let selfRef = manager.getSelf(component);
     vm.pushRootScope(selfRef, layout.symbols);

--- a/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
@@ -312,7 +312,7 @@ export class Attribute {
   private element: Element;
   private reference: Reference<Opaque>;
   private cache: ReferenceCache<Opaque>;
-  private namespace?: string;
+  private namespace: string | undefined;
 
   protected name: InternedString;
 

--- a/packages/glimmer-runtime/lib/compiler.ts
+++ b/packages/glimmer-runtime/lib/compiler.ts
@@ -160,7 +160,7 @@ export interface CompiledComponentParts {
   main: CompileIntoList;
 }
 
-interface Compilable {
+export interface Compilable {
   compile(builder: ComponentLayoutBuilder);
 }
 

--- a/packages/glimmer-runtime/lib/compiler.ts
+++ b/packages/glimmer-runtime/lib/compiler.ts
@@ -164,10 +164,6 @@ export interface Compilable {
   compile(builder: ComponentLayoutBuilder);
 }
 
-export function layoutFor(...args) {
-
-}
-
 export function compileLayout(compilable: Compilable, env: Environment): CompiledBlock {
   let builder = new ComponentLayoutBuilder(env);
 

--- a/packages/glimmer-runtime/lib/compiler.ts
+++ b/packages/glimmer-runtime/lib/compiler.ts
@@ -52,7 +52,6 @@ import {
 } from './compiled/expressions/function';
 
 import * as Component from './component/interfaces';
-import { CACHED_LAYOUT } from './component/interfaces';
 
 abstract class Compiler {
   public env: Environment;
@@ -161,15 +160,20 @@ export interface CompiledComponentParts {
   main: CompileIntoList;
 }
 
-export function layoutFor(definition: Component.ComponentDefinition<any>, env: Environment): CompiledBlock {
-  let layout = definition[CACHED_LAYOUT];
-  if (layout) return layout;
+interface Compilable {
+  compile(builder: ComponentLayoutBuilder);
+}
 
+export function layoutFor(...args) {
+
+}
+
+export function compileLayout(compilable: Compilable, env: Environment): CompiledBlock {
   let builder = new ComponentLayoutBuilder(env);
 
-  definition['compile'](builder);
+  compilable.compile(builder);
 
-  return definition[CACHED_LAYOUT] = builder.compile();
+  return builder.compile();
 }
 
 class ComponentLayoutBuilder implements Component.ComponentLayoutBuilder {

--- a/packages/glimmer-runtime/lib/component/interfaces.ts
+++ b/packages/glimmer-runtime/lib/component/interfaces.ts
@@ -17,8 +17,11 @@ export interface ComponentManager<T extends Component> {
   // an opaque token, but in practice it is probably a component object.
   create(definition: ComponentDefinition<T>, args: EvaluatedArgs, dynamicScope: DynamicScope, hasDefaultBlock: boolean): T;
 
-  // Check if definition is compilable should default it and return a new definition
-  ensureCompilable(definition: ComponentDefinition<T>, component: T, env: Environment): ComponentDefinition<T>;
+  // Return the compiled layout to use for this component. This is called
+  // *after* the component instance has been created, because you might
+  // want to return a different layout per-instance for optimization reasons
+  // or to implement features like Ember's "late-bound" layouts.
+  layoutFor(definition: ComponentDefinition<T>, component: T, env: Environment): CompiledBlock;
 
   // Next, Glimmer asks the manager to create a reference for the `self`
   // it should use in the layout.
@@ -72,20 +75,14 @@ export interface ComponentAttrsBuilder {
   dynamic(name: string, value: FunctionExpression<string>);
 }
 
-export const CACHED_LAYOUT = "CACHED_LAYOUT [d990e194-8529-4f3b-8ee9-11c58a70f7a4]";
-
 export abstract class ComponentDefinition<T> {
   public name: string; // for debugging
   public manager: ComponentManager<T>;
   public ComponentClass: ComponentClass;
-
-  private "CACHED_LAYOUT [d990e194-8529-4f3b-8ee9-11c58a70f7a4]": CompiledBlock = null;
 
   constructor(name: string, manager: ComponentManager<T>, ComponentClass: ComponentClass) {
     this.name = name;
     this.manager = manager;
     this.ComponentClass = ComponentClass;
   }
-
-  protected abstract compile(builder: ComponentLayoutBuilder);
 }

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -2806,9 +2806,9 @@ QUnit.test('components inside the root are destroyed when the render result is d
 });
 
 QUnit.test('tagless components render properly', function(assert) {
-  class FooBar extends EmberishCurlyComponent {}
+  class FooBar extends BasicComponent {}
 
-  env.registerEmberishCurlyTaglessComponent('foo-bar', FooBar, `Michael Jordan says "Go Tagless"`);
+  env.registerStaticTaglessComponent('foo-bar', FooBar, `Michael Jordan says "Go Tagless"`);
 
   appendViewFor(`{{foo-bar}}`);
   assertAppended('Michael Jordan says "Go Tagless"');

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -189,14 +189,14 @@ class Iterable implements AbstractIterable<Opaque, Opaque, IterationItem<Opaque,
 
     if (Array.isArray(iterable)) {
       return iterable.length > 0 ? new ArrayIterator(iterable, keyFor) : EMPTY_ITERATOR;
+    } else if (iterable === undefined || iterable === null) {
+      return EMPTY_ITERATOR;
     } else if (iterable.forEach !== undefined) {
       let array = [];
       iterable.forEach(function(item) {
         array.push(item);
       });
       return array.length > 0 ? new ArrayIterator(array, keyFor) : EMPTY_ITERATOR;
-    } else if (iterable === undefined || iterable === null) {
-      return EMPTY_ITERATOR;
     } else if (typeof iterable === 'object') {
        let keys = Object.keys(iterable);
        return keys.length > 0 ? new ObjectKeysIterator(keys, keys.map(key => iterable[key]), keyFor) : EMPTY_ITERATOR;

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -4,6 +4,7 @@ import {
   DynamicScope,
 
   // Compiler
+  Compilable,
   CompileInto,
   CompiledBlock,
   StatementCompilationBuffer,
@@ -948,7 +949,7 @@ class EmberishGlimmerComponentDefinition extends GenericComponentDefinition<Embe
   public ComponentClass: EmberishGlimmerComponentFactory;
 }
 
-abstract class GenericComponentLayoutCompiler {
+abstract class GenericComponentLayoutCompiler implements Compilable {
   constructor(private layoutString: string) {}
 
   protected compileLayout(env: Environment) {

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -955,6 +955,8 @@ abstract class GenericComponentLayoutCompiler implements Compilable {
   protected compileLayout(env: Environment) {
     return rawCompileLayout(this.layoutString, { env });
   }
+
+  abstract compile(builder: ComponentLayoutBuilder);
 }
 
 class BasicComponentLayoutCompiler extends GenericComponentLayoutCompiler {


### PR DESCRIPTION
This removes the special CACHED_LAYOUT symbol and instead replaced it with a `layoutFor` hook on the component manager. The primary reason for this is to decouple layout caching from component definitions (the hosts can implement their own caching layer).

In addition to that, it also solves the problem of Ember’s “late-bound” layout feature, because the `layoutFor` hook is called *after* `create`, and we pass in the component instance as an argument to `layoutFor`. This allows you to make whatever decisions you need to construct/lookup the right layout.

Finally, this also allows the hosts to return optimized layouts based on instance-side information.