### PR TITLE
pin typescript compiler to ^1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "handlebars": "^3.0.2",
     "qunit": "^0.7.2",
     "simple-html-tokenizer": "^0.2.5",
-    "typescript": "next"
+    "typescript": "^1.8.10"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",


### PR DESCRIPTION
The "next" tag for typescript has shifted to '2.1.0-dev.20160716',
when it was previously a 1.x value. The `broccoli-typescript-compiler`
requires a peer dependency of `typescript@^1.6.2 || ^1.7.0 || ^1.8.0 ||
^1.9.0-dev`, so a `2.x` does not fall within this semver range.