### PR TITLE
fix <textarea> empty string values

### DIFF
--- a/packages/glimmer-runtime/lib/dom/change-lists.ts
+++ b/packages/glimmer-runtime/lib/dom/change-lists.ts
@@ -35,7 +35,7 @@ export function defaultPropertyChangeLists(tagName: string, attr: string) {
     return SafeHrefPropertyChangeList;
   }
 
-  if (isInputValue(tagName, attr)) {
+  if (isUserInputValue(tagName, attr)) {
     return InputValuePropertyChangeList;
   }
 
@@ -107,8 +107,8 @@ export const AttributeChangeList = {
   }
 };
 
-function isInputValue(tagName: string, attribute: string) {
-  return tagName === 'INPUT' && attribute === 'value';
+function isUserInputValue(tagName: string, attribute: string) {
+  return (tagName === 'INPUT' || tagName === 'TEXTAREA') && attribute === 'value';
 }
 
 export const InputValuePropertyChangeList = {

--- a/packages/glimmer-runtime/tests/attributes-test.ts
+++ b/packages/glimmer-runtime/tests/attributes-test.ts
@@ -213,3 +213,19 @@ test('handles undefined `toString` input values', assert => {
 
   assert.equal(readDOMAttr(root.firstChild as Element, 'value'), '');
 });
+
+test('handles empty string textarea values', assert => {
+  let template = compile('<textarea value={{name}} />');
+
+  render(template, { name: '' });
+
+  assert.equal(readDOMAttr(root.firstChild as Element, 'value'), '');
+
+  rerender({ name: 'Alex' });
+
+  assert.equal(readDOMAttr(root.firstChild as Element, 'value'), 'Alex');
+
+  rerender({ name: '' });
+
+  assert.equal(readDOMAttr(root.firstChild as Element, 'value'), '');
+});


### PR DESCRIPTION
This fixes https://github.com/emberjs/ember.js/issues/14001

Some questions:

 * Are there elements other than `<input>` and `<textarea>` that should behave this way?
 * ~~Is there a generic name for `input` and `textarea` so that we can give `isInputValue` a better name?~~ **updated to use Godfrey's `isUserInputValue` suggestion below**