### PR TITLE
Always compute before “stamping” the validation

### DIFF
--- a/guides/05-validators.md
+++ b/guides/05-validators.md
@@ -352,8 +352,8 @@ class SimpleRenderer {
     let { reference, lastTicket } = this;
 
     if (!reference.tag.validate(lastTicket)) {
-      this.lastTicket = reference.tag.value();
       this.textNode.textContent = reference.value();
+      this.lastTicket = reference.tag.value();
     }
   }
 }
@@ -516,14 +516,14 @@ let nameReference: VersionedReference<string> {
 
 let uppercaseReference = new UppercaseReference(nameReference);
 
-uppercaseReference.value(); // => 'GODFREY CHAN'
-uppercaseReference.tag.value(); // => 1
+uppercaseReference.value();         // => 'GODFREY CHAN'
+uppercaseReference.tag.value();     // => 1
 
 set(person, 'name', 'Yehuda Katz');
 
 uppercaseReference.tag.validate(1); // => false
-uppercaseReference.tag.value(); // => 2
-uppercaseReference.value(); // => 'YEHUDA KATZ'
+uppercaseReference.value();         // => 'YEHUDA KATZ'
+uppercaseReference.tag.value();     // => 2
 ```
 
 Since we can now assume that validation tickets are revision numbers, we can

--- a/packages/glimmer-reference/lib/validators.ts
+++ b/packages/glimmer-reference/lib/validators.ts
@@ -220,7 +220,7 @@ export interface VersionedPathReference<T> extends PathReference<T>, Tagged<Revi
 }
 
 export abstract class CachedReference<T> implements VersionedReference<T> {
-  public tag: RevisionTag;
+  public abstract tag: RevisionTag;
 
   private lastRevision: Revision = null;
   private lastValue: T = null;
@@ -229,8 +229,8 @@ export abstract class CachedReference<T> implements VersionedReference<T> {
     let { tag, lastRevision, lastValue } = this;
 
     if (!lastRevision || !tag.validate(lastRevision)) {
-      this.lastRevision = tag.value();
       lastValue = this.lastValue = this.compute();
+      this.lastRevision = tag.value();
     }
 
     return lastValue;

--- a/packages/glimmer-reference/tests/references-test.ts
+++ b/packages/glimmer-reference/tests/references-test.ts
@@ -1,0 +1,177 @@
+import {
+  CONSTANT_TAG,
+
+  DirtyableTag,
+  UpdatableTag,
+  RevisionTag,
+
+  Reference,
+  CachedReference,
+
+  combine
+} from 'glimmer-reference';
+
+import {
+  dict
+} from 'glimmer-util';
+
+class UpdatableReference<T> implements Reference<T> {
+  public tag: RevisionTag;
+  private _tag: DirtyableTag;
+
+  constructor(private content: T) {
+    this.tag = this._tag = new DirtyableTag();
+  }
+
+  value(): T {
+    return this.content;
+  }
+
+  update(content: T) {
+    this._tag.dirty();
+    return this.content = content;
+  }
+}
+
+class TaggedDict<T> {
+  public tag: RevisionTag;
+  private _tag: DirtyableTag;
+  private data = dict<T>();
+
+  constructor() {
+    this.tag = this._tag = new DirtyableTag();
+  }
+
+  get(key: string): T {
+    return this.data[key];
+  }
+
+  set(key: string, value: T) {
+    this._tag.dirty();
+    return this.data[key] = value;
+  }
+}
+
+QUnit.module("References");
+
+QUnit.test("CachedReference caches computation correctly", assert => {
+  let computed = 0;
+
+  class DictValueReference extends CachedReference<string> {
+    public tag: RevisionTag;
+
+    constructor(private dict: TaggedDict<string>, private key: string) {
+      super();
+      this.tag = dict.tag;
+    }
+
+    compute(): string {
+      computed++;
+      return this.dict.get(this.key);
+    }
+  }
+
+  let dict = new TaggedDict<string>();
+  let reference = new DictValueReference(dict, 'foo');
+
+  dict.set('foo', 'bar');
+
+  assert.strictEqual(computed, 0, 'precond');
+
+  assert.equal(reference.value(), 'bar');
+  assert.equal(reference.value(), 'bar');
+  assert.equal(reference.value(), 'bar');
+
+  assert.strictEqual(computed, 1, 'computed');
+
+  dict.set('foo', 'BAR');
+
+  assert.equal(reference.value(), 'BAR');
+  assert.equal(reference.value(), 'BAR');
+  assert.equal(reference.value(), 'BAR');
+
+  assert.strictEqual(computed, 2, 'computed');
+
+  dict.set('baz', 'bat');
+
+  assert.equal(reference.value(), 'BAR');
+  assert.equal(reference.value(), 'BAR');
+  assert.equal(reference.value(), 'BAR');
+
+  assert.strictEqual(computed, 3, 'computed');
+
+  dict.set('foo', 'bar');
+
+  assert.equal(reference.value(), 'bar');
+  assert.equal(reference.value(), 'bar');
+  assert.equal(reference.value(), 'bar');
+
+  assert.strictEqual(computed, 4, 'computed');
+});
+
+QUnit.test("CachedReference caches nested computation correctly", assert => {
+  let computed = 0;
+
+  class DictValueReference extends CachedReference<string> {
+    public tag: RevisionTag;
+    private _tag: UpdatableTag;
+
+    constructor(private parent: Reference<TaggedDict<string>>, private key: string) {
+      super();
+      let _tag = this._tag = new UpdatableTag(CONSTANT_TAG);
+      this.tag = combine([parent.tag, _tag]);
+    }
+
+    compute(): string {
+      computed++;
+
+      let { parent, _tag, key } = this;
+
+      let dict = parent.value();
+
+      _tag.update(dict.tag);
+
+      return dict.get(key);
+    }
+  }
+
+  let first = new TaggedDict<string>();
+  let second = new TaggedDict<string>();
+
+  let dictReference = new UpdatableReference(first);
+  let valueReference = new DictValueReference(dictReference, 'foo');
+
+  first.set('foo', 'bar');
+
+  assert.strictEqual(computed, 0, 'precond');
+
+  assert.equal(valueReference.value(), 'bar');
+  assert.equal(valueReference.value(), 'bar');
+  assert.equal(valueReference.value(), 'bar');
+
+  assert.strictEqual(computed, 1, 'computed');
+
+  second.set('foo', 'BAR');
+
+  assert.equal(valueReference.value(), 'bar');
+  assert.equal(valueReference.value(), 'bar');
+  assert.equal(valueReference.value(), 'bar');
+
+  assert.strictEqual(computed, 1, 'computed');
+
+  dictReference.update(second);
+
+  assert.equal(valueReference.value(), 'BAR');
+  assert.equal(valueReference.value(), 'BAR');
+  assert.equal(valueReference.value(), 'BAR');
+
+  assert.strictEqual(computed, 2, 'computed');
+
+  second.set('foo', 'foo-bar');
+
+  assert.equal(valueReference.value(), 'foo-bar');
+  assert.equal(valueReference.value(), 'foo-bar');
+  assert.equal(valueReference.value(), 'foo-bar');
+
+  assert.strictEqual(computed, 3, 'computed');
+});


### PR DESCRIPTION
Computing the reference value could potentially be side-effectful (from the perspective of the revision timeline), so you should always compute the value before getting the tag value.