### PR TITLE
Actually run Glimmer test suite

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -75,9 +75,9 @@ module.exports = function() {
     include: ['**/*.ts'],
     exclude: ['**/*.d.ts']
   });
-  var tsLintTree = new TSLint(tsTree);
 
-  var jsTree = typescript(tsLintTree, tsOptions);
+  var tsLintTree = new TSLint(tsTree);
+  var jsTree = typescript(merge([tsTree, tsLintTree]), tsOptions);
 
   var libTree = find(jsTree, {
     include: ['*/index.js', '*/lib/**/*.js']


### PR DESCRIPTION
#214 introduced an issue where all tests would appear to pass, but in reality no tests were being run.

That's because the new tslint broccoli tree was filtering out non-test files. This change merges the two trees instead of assuming that the tslinter passes through non-transformed files.