### PR TITLE
clear Bounds when destroying RenderResult's

### DIFF
--- a/packages/glimmer-runtime/lib/vm/render-result.ts
+++ b/packages/glimmer-runtime/lib/vm/render-result.ts
@@ -1,6 +1,6 @@
 import { Destroyable, LinkedList } from 'glimmer-util';
 import Environment from '../environment';
-import { Bounds } from '../bounds';
+import { Bounds, clear } from '../bounds';
 import UpdatingVM, { ExceptionHandler } from './update';
 import { UpdatingOpcode } from '../opcodes';
 
@@ -55,5 +55,6 @@ export default class RenderResult implements Bounds, Destroyable, ExceptionHandl
 
   destroy() {
     this.bounds.destroy();
+    clear(this.bounds);
   }
 }

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -2794,15 +2794,20 @@ QUnit.test('components inside the root are destroyed when the render result is d
   env.registerEmberishGlimmerComponent('destroy-me1', DestroyMe1Component as any, '<div>Destry me!</div>');
   env.registerEmberishCurlyComponent('destroy-me2', DestroyMe2Component as any, 'Destroy me too!');
 
-  appendViewFor(`<destroy-me1 />{{destroy-me2}}`);
+  appendViewFor(`<destroy-me1 id="destroy-me1"/>{{destroy-me2 id="destroy-me2"}}`);
 
   assert.strictEqual(glimmerDestroyed, false, 'the glimmer component should not be destroyed');
   assert.strictEqual(curlyDestroyed, false, 'the curly component should not be destroyed');
 
   view.destroy();
 
-  assert.strictEqual(glimmerDestroyed, true, 'the glimmer component should be destroyed');
-  assert.strictEqual(curlyDestroyed, true, 'the curly component should be destroyed');
+  assert.strictEqual(glimmerDestroyed, true, 'the glimmer component destroy hook was called');
+  assert.strictEqual(curlyDestroyed, true, 'the glimmer component destroy hook was called');
+
+  assert.strictEqual(document.querySelectorAll('#destroy-me1').length, 0, 'component DOM node was removed from DOM');
+  assert.strictEqual(document.querySelectorAll('#destroy-me2').length, 0, 'component DOM node was removed from DOM');
+
+  assert.strictEqual(document.querySelector('#qunit-fixture').childElementCount, 0, 'root view was removed from DOM');
 });
 
 QUnit.test('tagless components render properly', function(assert) {


### PR DESCRIPTION
In Glimmer, elements are not implicitly removed from the DOM when their
destroy hooks are called. Instead of removing each DOM node individually
which can be very ineffecient, Ember's integration with Glimmer uses
higher level elements for disconnecting large number of nodes.

Two examples are the OutletView and then the `RenderResult` which lives
inside Glimmer itself. When `RenderResult` and `OutletView` are called,
they should remove themselves from the DOM, thus removing all their
children DOM nodes.

The `Bounds` object on `RenderResult` was not being cleared when the
`RenderResult` was destroyed, meaning that when you ran
`Ember.ApplicationInstance.destroy()` in an Ember test, DOM nodes would
linger in the fixture element for tests.

In Ember CLI, the generated blueprint for acceptance tests is to run
`Ember.Application.destroy()` so that no two tests share the same app
instance. Indeed, Ember's tests also use this. Leaving lingering DOM
nodes were causing several failures in Ember's integration with
Glimmer2.

Thanks @chancancode for helping me understand more of the architecture
of Glimmer2 and debugging this with me! :tada:

refs #emberjs/13807