### PR TITLE
Temporarily lock typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "handlebars": "^3.0.2",
     "qunit": "^0.7.2",
     "simple-html-tokenizer": "^0.2.5",
-    "typescript": "next"
+    "typescript": "2.1.0-dev.20160728"
   },
   "devDependencies": {
     "loader.js": "^4.0.10",


### PR DESCRIPTION
Today’s build contained a change that breaks our `InternedString` approach. Need to investigate the correct fix.