### PR TITLE
Add prepareArgs to ComponentManager<T> interface

### DIFF
--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -84,22 +84,23 @@ export class OpenComponentOpcode extends Opcode {
 
     let manager = definition.manager;
     let hasDefaultBlock = templates && !!templates.default; // TODO Cleanup?
-    let component = manager.create(definition, args, dynamicScope, hasDefaultBlock);
+    let preparedArgs = manager.prepareArgs(definition, args);
+    let component = manager.create(definition, preparedArgs, dynamicScope, hasDefaultBlock);
     let destructor = manager.getDestructor(component);
     if (destructor) vm.newDestroyable(destructor);
-    args.internal["component"] = component;
-    args.internal["definition"] = definition;
-    args.internal["shadow"] = shadow;
+    preparedArgs.internal["component"] = component;
+    preparedArgs.internal["definition"] = definition;
+    preparedArgs.internal["shadow"] = shadow;
 
     vm.beginCacheGroup();
     let layout = manager.layoutFor(definition, component, vm.env);
     let callerScope = vm.scope();
     let selfRef = manager.getSelf(component);
     vm.pushRootScope(selfRef, layout.symbols);
-    vm.invokeLayout({ templates, args, shadow, layout, callerScope });
+    vm.invokeLayout({ templates, args: preparedArgs, shadow, layout, callerScope });
     vm.env.didCreate(component, manager);
 
-    vm.updateWith(new UpdateComponentOpcode({ name: definition.name, component, manager, args, dynamicScope }));
+    vm.updateWith(new UpdateComponentOpcode({ name: definition.name, component, manager, args: preparedArgs, dynamicScope }));
   }
 }
 

--- a/packages/glimmer-runtime/lib/component/interfaces.ts
+++ b/packages/glimmer-runtime/lib/component/interfaces.ts
@@ -12,7 +12,13 @@ export type Component = Opaque;
 export type ComponentClass = any;
 
 export interface ComponentManager<T extends Component> {
-  // First, the component manager is asked to create a bucket of state for
+  // First, the component manager is asked to prepare the arguments needed
+  // for `create`. This allows for things like closure components where the
+  // args need to be curried before constructing the instance of the state
+  // bucket.
+  prepareArgs(definition: ComponentDefinition<T>, args: EvaluatedArgs): EvaluatedArgs;
+
+  // Then, the component manager is asked to create a bucket of state for
   // the supplied arguments. From the perspective of Glimmer, this is
   // an opaque token, but in practice it is probably a component object.
   create(definition: ComponentDefinition<T>, args: EvaluatedArgs, dynamicScope: DynamicScope, hasDefaultBlock: boolean): T;

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -288,6 +288,10 @@ export class EmberishGlimmerComponent extends GlimmerObject {
 }
 
 class BasicComponentManager implements ComponentManager<BasicComponent> {
+  prepareArgs(definition: BasicComponentDefinition, args: EvaluatedArgs): EvaluatedArgs {
+    return args;
+  }
+
   create(definition: BasicComponentDefinition, args: EvaluatedArgs): BasicComponent {
     let klass = definition.ComponentClass || BasicComponent;
     return new klass(args.named.value());
@@ -335,6 +339,10 @@ const STATIC_TAGLESS_COMPONENT_MANAGER = new StaticTaglessComponentManager();
 const BaseEmberishGlimmerComponent = EmberishGlimmerComponent.extend() as typeof EmberishGlimmerComponent;
 
 class EmberishGlimmerComponentManager implements ComponentManager<EmberishGlimmerComponent> {
+  prepareArgs(definition: EmberishGlimmerComponentDefinition, args: EvaluatedArgs): EvaluatedArgs {
+    return args;
+  }
+
   create(definition: EmberishGlimmerComponentDefinition, args: EvaluatedArgs, dynamicScope, hasDefaultBlock: boolean): EmberishGlimmerComponent {
     let klass = definition.ComponentClass || BaseEmberishGlimmerComponent;
     let attrs = args.named.value();
@@ -433,6 +441,10 @@ const EMBERISH_GLIMMER_COMPONENT_MANAGER = new EmberishGlimmerComponentManager()
 const BaseEmberishCurlyComponent = EmberishCurlyComponent.extend() as typeof EmberishCurlyComponent;
 
 class EmberishCurlyComponentManager implements ComponentManager<EmberishCurlyComponent> {
+  prepareArgs(definition: EmberishCurlyComponentDefinition, args: EvaluatedArgs): EvaluatedArgs {
+    return args;
+  }
+
   create(definition: EmberishCurlyComponentDefinition, args: EvaluatedArgs): EmberishCurlyComponent {
     let klass = definition.ComponentClass || BaseEmberishCurlyComponent;
     let processedArgs = processArgs(args, klass['positionalParams']);


### PR DESCRIPTION
This adds the `prepareArgs` hook to the `ComponentManager<T>` interface as well as a default implementation for the test helpers. This is needed for closure component support.