### PR TITLE
Ensure tslint.json uses the one local to the package

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -40,6 +40,7 @@ function buildTSOptions(compilerOptions) {
 
 module.exports = function() {
   var packages = __dirname + '/packages';
+  var tslintConfig = __dirname + '/tslint.json';
   var bower = __dirname + '/bower_components';
   var hasBower = existsSync(bower);
 
@@ -76,7 +77,9 @@ module.exports = function() {
     exclude: ['**/*.d.ts']
   });
 
-  var tsLintTree = new TSLint(tsTree);
+  var tsLintTree = new TSLint(tsTree, {
+    configuration: tslintConfig
+  });
   var jsTree = typescript(merge([tsTree, tsLintTree]), tsOptions);
 
   var libTree = find(jsTree, {


### PR DESCRIPTION
Hard-codes the path for `tslint.json` so it will be able to find it if consumed by another app. cc @rwjblue 