### PR TITLE
Make AST traversal recursive

### DIFF
--- a/packages/glimmer-syntax/lib/traversal/traverse.ts
+++ b/packages/glimmer-syntax/lib/traversal/traverse.ts
@@ -13,6 +13,16 @@ function visitNode(visitor, node) {
     result = handler.enter.call(null, node);
   }
 
+  if (result !== undefined && result !== null) {
+    if (JSON.stringify(node) === JSON.stringify(result)) {
+      result = undefined;
+    } else if (Array.isArray(result)) {
+      return visitArray(visitor, result) || result;
+    } else {
+      return visitNode(visitor, result) || result;
+    }
+  }
+
   if (result === undefined) {
     let keys = visitorKeys[node.type];
 


### PR DESCRIPTION
Previously, if you return a new AST node, that new node is not walked.

This is causing a bug in Ember where we transform:

```hbs
{{#each-in foo ...}}...{{/each-in}}
```

...into...

```hbs
{{#each (-each-in foo) ...}}...{{/each}}
```

In the case where there are nested `each-in`s, like this:

```hbs
{{#each-in foo as |fooKey fooValue|}}
  {{#each-in fooValue as |barKey barValue}}
    ...
  {{/each-in}}
{{/each-in}}
```

Because we walk from the outside in, and the outside `{{#each-in}}` returned a new node, the inner block was never walked, causing the inner `{{#each-in}}` to not be transformed.

This commit fixes the problem by recursively walking the returned nodes.