### PR TITLE
Temp fix to make helpers destroyable

### DIFF
--- a/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
@@ -20,7 +20,7 @@ export default class CompiledHelper extends CompiledExpression<Opaque> {
 
   evaluate(vm: VM): PathReference<Opaque> {
     let { helper } = this;
-    return helper(this.args.evaluate(vm));
+    return helper(vm, this.args.evaluate(vm));
   }
 
   toJSON(): string {

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -4,7 +4,8 @@ import { DOMHelper } from './dom/helper';
 import { Reference, OpaqueIterable } from 'glimmer-reference';
 import { NULL_REFERENCE, ConditionalReference } from './references';
 import {
-  defaultChangeLists
+  defaultChangeLists,
+  IChangeList
 } from './dom/change-lists';
 
 import {
@@ -18,10 +19,6 @@ import {
 } from './component/interfaces';
 
 import {
-  IChangeList
-} from './dom/change-lists';
-
-import {
   ModifierManager
 } from './modifier/interfaces';
 
@@ -30,6 +27,9 @@ import {
 } from 'glimmer-reference';
 
 import {
+  Destroyable,
+  Dict,
+  Opaque,
   HasGuid,
   InternedString,
   intern,
@@ -44,8 +44,6 @@ import { EvaluatedArgs } from './compiled/expressions/args';
 
 import { InlineBlock } from './compiled/blocks';
 
-import { Destroyable, Dict, Opaque } from 'glimmer-util';
-
 import * as Syntax from './syntax/core';
 
 import IfSyntax from './syntax/builtins/if';
@@ -53,6 +51,8 @@ import UnlessSyntax from './syntax/builtins/unless';
 import WithSyntax from './syntax/builtins/with';
 import EachSyntax from './syntax/builtins/each';
 import PartialSyntax from './syntax/builtins/partial';
+
+import { PublicVM } from './vm/append';
 
 type ScopeSlot = PathReference<Opaque> | InlineBlock;
 
@@ -241,7 +241,7 @@ type PositionalArguments = Opaque[];
 type KeywordArguments = Dict<Opaque>;
 
 export interface Helper {
-  (args: EvaluatedArgs): PathReference<Opaque>;
+  (vm: PublicVM, args: EvaluatedArgs): PathReference<Opaque>;
 }
 
 export interface ParsedStatement {

--- a/packages/glimmer-runtime/lib/vm/append.ts
+++ b/packages/glimmer-runtime/lib/vm/append.ts
@@ -58,6 +58,7 @@ export interface PublicVM {
   getArgs(): EvaluatedArgs;
   dynamicScope(): DynamicScope;
   getSelf(): PathReference<Opaque>;
+  newDestroyable(d: Destroyable);
 }
 
 type OpList = Range<Opcode>;

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -643,7 +643,7 @@ export class TestEnvironment extends Environment {
   }
 
   registerHelper(name: string, helper: UserHelper) {
-    this.helpers[name] = (args: EvaluatedArgs) => new HelperReference(helper, args);
+    this.helpers[name] = (vm: VM, args: EvaluatedArgs) => new HelperReference(helper, args);
   }
 
   registerInternalHelper(name: string, helper: GlimmerHelper) {


### PR DESCRIPTION
This will probably (hopefully) not stick around for a very long time, but until we can unify helpers and components, this allows Ember to register class-based helpers as destroyable.