### PR TITLE
Remove `InternedString` (and get back on TS next)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "handlebars": "^3.0.2",
     "qunit": "^0.7.2",
     "simple-html-tokenizer": "^0.2.5",
-    "typescript": "2.1.0-dev.20160728"
+    "typescript": "next"
   },
   "devDependencies": {
     "loader.js": "^4.0.10",

--- a/packages/glimmer-compiler/lib/javascript-compiler.ts
+++ b/packages/glimmer-compiler/lib/javascript-compiler.ts
@@ -1,5 +1,5 @@
 import { assert } from "glimmer-util";
-import { Stack, DictSet, InternedString, dict } from "glimmer-util";
+import { Stack, DictSet, dict } from "glimmer-util";
 
 import {
   BlockMeta,
@@ -23,7 +23,7 @@ export class Block {
   toJSON(): SerializedBlock {
     return {
       statements: this.statements,
-      locals: this.positionals as InternedString[]
+      locals: this.positionals
     };
   }
 
@@ -47,7 +47,7 @@ export class Template extends Block {
   toJSON(): SerializedTemplate {
     return {
       statements: this.statements,
-      locals: this.positionals as InternedString[],
+      locals: this.positionals,
       named: this.named.toArray(),
       yields: this.yields.toArray(),
       blocks: this.blocks.map(b => b.toJSON()),

--- a/packages/glimmer-object-reference/lib/meta.ts
+++ b/packages/glimmer-object-reference/lib/meta.ts
@@ -1,7 +1,6 @@
 import { PropertyReference } from './references/descriptors';
 import RootReference from './references/root';
 import { MetaOptions } from './types';
-import { InternedString } from 'glimmer-util';
 
 import { Dict, DictSet, HasGuid, Set, dict } from 'glimmer-util';
 
@@ -20,10 +19,10 @@ const NOOP_DESTROY = { destroy() {} };
 
 class ConstPath implements IPathReference<any> {
   private parent: any;
-  private property: InternedString;
+  private property: string;
   public tag = VOLATILE_TAG;
 
-  constructor(parent: any, property: InternedString) {
+  constructor(parent: any, property: string) {
     this.parent = parent;
   }
 
@@ -34,7 +33,7 @@ class ConstPath implements IPathReference<any> {
     return this.parent[<string>this.property];
   }
 
-  get(prop: InternedString): IPathReference<any> {
+  get(prop: string): IPathReference<any> {
     return new ConstPath(this.parent[<string>this.property], prop);
   }
 }
@@ -58,15 +57,15 @@ class ConstRoot implements IRootReference<any> {
     return this.inner;
   }
 
-  referenceFromParts(parts: InternedString[]): IPathReference<any> {
+  referenceFromParts(parts: string[]): IPathReference<any> {
     throw new Error("Not implemented");
   }
 
-  chainFor(prop: InternedString): IPathReference<any> {
+  chainFor(prop: string): IPathReference<any> {
     throw new Error("Not implemented");
   }
 
-  get(prop: InternedString): IPathReference<any> {
+  get(prop: string): IPathReference<any> {
     return new ConstPath(this.inner, prop);
   }
 }
@@ -109,7 +108,7 @@ class Meta implements IMeta, HasGuid {
     return typeof obj === 'object' && obj._meta;
   }
 
-  static metadataForProperty(key: InternedString): any {
+  static metadataForProperty(key: string): any {
     return null;
   }
 
@@ -129,23 +128,23 @@ class Meta implements IMeta, HasGuid {
     this.DefaultPathReferenceFactory = DefaultPathReferenceFactory || PropertyReference;
   }
 
-  addReference(property: InternedString, reference: IPathReference<any> & HasGuid) {
+  addReference(property: string, reference: IPathReference<any> & HasGuid) {
     let refs = this.references = this.references || dict<DictSet<IPathReference<any> & HasGuid>>();
     let set = refs[<string>property] = refs[<string>property] || new DictSet<IPathReference<any> & HasGuid>();
     set.add(reference);
   }
 
-  addReferenceTypeFor(property: InternedString, type: PathReferenceFactory<any>) {
+  addReferenceTypeFor(property: string, type: PathReferenceFactory<any>) {
     this.referenceTypes = this.referenceTypes || dict<PathReferenceFactory<any>>();
     this.referenceTypes[<string>property] = type;
   }
 
-  referenceTypeFor(property: InternedString): InnerReferenceFactory<any> {
+  referenceTypeFor(property: string): InnerReferenceFactory<any> {
     if (!this.referenceTypes) return PropertyReference;
     return this.referenceTypes[<string>property] || PropertyReference;
   }
 
-  removeReference(property: InternedString, reference: IPathReference<any> & HasGuid) {
+  removeReference(property: string, reference: IPathReference<any> & HasGuid) {
     if (!this.references) return;
     let set = this.references[<string>property];
     set.delete(reference);
@@ -156,7 +155,7 @@ class Meta implements IMeta, HasGuid {
     return this.referenceTypes;
   }
 
-  referencesFor(property: InternedString): Set<IPathReference<any>> {
+  referencesFor(property: string): Set<IPathReference<any>> {
     if (!this.references) return;
     return this.references[<string>property];
   }

--- a/packages/glimmer-object-reference/lib/object.ts
+++ b/packages/glimmer-object-reference/lib/object.ts
@@ -2,9 +2,9 @@
 // import { intern } from 'glimmer-util';
 
 export function setProperty(parent: any, property: string, val: any) {
-  // let rootProp = metaFor(parent).root().chainFor(intern(property));
+  // let rootProp = metaFor(parent).root().chainFor(property));
 
-  // let referencesToNotify = metaFor(parent).referencesFor(intern(property));
+  // let referencesToNotify = metaFor(parent).referencesFor(property));
 
   parent[<string>property] = val;
 
@@ -16,9 +16,9 @@ export function setProperty(parent: any, property: string, val: any) {
 }
 
 export function notifyProperty(parent: any, property: string) {
-  // let rootProp = metaFor(parent).root().chainFor(intern(property));
+  // let rootProp = metaFor(parent).root().chainFor(property));
 
-  // let referencesToNotify = metaFor(parent).referencesFor(intern(property));
+  // let referencesToNotify = metaFor(parent).referencesFor(property));
 
   // if (referencesToNotify) {
   //   referencesToNotify.forEach(function(ref) { ref.notify(); });

--- a/packages/glimmer-object-reference/lib/references/descriptors.ts
+++ b/packages/glimmer-object-reference/lib/references/descriptors.ts
@@ -1,18 +1,17 @@
 import Meta from '../meta';
 import { Reference, VOLATILE_TAG } from 'glimmer-reference';
 import { NotifiableReference } from '../types';
-import { InternedString } from 'glimmer-util';
 
 export interface InnerReferenceFactory<T> {
-  new (object: any, property: InternedString, outer: NotifiableReference<any>): Reference<T>;
+  new (object: any, property: string, outer: NotifiableReference<any>): Reference<T>;
 }
 
 export class PropertyReference<T> implements Reference<T> {
   private object: any;
-  private property: InternedString;
+  private property: string;
   public tag = VOLATILE_TAG;
 
-  constructor(object: any, property: InternedString, outer: NotifiableReference<T>) {
+  constructor(object: any, property: string, outer: NotifiableReference<T>) {
     this.object = object;
     this.property = property;
   }
@@ -27,13 +26,13 @@ export class PropertyReference<T> implements Reference<T> {
 export function ComputedReferenceBlueprint(property, dependencies) {
   return class ComputedReference<T> implements Reference<T> {
     private object: any;
-    private property: InternedString;
-    private dependencies: InternedString[][];
+    private property: string;
+    private dependencies: string[][];
     private outer: NotifiableReference<T>;
     private installed = false;
     public tag = VOLATILE_TAG;
 
-    constructor(object: any, property: InternedString, outer: NotifiableReference<T>) {
+    constructor(object: any, property: string, outer: NotifiableReference<T>) {
       this.object = object;
       this.property = property;
       this.dependencies = dependencies;

--- a/packages/glimmer-object-reference/lib/references/path.ts
+++ b/packages/glimmer-object-reference/lib/references/path.ts
@@ -1,5 +1,5 @@
 import { EMPTY_CACHE } from '../utils';
-import { InternedString, DictSet, dict } from 'glimmer-util';
+import { DictSet, dict } from 'glimmer-util';
 import Meta from '../meta';
 import { PropertyReference } from './descriptors';
 import { VOLATILE_TAG, PathReference as IPathReference, Reference } from 'glimmer-reference';
@@ -21,7 +21,7 @@ class UnchainFromPath {
 
 export default class PathReference<T> implements IPathReference<T>, HasGuid {
   private parent: IPathReference<any>;
-  private property: InternedString;
+  private property: string;
   protected cache: any = EMPTY_CACHE;
   private inner: Reference<T> = null;
   private chains: Dict<PathReference<any>> = null;
@@ -29,7 +29,7 @@ export default class PathReference<T> implements IPathReference<T>, HasGuid {
   public _guid = null;
   public tag = VOLATILE_TAG;
 
-  constructor(parent: IPathReference<T>, property: InternedString) {
+  constructor(parent: IPathReference<T>, property: string) {
     this.parent = parent;
     this.property = property;
   }
@@ -56,7 +56,7 @@ export default class PathReference<T> implements IPathReference<T>, HasGuid {
     return (this.cache = inner.value());
   }
 
-  get(prop: InternedString): IPathReference<any> {
+  get(prop: string): IPathReference<any> {
     let chains = this._getChains();
     if (<string>prop in chains) return chains[<string>prop];
     return (chains[<string>prop] = new PathReference(this, prop));

--- a/packages/glimmer-object-reference/lib/references/root.ts
+++ b/packages/glimmer-object-reference/lib/references/root.ts
@@ -1,4 +1,4 @@
-import { Opaque, InternedString, intern, dict } from 'glimmer-util';
+import { Opaque, dict } from 'glimmer-util';
 import { PathReference } from './path';
 import { RootReference as IRootReference } from '../types';
 import { VOLATILE_TAG, PathReference as IPathReference } from 'glimmer-reference';
@@ -19,23 +19,23 @@ export default class RootReference<T> implements IRootReference<T>, IPathReferen
     // this.notify();
   }
 
-  get<U>(prop: InternedString): IPathReference<U> {
+  get<U>(prop: string): IPathReference<U> {
     let chains = this.chains;
     if (<string>prop in chains) return chains[<string>prop];
     return (chains[<string>prop] = new PathReference(this, prop));
   }
 
-  chainFor<U>(prop: InternedString): IPathReference<U> {
+  chainFor<U>(prop: string): IPathReference<U> {
     let chains = this.chains;
     if (<string>prop in chains) return chains[<string>prop];
     return null;
   }
 
   path(string) {
-    return string.split('.').reduce((ref, part) => ref.get(intern(part)), this);
+    return string.split('.').reduce((ref, part) => ref.get(part), this);
   }
 
-  referenceFromParts(parts: InternedString[]): IPathReference<Opaque> {
+  referenceFromParts(parts: string[]): IPathReference<Opaque> {
     return parts.reduce((ref, part) => ref.get(part) as IPathReference<Opaque>, this as IPathReference<Opaque>);
   }
 

--- a/packages/glimmer-object-reference/lib/types.ts
+++ b/packages/glimmer-object-reference/lib/types.ts
@@ -1,4 +1,4 @@
-import { Opaque, Dict, Set, InternedString } from 'glimmer-util';
+import { Opaque, Dict, Set } from 'glimmer-util';
 import { Reference, PathReference } from 'glimmer-reference';
 
 export interface NotifiableReference<T> extends Reference<T> {
@@ -10,7 +10,7 @@ export interface ChainableReference<T> extends Reference<T> {
 }
 
 export interface PathReferenceFactory<T> {
-  new (object: any, property: InternedString): PathReference<T>;
+  new (object: any, property: string): PathReference<T>;
 }
 
 export interface RootReferenceFactory<T> {
@@ -19,8 +19,8 @@ export interface RootReferenceFactory<T> {
 
 export interface RootReference<T> extends PathReference<T> {
   update(value: T);
-  referenceFromParts(parts: InternedString[]): PathReference<Opaque>;
-  chainFor(prop: InternedString): PathReference<T>;
+  referenceFromParts(parts: string[]): PathReference<Opaque>;
+  chainFor(prop: string): PathReference<T>;
 }
 
 import { InnerReferenceFactory } from './references/descriptors';
@@ -32,11 +32,11 @@ export interface MetaOptions {
 
 export interface Meta {
   root(): RootReference<any>;
-  referencesFor(property: InternedString): Set<PathReference<any>>;
-  referenceTypeFor(property: InternedString): InnerReferenceFactory<any>;
+  referencesFor(property: string): Set<PathReference<any>>;
+  referenceTypeFor(property: string): InnerReferenceFactory<any>;
   getReferenceTypes(): Dict<InnerReferenceFactory<any>>;
-  addReference(property: InternedString, reference: PathReference<any>);
-  removeReference(property: InternedString, reference: PathReference<any>);
+  addReference(property: string, reference: PathReference<any>);
+  removeReference(property: string, reference: PathReference<any>);
   getSlots(): Dict<any>;
 }
 

--- a/packages/glimmer-object-reference/tests/reference-test.ts
+++ b/packages/glimmer-object-reference/tests/reference-test.ts
@@ -13,10 +13,8 @@ import { metaFor, setProperty } from "glimmer-object-reference";
   //Meta.for(obj).addReferenceTypeFor(name, ComputedBlueprint(name, deps)); [>jshint +W064<]
 //}
 
-import { intern } from 'glimmer-util';
-
 function addObserver(obj: any, name: string, path: string) {
-  return metaFor(obj).root().referenceFromParts(path.split('.').map(intern));
+  return metaFor(obj).root().referenceFromParts(path.split('.'));
 }
 
 QUnit.module("references");

--- a/packages/glimmer-object/lib/computed.ts
+++ b/packages/glimmer-object/lib/computed.ts
@@ -1,4 +1,3 @@
-import { InternedString, intern } from 'glimmer-util';
 import { ComputedReferenceBlueprint, Meta } from 'glimmer-object-reference';
 import { EMPTY_CACHE, ClassMeta } from './object';
 import { Descriptor, Blueprint } from './mixin';
@@ -28,16 +27,16 @@ type ComputedArgument = ComputedGetCallback | ComputedDescriptor;
 
 export class ComputedBlueprint extends Blueprint {
   private accessor: ComputedDescriptor;
-  private deps: InternedString[][];
+  private deps: string[][];
   private metadata: Object = {};
 
-  constructor(accessor: ComputedDescriptor, deps: InternedString[][] = []) {
+  constructor(accessor: ComputedDescriptor, deps: string[][] = []) {
     super();
     this.accessor = accessor;
     this.deps = deps;
   }
 
-  descriptor(target: Object, key: InternedString, classMeta: ClassMeta): Descriptor {
+  descriptor(target: Object, key: string, classMeta: ClassMeta): Descriptor {
     classMeta.addReferenceTypeFor(key, ComputedReferenceBlueprint(key, this.deps));
     classMeta.addPropertyMetadata(key, this.metadata);
     classMeta.addSlotFor(key);
@@ -45,7 +44,7 @@ export class ComputedBlueprint extends Blueprint {
   }
 
   property(...paths: string[]) {
-    this.deps = paths.map(d => d.split('.').map(intern));
+    this.deps = paths.map(d => d.split('.'));
     return this;
   }
 
@@ -70,12 +69,12 @@ class Computed implements Descriptor {
     this.accessor = accessor;
   }
 
-  define(prototype: Object, key: InternedString, home: Object) {
+  define(prototype: Object, key: string, home: Object) {
     Object.defineProperty(prototype, key, wrapAccessor(home, key, this.accessor));
   }
 }
 
-function wrapAccessor(home: Object, accessorName: InternedString, _desc: ComputedDescriptor): PropertyDescriptor {
+function wrapAccessor(home: Object, accessorName: string, _desc: ComputedDescriptor): PropertyDescriptor {
   let superDesc = getPropertyDescriptor(home, accessorName);
 
   let originalGet: ComputedGetCallback;

--- a/packages/glimmer-object/lib/descriptors.ts
+++ b/packages/glimmer-object/lib/descriptors.ts
@@ -1,17 +1,16 @@
 import { Blueprint, Descriptor } from './mixin';
 import { ClassMeta } from './object';
 import { ComputedBlueprint } from './computed';
-import { InternedString, intern } from 'glimmer-util';
 
 class AliasMethodDescriptor extends Descriptor {
-  private name: InternedString;
+  private name: string;
 
-  constructor(name: InternedString) {
+  constructor(name: string) {
     super();
     this.name = name;
   }
 
-  define(target: Object, key: InternedString, home: Object) {
+  define(target: Object, key: string, home: Object) {
     let name = <string>this.name;
 
     Object.defineProperty(target, key, {
@@ -25,26 +24,26 @@ class AliasMethodDescriptor extends Descriptor {
 }
 
 class AliasMethodBlueprint extends Blueprint {
-  private name: InternedString;
+  private name: string;
 
-  constructor(name: InternedString) {
+  constructor(name: string) {
     super();
     this.name = name;
   }
 
-  descriptor(target: Object, key: InternedString, meta: ClassMeta): Descriptor {
+  descriptor(target: Object, key: string, meta: ClassMeta): Descriptor {
     return new AliasMethodDescriptor(this.name);
   }
 }
 
 export function aliasMethod(name: string) {
-  return new AliasMethodBlueprint(intern(name));
+  return new AliasMethodBlueprint(name);
 }
 
 class AliasBlueprint extends ComputedBlueprint {
-  private name: InternedString[];
+  private name: string[];
 
-  constructor(name: InternedString[]) {
+  constructor(name: string[]) {
     let parent = name.slice(0, -1);
     let last = name[name.length - 1];
 
@@ -61,12 +60,12 @@ class AliasBlueprint extends ComputedBlueprint {
     this.name = name;
   }
 
-  descriptor(target: Object, key: InternedString, meta: ClassMeta): Descriptor {
+  descriptor(target: Object, key: string, meta: ClassMeta): Descriptor {
     if (this.name[0] === key) throw new Error(`Setting alias '${key}' on self`);
     return super.descriptor(target, key, meta);
   }
 }
 
 export function alias(name: string): AliasBlueprint {
-  return new AliasBlueprint(name.split('.').map(intern));
+  return new AliasBlueprint(name.split('.'));
 }

--- a/packages/glimmer-object/lib/mixin.ts
+++ b/packages/glimmer-object/lib/mixin.ts
@@ -1,5 +1,5 @@
 import { CLASS_META } from 'glimmer-object-reference';
-import { InternedString, Dict, dict, isArray, intern, assign } from 'glimmer-util';
+import { Dict, dict, isArray, assign } from 'glimmer-util';
 import GlimmerObject, {
   GlimmerObjectFactory,
   ClassMeta,
@@ -14,12 +14,12 @@ export const BLUEPRINT  = "8d97cf5f-db9e-48d8-a6b2-7a75b7170805";
 
 export abstract class Descriptor {
   "5d90f84f-908e-4a42-9749-3d0f523c262c" = true;
-  abstract define(prototype: Object, key: InternedString, home: Object);
+  abstract define(prototype: Object, key: string, home: Object);
 }
 
 export abstract class Blueprint {
   "8d97cf5f-db9e-48d8-a6b2-7a75b7170805" = true;
-  abstract descriptor(target: Object, key: InternedString, classMeta: ClassMeta): Descriptor;
+  abstract descriptor(target: Object, key: string, classMeta: ClassMeta): Descriptor;
 }
 
 interface Extensions {
@@ -31,8 +31,8 @@ interface Extensions {
 
 export class Mixin {
   private extensions = null;
-  private concatenatedProperties: InternedString[] = [];
-  private mergedProperties: InternedString[] = [];
+  private concatenatedProperties: string[] = [];
+  private mergedProperties: string[] = [];
   private dependencies: Mixin[] = [];
 
   static create(...args: (Mixin | Extensions)[]) {
@@ -79,15 +79,15 @@ export class Mixin {
     }
 
     if (typeof extensions === 'object' && 'concatenatedProperties' in extensions) {
-      let concat: InternedString[];
+      let concat: string[];
       let rawConcat = extensions.concatenatedProperties;
 
       if (isArray(rawConcat)) {
-        concat = (<string[]>rawConcat).slice().map(intern);
+        concat = (<string[]>rawConcat).slice();
       } else if (rawConcat === null || rawConcat === undefined) {
         concat = [];
       } else {
-        concat = [intern(<string>rawConcat)];
+        concat = [<string>rawConcat];
       }
 
       delete extensions.concatenatedProperties;
@@ -95,15 +95,15 @@ export class Mixin {
     }
 
     if (typeof extensions === 'object' && 'mergedProperties' in extensions) {
-      let merged: InternedString[];
+      let merged: string[];
       let rawMerged = extensions.mergedProperties;
 
       if (isArray(rawMerged)) {
-        merged = (<string[]>rawMerged).slice().map(intern);
+        merged = (<string[]>rawMerged).slice();
       } else if (rawMerged === null || rawMerged === undefined) {
         merged = [];
       } else {
-        merged = [intern(<string>rawMerged)];
+        merged = [<string>rawMerged];
       }
 
       delete extensions.mergedProperties;
@@ -170,16 +170,16 @@ export class Mixin {
     this.mergedProperties.forEach(k => meta.addMergedProperty(k, parent[<string>k]));
     this.concatenatedProperties.forEach(k => meta.addConcatenatedProperty(k, []));
 
-    new ValueDescriptor({ value: meta.getConcatenatedProperties() }).define(target, <InternedString>'concatenatedProperties', null);
-    new ValueDescriptor({ value: meta.getMergedProperties() }).define(target, <InternedString>'mergedProperties', null);
+    new ValueDescriptor({ value: meta.getConcatenatedProperties() }).define(target, <string>'concatenatedProperties', null);
+    new ValueDescriptor({ value: meta.getMergedProperties() }).define(target, <string>'mergedProperties', null);
 
     Object.keys(this.extensions).forEach(key => {
       let extension: Blueprint = this.extensions[key];
-      let desc = extension.descriptor(target, <InternedString>key, meta);
-      desc.define(target, <InternedString>key, parent);
+      let desc = extension.descriptor(target, <string>key, meta);
+      desc.define(target, <string>key, parent);
     });
 
-    new ValueDescriptor({ value: ROOT }).define(target, <InternedString>'_super', null);
+    new ValueDescriptor({ value: ROOT }).define(target, <string>'_super', null);
   }
 }
 
@@ -231,7 +231,7 @@ class ValueDescriptor extends Descriptor {
     this.value = value;
   }
 
-  define(target: Object, key: InternedString, home: Object) {
+  define(target: Object, key: string, home: Object) {
     Object.defineProperty(target, key, {
       enumerable: this.enumerable,
       configurable: this.configurable,
@@ -255,7 +255,7 @@ class AccessorDescriptor extends Descriptor {
     this.set = set;
   }
 
-  define(target: Object, key: InternedString) {
+  define(target: Object, key: string) {
     Object.defineProperty(target, key, {
       enumerable: this.enumerable,
       configurable: this.configurable,
@@ -279,15 +279,15 @@ export class DataBlueprint extends Blueprint {
     this.writable = writable;
   }
 
-  descriptor(target: Object, key: InternedString, classMeta: ClassMeta): ValueDescriptor {
+  descriptor(target: Object, key: string, classMeta: ClassMeta): ValueDescriptor {
     let { enumerable, configurable, writable, value } = this;
 
-    if (classMeta.hasConcatenatedProperty(<InternedString>key)) {
-      classMeta.addConcatenatedProperty(<InternedString>key, value);
-      value = classMeta.getConcatenatedProperty(<InternedString>key);
-    } else if (classMeta.hasMergedProperty(<InternedString>key)) {
-      classMeta.addMergedProperty(<InternedString>key, value);
-      value = classMeta.getMergedProperty(<InternedString>key);
+    if (classMeta.hasConcatenatedProperty(<string>key)) {
+      classMeta.addConcatenatedProperty(<string>key, value);
+      value = classMeta.getConcatenatedProperty(<string>key);
+    } else if (classMeta.hasMergedProperty(<string>key)) {
+      classMeta.addMergedProperty(<string>key, value);
+      value = classMeta.getMergedProperty(<string>key);
     }
 
     return new ValueDescriptor({ enumerable, configurable, writable, value });
@@ -308,7 +308,7 @@ export abstract class AccessorBlueprint extends Blueprint {
     this.set = set;
   }
 
-  descriptor(target: Object, key: InternedString, classMeta: ClassMeta): Descriptor {
+  descriptor(target: Object, key: string, classMeta: ClassMeta): Descriptor {
     return new ValueDescriptor({
       enumerable: this.enumerable,
       configurable: this.configurable,
@@ -319,20 +319,20 @@ export abstract class AccessorBlueprint extends Blueprint {
 }
 
 class MethodDescriptor extends ValueDescriptor {
-  define(target: Object, key: InternedString, home: Object) {
+  define(target: Object, key: string, home: Object) {
     this.value = wrapMethod(home, key, this.value);
     super.define(target, key, home);
   }
 }
 
 class MethodBlueprint extends DataBlueprint {
-  descriptor(target: Object, key: InternedString, classMeta: ClassMeta): MethodDescriptor {
+  descriptor(target: Object, key: string, classMeta: ClassMeta): MethodDescriptor {
     let desc = super.descriptor(target, key, classMeta);
     return new MethodDescriptor(desc);
   }
 }
 
-export function wrapMethod(home: Object, methodName: InternedString, original: (...args) => any) {
+export function wrapMethod(home: Object, methodName: string, original: (...args) => any) {
   if (!(<string>methodName in home)) return maybeWrap(original);
 
   let superMethod = home[<string>methodName];

--- a/packages/glimmer-object/lib/object.ts
+++ b/packages/glimmer-object/lib/object.ts
@@ -3,7 +3,7 @@ import {
   InnerReferenceFactory,
   PropertyReference
 } from 'glimmer-object-reference';
-import { InternedString, Dict, dict, isArray, intern, assign, initializeGuid } from 'glimmer-util';
+import { Dict, dict, isArray, assign, initializeGuid } from 'glimmer-util';
 import {
   Mixin,
   extend as extendClass,
@@ -36,7 +36,7 @@ export interface GlimmerObjectFactory<T> {
   reopen<U>(extensions: U);
   reopenClass<U>(extensions: U);
   metaForProperty(property: string): Object;
-  eachComputedProperty(callback: (InternedString, Object) => void);
+  eachComputedProperty(callback: (string, Object) => void);
   "df8be4c8-4e89-44e2-a8f9-550c8dacdca7": InstanceMeta;
 }
 
@@ -63,7 +63,7 @@ export class ClassMeta {
   private appliedMixins: Mixin[] = [];
   private staticMixins: Mixin[] = [];
   private subclasses: GlimmerObjectFactory<any>[] = [];
-  private slots: InternedString[] = [];
+  private slots: string[] = [];
   public InstanceMetaConstructor: typeof Meta = null;
 
   static fromParent(parent: ClassMeta) {
@@ -148,36 +148,36 @@ export class ClassMeta {
     return this.subclasses;
   }
 
-  addPropertyMetadata(property: InternedString, value: any) {
+  addPropertyMetadata(property: string, value: any) {
     this.propertyMetadata[<string>property] = value;
   }
 
-  metadataForProperty(property: InternedString): Object {
+  metadataForProperty(property: string): Object {
     return this.propertyMetadata[<string>property];
   }
 
-  addReferenceTypeFor(property: InternedString, type: InnerReferenceFactory<any>) {
+  addReferenceTypeFor(property: string, type: InnerReferenceFactory<any>) {
     this.referenceTypes[<string>property] = type;
   }
 
-  addSlotFor(property: InternedString) {
+  addSlotFor(property: string) {
     this.slots.push(property);
   }
 
-  hasConcatenatedProperty(property: InternedString): boolean {
+  hasConcatenatedProperty(property: string): boolean {
     if (!this.hasConcatenatedProperties) return false;
     return <string>property in this.concatenatedProperties;
   }
 
-  getConcatenatedProperty(property: InternedString): any[] {
+  getConcatenatedProperty(property: string): any[] {
     return this.concatenatedProperties[<string>property];
   }
 
-  getConcatenatedProperties(): InternedString[] {
-    return <InternedString[]>Object.keys(this.concatenatedProperties);
+  getConcatenatedProperties(): string[] {
+    return <string[]>Object.keys(this.concatenatedProperties);
   }
 
-  addConcatenatedProperty(property: InternedString, value: any) {
+  addConcatenatedProperty(property: string, value: any) {
     this.hasConcatenatedProperties = true;
 
     if (<string>property in this.concatenatedProperties) {
@@ -188,20 +188,20 @@ export class ClassMeta {
     }
   }
 
-  hasMergedProperty(property: InternedString): boolean {
+  hasMergedProperty(property: string): boolean {
     if (!this.hasMergedProperties) return false;
     return <string>property in this.mergedProperties;
   }
 
-  getMergedProperty(property: InternedString): Object {
+  getMergedProperty(property: string): Object {
     return this.mergedProperties[<string>property];
   }
 
-  getMergedProperties(): InternedString[] {
-    return <InternedString[]>Object.keys(this.mergedProperties);
+  getMergedProperties(): string[] {
+    return <string[]>Object.keys(this.mergedProperties);
   }
 
-  addMergedProperty(property: InternedString, value: Object) {
+  addMergedProperty(property: string, value: Object) {
     this.hasMergedProperties = true;
 
     if (isArray(value)) {
@@ -283,7 +283,7 @@ export class ClassMeta {
         return this.referenceTypes;
       }
 
-      referenceTypeFor(property: InternedString): InnerReferenceFactory<any> {
+      referenceTypeFor(property: string): InnerReferenceFactory<any> {
         return this.referenceTypes[<string>property] || PropertyReference;
       }
 
@@ -301,7 +301,7 @@ function mergeMergedProperties(attrs: Object, parent: Object) {
 
   for (let prop in attrs) {
     if (prop in parent && typeof parent[prop] === 'function' && typeof attrs[prop] === 'function') {
-      let wrapped = wrapMethod(parent, prop as InternedString, attrs[prop]);
+      let wrapped = wrapMethod(parent, prop, attrs[prop]);
       merged[prop] = wrapped;
     } else {
       merged[prop] = attrs[prop];
@@ -358,12 +358,12 @@ export default class GlimmerObject {
   }
 
   static metaForProperty(property: string): Object {
-    let value = this[CLASS_META].metadataForProperty(intern(property));
+    let value = this[CLASS_META].metadataForProperty(property);
     if (!value) throw new Error(`metaForProperty() could not find a computed property with key '${property}'.`);
     return value;
   }
 
-  static eachComputedProperty(callback: (InternedString, Object) => void) {
+  static eachComputedProperty(callback: (string, Object) => void) {
     let metadata = this[CLASS_META].getPropertyMetadata();
     if (!metadata) return;
 

--- a/packages/glimmer-object/tests/ember-metal-alias-test.ts
+++ b/packages/glimmer-object/tests/ember-metal-alias-test.ts
@@ -1,7 +1,6 @@
 import { alias } from 'glimmer-object';
 import { Reference } from 'glimmer-reference';
 import{ Meta } from 'glimmer-object-reference';
-import { LITERAL } from 'glimmer-util';
 import { get, set, defineProperty } from './support';
 
 let obj, count;
@@ -37,7 +36,7 @@ QUnit.test('should proxy set to alt key', function() {
 
 QUnit.test('should observe the alias', function() {
   defineProperty(obj, 'bar', alias('foo.faz'));
-  let ref = Meta.for(obj).root().get(LITERAL('bar'));
+  let ref = Meta.for(obj).root().get('bar');
   let val = ref.value();
   equal(val, 'FOO');
   shouldBeClean(ref);

--- a/packages/glimmer-object/tests/object-test.ts
+++ b/packages/glimmer-object/tests/object-test.ts
@@ -1,6 +1,5 @@
 import GlimmerObject, { computed } from 'glimmer-object';
 import { UpdatableReference, metaFor, setProperty } from 'glimmer-object-reference';
-import { intern } from 'glimmer-util';
 
 let Wrapper = <any>GlimmerObject.extend({
   fullName: computed(function() {
@@ -149,7 +148,7 @@ function root<T>(obj: T): UpdatableReference<T> {
 QUnit.test("Simple computed properties", function() {
   let name = <any>new Name({ first: "Godfrey", last: "Chan" });
 
-  let ref = metaFor(name).root().get(intern('fullName'));
+  let ref = metaFor(name).root().get('fullName');
 
   equal(name.fullName, "Godfrey Chan");
   equal(ref.value(), "Godfrey Chan");
@@ -173,7 +172,7 @@ QUnit.test("Computed properties", function() {
   });
 
   let originalPerson = obj1.model.person;
-  let ref = metaFor(obj1).root().get(intern('fullName'));
+  let ref = metaFor(obj1).root().get('fullName');
 
   equal(obj1.fullName, "Yehuda Katz");
   equal(ref.value(), "Yehuda Katz");

--- a/packages/glimmer-reference/lib/iterable.ts
+++ b/packages/glimmer-reference/lib/iterable.ts
@@ -1,4 +1,4 @@
-import { FIXME, LinkedList, ListNode, InternedString, Opaque, dict } from 'glimmer-util';
+import { LinkedList, ListNode, Opaque, dict } from 'glimmer-util';
 import { VersionedPathReference as PathReference, RevisionTag } from './validators';
 
 export interface IterationItem<T, U> {
@@ -31,7 +31,7 @@ export type OpaqueIterator = AbstractIterator<Opaque, Opaque, OpaqueIterationIte
 export type OpaqueIterable = AbstractIterable<Opaque, Opaque, OpaqueIterationItem, PathReference<Opaque>, PathReference<Opaque>>;
 
 class ListItem extends ListNode<PathReference<Opaque>> implements IterationItem<PathReference<Opaque>, PathReference<Opaque>> {
-  public key: InternedString;
+  public key: string;
   public memo: PathReference<Opaque>;
   public retained: boolean = false;
   public seen: boolean = false;
@@ -39,7 +39,7 @@ class ListItem extends ListNode<PathReference<Opaque>> implements IterationItem<
 
   constructor(iterable: OpaqueIterable, result: OpaqueIterationItem) {
     super(iterable.valueReferenceFor(result));
-    this.key = result.key as FIXME<'user string to InternedString'>;
+    this.key = result.key;
     this.iterable = iterable;
     this.memo = iterable.memoReferenceFor(result);
   }
@@ -164,10 +164,10 @@ export class ReferenceIterator {
 }
 
 export interface IteratorSynchronizerDelegate {
-  retain(key: InternedString, item: PathReference<Opaque>, memo: PathReference<Opaque>);
-  insert(key: InternedString, item: PathReference<Opaque>, memo: PathReference<Opaque>, before: InternedString);
-  move(key: InternedString, item: PathReference<Opaque>, memo: PathReference<Opaque>, before: InternedString);
-  delete(key: InternedString);
+  retain(key: string, item: PathReference<Opaque>, memo: PathReference<Opaque>);
+  insert(key: string, item: PathReference<Opaque>, memo: PathReference<Opaque>, before: string);
+  move(key: string, item: PathReference<Opaque>, memo: PathReference<Opaque>, before: string);
+  delete(key: string);
   done();
 }
 
@@ -207,7 +207,7 @@ export class IteratorSynchronizer {
     }
   }
 
-  private advanceToKey(key: InternedString) {
+  private advanceToKey(key: string) {
     let { current, artifacts } = this;
 
     let seek = current;
@@ -247,7 +247,7 @@ export class IteratorSynchronizer {
 
     current.update(item);
     this.current = artifacts.nextNode(current);
-    this.target.retain(item.key as FIXME<'user string to InternedString'>, current.value, current.memo);
+    this.target.retain(item.key, current.value, current.memo);
   }
 
   private nextMove(item: OpaqueIterationItem) {
@@ -261,7 +261,7 @@ export class IteratorSynchronizer {
       artifacts.move(found, current);
       target.move(found.key, found.value, found.memo, current ? current.key : null);
     } else {
-      this.advanceToKey(key as FIXME<'user string to InternedString'>);
+      this.advanceToKey(key);
     }
   }
 

--- a/packages/glimmer-reference/lib/utils.ts
+++ b/packages/glimmer-reference/lib/utils.ts
@@ -1,7 +1,7 @@
 import { VersionedPathReference } from './validators';
-import { InternedString, Opaque } from 'glimmer-util';
+import { Opaque } from 'glimmer-util';
 
-export function referenceFromParts(root: VersionedPathReference<Opaque>, parts: InternedString[]): VersionedPathReference<Opaque> {
+export function referenceFromParts(root: VersionedPathReference<Opaque>, parts: string[]): VersionedPathReference<Opaque> {
   let reference = root;
 
   for (let i=0; i<parts.length; i++) {

--- a/packages/glimmer-reference/lib/validators.ts
+++ b/packages/glimmer-reference/lib/validators.ts
@@ -1,5 +1,5 @@
 import Reference, { PathReference } from './reference';
-import { InternedString, Opaque, Slice, LinkedListNode } from 'glimmer-util';
+import { Opaque, Slice, LinkedListNode } from 'glimmer-util';
 
 //////////
 
@@ -216,7 +216,7 @@ export const CURRENT_TAG: DirtyableTag = new (
 export interface VersionedReference<T> extends Reference<T>, Tagged<Revision> {}
 
 export interface VersionedPathReference<T> extends PathReference<T>, Tagged<Revision> {
-  get(property: InternedString): VersionedPathReference<Opaque>;
+  get(property: string): VersionedPathReference<Opaque>;
 }
 
 export abstract class CachedReference<T> implements VersionedReference<T> {

--- a/packages/glimmer-runtime/lib/builder.ts
+++ b/packages/glimmer-runtime/lib/builder.ts
@@ -2,7 +2,7 @@ import Bounds, { clear, Cursor } from './bounds';
 
 import { DOMHelper } from './dom/helper';
 
-import { Destroyable, InternedString, Stack, LinkedList, LinkedListNode, assert } from 'glimmer-util';
+import { Destroyable, Stack, LinkedList, LinkedListNode, assert } from 'glimmer-util';
 
 import { Environment } from './environment';
 
@@ -62,8 +62,8 @@ class BlockStackElement {
 }
 
 export interface ElementOperations {
-  addAttribute(name: InternedString, value: PathReference<string>, isTrusting: boolean);
-  addAttributeNS(namespace: InternedString, name: InternedString, value: PathReference<string>, isTrusting: boolean);
+  addAttribute(name: string, value: PathReference<string>, isTrusting: boolean);
+  addAttributeNS(namespace: string, name: string, value: PathReference<string>, isTrusting: boolean);
 }
 
 class GroupedElementOperations implements ElementOperations {
@@ -85,13 +85,13 @@ class GroupedElementOperations implements ElementOperations {
     this.groups.push(group);
   }
 
-  addAttribute(name: InternedString, reference: PathReference<string>, isTrusting: boolean) {
+  addAttribute(name: string, reference: PathReference<string>, isTrusting: boolean) {
     let attributeManager = this.env.attributeFor(this.element, name, reference, isTrusting);
     let attribute = new Attribute(this.element, attributeManager, name, reference);
     this.group.push(attribute);
   }
 
-  addAttributeNS(namespace: InternedString, name: InternedString, reference: PathReference<string>, isTrusting: boolean) {
+  addAttributeNS(namespace: string, name: string, reference: PathReference<string>, isTrusting: boolean) {
     let attributeManager = this.env.attributeFor(this.element, name, reference,isTrusting, namespace);
     let nsAttribute = new Attribute(this.element, attributeManager, name, reference, namespace);
 
@@ -174,7 +174,7 @@ export class ElementStack implements Cursor {
     return this.blockStack.current;
   }
 
-  private pushElement(tag: InternedString): Element {
+  private pushElement(tag: string): Element {
     let element = this.dom.createElement(tag, this.element);
     let elementOperations = new GroupedElementOperations(element, this.env);
 
@@ -240,7 +240,7 @@ export class ElementStack implements Cursor {
     return this.blockStack.pop();
   }
 
-  openElement(tag: InternedString): Element {
+  openElement(tag: string): Element {
     let element = this.pushElement(tag);
     this.blockStack.current.openElement(element);
     return element;
@@ -270,11 +270,11 @@ export class ElementStack implements Cursor {
     return comment;
   }
 
-  setAttribute(name: InternedString, reference: PathReference<string>, isTrusting: boolean) {
+  setAttribute(name: string, reference: PathReference<string>, isTrusting: boolean) {
     this.elementOperations.addAttribute(name, reference, isTrusting);
   }
 
-  setAttributeNS(namespace: InternedString, name: InternedString, reference: PathReference<string>, isTrusting: boolean) {
+  setAttributeNS(namespace: string, name: string, reference: PathReference<string>, isTrusting: boolean) {
     this.elementOperations.addAttributeNS(namespace, name, reference, isTrusting);
   }
 

--- a/packages/glimmer-runtime/lib/compiled/blocks.ts
+++ b/packages/glimmer-runtime/lib/compiled/blocks.ts
@@ -1,4 +1,3 @@
-import { InternedString } from 'glimmer-util';
 import { OpSeq } from '../opcodes';
 import { Program } from '../syntax';
 import { Environment } from '../environment';
@@ -45,11 +44,11 @@ export abstract class Block {
 }
 
 export interface InlineBlockOptions extends BlockOptions {
-  locals: InternedString[];
+  locals: string[];
 }
 
 export class InlineBlock extends Block {
-  public locals: InternedString[];
+  public locals: string[];
 
   constructor(options: InlineBlockOptions) {
     super(options);
@@ -106,8 +105,8 @@ export class EntryPoint extends TopLevelTemplate {
 }
 
 export interface LayoutOptions extends BlockOptions {
-  named: InternedString[];
-  yields: InternedString[];
+  named: string[];
+  yields: string[];
   program: Program;
 }
 
@@ -118,8 +117,8 @@ export class Layout extends TopLevelTemplate {
     return layout;
   }
 
-  public named: InternedString[];
-  public yields: InternedString[];
+  public named: string[];
+  public yields: string[];
 
   constructor(options: LayoutOptions) {
     super(options);

--- a/packages/glimmer-runtime/lib/compiled/expressions/has-block-params.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/has-block-params.ts
@@ -1,14 +1,13 @@
 import VM from '../../vm/append';
 import { CompiledExpression } from '../expressions';
 import { ValueReference } from './value';
-import { InternedString } from 'glimmer-util';
 
 export default class CompiledHasBlockParams extends CompiledExpression<boolean> {
   public type = "has-block-params";
-  public blockName: InternedString;
+  public blockName: string;
   public blockSymbol: number;
 
-  constructor({ blockName, blockSymbol }: { blockName: InternedString, blockSymbol: number }) {
+  constructor({ blockName, blockSymbol }: { blockName: string, blockSymbol: number }) {
     super();
     this.blockName = blockName;
     this.blockSymbol = blockSymbol;

--- a/packages/glimmer-runtime/lib/compiled/expressions/has-block.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/has-block.ts
@@ -1,14 +1,13 @@
 import VM from '../../vm/append';
 import { CompiledExpression } from '../expressions';
 import { ValueReference } from './value';
-import { InternedString } from 'glimmer-util';
 
 export default class CompiledHasBlock extends CompiledExpression<boolean> {
   public type = "has-block";
-  public blockName: InternedString;
+  public blockName: string;
   public blockSymbol: number;
 
-  constructor({ blockName, blockSymbol }: { blockName: InternedString, blockSymbol: number }) {
+  constructor({ blockName, blockSymbol }: { blockName: string, blockSymbol: number }) {
     super();
     this.blockName = blockName;
     this.blockSymbol = blockSymbol;

--- a/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
@@ -3,15 +3,15 @@ import { CompiledArgs } from './args';
 import VM from '../../vm/append';
 import { Helper } from '../../environment';
 import { PathReference } from 'glimmer-reference';
-import { InternedString, Opaque } from 'glimmer-util';
+import { Opaque } from 'glimmer-util';
 
 export default class CompiledHelper extends CompiledExpression<Opaque> {
   public type = "helper";
-  public name: InternedString[];
+  public name: string[];
   public helper: Helper;
   public args: CompiledArgs;
 
-  constructor({ name, helper, args }: { name: InternedString[], helper: Helper, args: CompiledArgs }) {
+  constructor({ name, helper, args }: { name: string[], helper: Helper, args: CompiledArgs }) {
     super();
     this.name = name;
     this.helper = helper;

--- a/packages/glimmer-runtime/lib/compiled/expressions/named-args.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/named-args.ts
@@ -2,7 +2,7 @@ import { UNDEFINED_REFERENCE } from '../../references';
 import { CompiledExpression } from '../expressions';
 import VM from '../../vm/append';
 import { CONSTANT_TAG, PathReference, RevisionTag, combine } from 'glimmer-reference';
-import { InternedString, Dict, dict } from 'glimmer-util';
+import { Dict, dict } from 'glimmer-util';
 
 export abstract class CompiledNamedArgs {
   public abstract type: string;
@@ -65,7 +65,7 @@ export const COMPILED_EMPTY_NAMED_ARGS: CompiledNamedArgs = new (class extends C
 
 export abstract class EvaluatedNamedArgs {
   public tag: RevisionTag;
-  public keys: InternedString[];
+  public keys: string[];
 
   static empty(): EvaluatedNamedArgs {
     return EVALUATED_EMPTY_NAMED_ARGS;
@@ -78,18 +78,18 @@ export abstract class EvaluatedNamedArgs {
   public type: string;
   public map: Dict<PathReference<any>>;
 
-  forEach(callback: (key: InternedString, value: PathReference<any>) => void) {
+  forEach(callback: (key: string, value: PathReference<any>) => void) {
     let { map } = this;
     let mapKeys = Object.keys(map);
 
     for (let i = 0; i < mapKeys.length; i++) {
       let key = mapKeys[i];
-      callback(key as InternedString, map[key]);
+      callback(key, map[key]);
     }
   }
 
-  abstract get(key: InternedString): PathReference<any>;
-  abstract has(key: InternedString): boolean;
+  abstract get(key: string): PathReference<any>;
+  abstract has(key: string): boolean;
   abstract value(): Dict<any>;
 }
 
@@ -100,7 +100,7 @@ class NonEmptyEvaluatedNamedArgs extends EvaluatedNamedArgs {
   constructor({ map }: { map: Dict<PathReference<any>> }) {
     super();
 
-    let keys = this.keys = Object.keys(map) as InternedString[];
+    let keys = this.keys = Object.keys(map);
     this.map = map;
 
     let tags = [];
@@ -113,11 +113,11 @@ class NonEmptyEvaluatedNamedArgs extends EvaluatedNamedArgs {
     this.tag = combine(tags);
   }
 
-  get(key: InternedString): PathReference<any> {
+  get(key: string): PathReference<any> {
     return this.map[<string>key] || UNDEFINED_REFERENCE;
   }
 
-  has(key: InternedString): boolean {
+  has(key: string): boolean {
     return !!this.map[<string>key];
   }
 
@@ -143,7 +143,7 @@ export const EVALUATED_EMPTY_NAMED_ARGS = new (class extends EvaluatedNamedArgs 
     return UNDEFINED_REFERENCE;
   }
 
-  has(key: InternedString): boolean {
+  has(key: string): boolean {
     return false;
   }
 

--- a/packages/glimmer-runtime/lib/compiled/expressions/ref.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/ref.ts
@@ -1,15 +1,14 @@
 import { CompiledExpression } from '../expressions';
 import VM from '../../vm/append';
-import { InternedString } from 'glimmer-util';
 import { PathReference } from 'glimmer-reference';
 import { referenceFromParts } from 'glimmer-reference';
 
 export abstract class CompiledSymbolRef extends CompiledExpression<any> {
   protected debug: string;
   protected symbol: number;
-  protected path: InternedString[];
+  protected path: string[];
 
-  constructor({ debug, symbol, path }: { debug: string, symbol: number, path: InternedString[] }) {
+  constructor({ debug, symbol, path }: { debug: string, symbol: number, path: string[] }) {
     super();
     this.debug = debug;
     this.symbol = symbol;
@@ -36,10 +35,10 @@ export abstract class CompiledSymbolRef extends CompiledExpression<any> {
 
 export class CompiledKeywordRef {
   public type = "keyword-ref";
-  public name: InternedString;
-  public path: InternedString[];
+  public name: string;
+  public path: string[];
 
-  constructor({ name, path }: { name: InternedString, path: InternedString[] }) {
+  constructor({ name, path }: { name: string, path: string[] }) {
     this.name = name;
     this.path = path;
   }
@@ -71,9 +70,9 @@ export class CompiledLocalRef extends CompiledSymbolRef {
 
 export class CompiledSelfRef extends CompiledExpression<any> {
   public type = "self-ref";
-  private parts: InternedString[];
+  private parts: string[];
 
-  constructor({ parts }: { parts: InternedString[] }) {
+  constructor({ parts }: { parts: string[] }) {
     super();
     this.parts = parts;
   }

--- a/packages/glimmer-runtime/lib/compiled/expressions/value.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/value.ts
@@ -1,7 +1,7 @@
 import { VM } from '../../vm';
 import { CompiledExpression } from '../expressions';
 import { ConstReference, PathReference } from 'glimmer-reference';
-import { InternedString, dict } from 'glimmer-util';
+import { dict } from 'glimmer-util';
 
 export default class CompiledValue<T> extends CompiledExpression<T> {
   public type = "value";
@@ -25,7 +25,7 @@ export class ValueReference<T> extends ConstReference<T> implements PathReferenc
   protected inner: T;
   protected children = dict<ValueReference<any>>();
 
-  get(key: InternedString) {
+  get(key: string) {
     let { children } = this;
     let child = children[<string>key];
 

--- a/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
@@ -5,7 +5,7 @@ import * as lists from './lists';
 import * as vm from './vm';
 import * as Syntax from '../../syntax/core';
 
-import { Stack, Dict, Opaque, InternedString, dict } from 'glimmer-util';
+import { Stack, Dict, Opaque, dict } from 'glimmer-util';
 import { StatementCompilationBuffer } from '../../syntax';
 import { Opcode, OpSeq } from '../../opcodes';
 import { CompiledArgs } from '../expressions/args';
@@ -39,32 +39,32 @@ class StatementCompilationBufferProxy implements StatementCompilationBuffer {
     this.inner.append(opcode);
   }
 
-  getLocalSymbol(name: InternedString): number {
+  getLocalSymbol(name: string): number {
     return this.inner.getLocalSymbol(name);
   }
 
-  hasLocalSymbol(name: InternedString): boolean {
+  hasLocalSymbol(name: string): boolean {
     return this.inner.hasLocalSymbol(name);
   }
 
-  getNamedSymbol(name: InternedString): number {
+  getNamedSymbol(name: string): number {
     return this.inner.getNamedSymbol(name);
   }
 
-  hasNamedSymbol(name: InternedString): boolean {
+  hasNamedSymbol(name: string): boolean {
     return this.inner.hasNamedSymbol(name);
   }
 
-  getBlockSymbol(name: InternedString): number {
+  getBlockSymbol(name: string): number {
     return this.inner.getBlockSymbol(name);
   }
 
-  hasBlockSymbol(name: InternedString): boolean {
+  hasBlockSymbol(name: string): boolean {
     return this.inner.hasBlockSymbol(name);
   }
 
   // only used for {{view.name}}
-  hasKeyword(name: InternedString): boolean {
+  hasKeyword(name: string): boolean {
     return this.inner.hasKeyword(name);
   }
 }
@@ -126,7 +126,7 @@ export abstract class BasicOpcodeBuilder extends StatementCompilationBufferProxy
     this.append(new component.PutDynamicComponentDefinitionOpcode({ args: this.compile(args) }));
   }
 
-  openComponent(shadow: InternedString[] = EMPTY_ARRAY) {
+  openComponent(shadow: string[] = EMPTY_ARRAY) {
     this.append(new component.OpenComponentOpcode({ shadow, templates: this.templates }));
   }
 
@@ -154,11 +154,11 @@ export abstract class BasicOpcodeBuilder extends StatementCompilationBufferProxy
 
   // dom
 
-  text(text: InternedString) {
+  text(text: string) {
     this.append(new dom.TextOpcode({ text }));
   }
 
-  openPrimitiveElement(tag: InternedString) {
+  openPrimitiveElement(tag: string) {
     this.append(new dom.OpenPrimitiveElementOpcode({ tag }));
   }
 
@@ -182,7 +182,7 @@ export abstract class BasicOpcodeBuilder extends StatementCompilationBufferProxy
     this.append(new dom.DynamicAttrOpcode(options));
   }
 
-  comment(comment: InternedString) {
+  comment(comment: string) {
     this.append(new dom.CommentOpcode({ comment }));
   }
 

--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -5,7 +5,7 @@ import { VM, UpdatingVM } from '../../vm';
 import { CompiledArgs, EvaluatedArgs } from '../../compiled/expressions/args';
 import { Templates } from '../../syntax/core';
 import { DynamicScope } from '../../environment';
-import { InternedString, Opaque } from 'glimmer-util';
+import { Opaque } from 'glimmer-util';
 import { ReferenceCache, Revision, combine, isConst } from 'glimmer-reference';
 
 export class PutDynamicComponentDefinitionOpcode extends Opcode {
@@ -57,7 +57,7 @@ export class PutComponentDefinitionOpcode extends Opcode {
 }
 
 export interface OpenComponentOptions {
-  shadow: InternedString[];
+  shadow: string[];
   templates: Templates;
 }
 
@@ -65,7 +65,7 @@ export class OpenComponentOpcode extends Opcode {
   public type = "open-component";
   public definition: ComponentDefinition<Opaque>;
   public args: CompiledArgs;
-  public shadow: InternedString[];
+  public shadow: string[];
   public templates: Templates;
 
   constructor({ shadow, templates }: OpenComponentOptions) {
@@ -183,7 +183,7 @@ export class ShadowAttributesOpcode extends Opcode {
   evaluate(vm: VM) {
     let args = vm.frame.getArgs();
     let internal = args.internal;
-    let shadow: InternedString[] = internal['shadow'] as InternedString[];
+    let shadow: string[] = internal['shadow'] as string[];
 
     let named = args.named;
 

--- a/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
@@ -1,7 +1,7 @@
 import { Opcode, OpcodeJSON, UpdatingOpcode } from '../../opcodes';
 import { VM, UpdatingVM } from '../../vm';
 import { DynamicScope } from '../../environment';
-import { FIXME, InternedString, Opaque, Dict, dict } from 'glimmer-util';
+import { FIXME, Opaque, Dict, dict } from 'glimmer-util';
 import {
   CachedReference,
   Reference,
@@ -21,9 +21,9 @@ import { IChangeList } from '../../dom/change-lists';
 
 export class TextOpcode extends Opcode {
   public type = "text";
-  public text: InternedString;
+  public text: string;
 
-  constructor({ text }: { text: InternedString }) {
+  constructor({ text }: { text: string }) {
     super();
     this.text = text;
   }
@@ -43,9 +43,9 @@ export class TextOpcode extends Opcode {
 
 export class OpenPrimitiveElementOpcode extends Opcode {
   public type = "open-primitive-element";
-  public tag: InternedString;
+  public tag: string;
 
-  constructor({ tag }: { tag: InternedString }) {
+  constructor({ tag }: { tag: string }) {
     super();
     this.tag = tag;
   }
@@ -67,7 +67,7 @@ export class OpenDynamicPrimitiveElementOpcode extends Opcode {
   public type = "open-dynamic-primitive-element";
 
   evaluate(vm: VM) {
-    let tagName = vm.frame.getOperand().value() as FIXME<'user string to InternedString'>;
+    let tagName = vm.frame.getOperand().value();
     vm.stack().openElement(tagName);
   }
 
@@ -151,8 +151,8 @@ export class CloseElementOpcode extends Opcode {
     for (let i = 0; i < groups.length; i++) {
       for (let j = 0; j < groups[i].length; j++) {
         let op = groups[i][j];
-        let name = op['name'] as FIXME<string>;
-        let reference = op['reference'] as FIXME<Reference<string>>;
+        let name = op['name'];
+        let reference = op['reference'] as Reference<string>;
         if (name === 'class') {
           classList.append(reference);
         } else if (!flattened[name]) {
@@ -163,7 +163,7 @@ export class CloseElementOpcode extends Opcode {
     }
 
     let className = classList.toReference();
-    let attr = 'class' as InternedString;
+    let attr = 'class';
     let attributeManager = vm.env.attributeFor(element, attr, className, false);
     let attribute = new Attribute(element, attributeManager, attr, className);
     let opcode = attribute.flush(dom);
@@ -182,15 +182,15 @@ export class CloseElementOpcode extends Opcode {
 }
 
 export interface StaticAttrOptions {
-  namespace: InternedString;
-  name: InternedString;
-  value: InternedString;
+  namespace: string;
+  name: string;
+  value: string;
 }
 
 export class StaticAttrOpcode extends Opcode {
   public type = "static-attr";
-  public namespace: InternedString;
-  public name: InternedString;
+  public namespace: string;
+  public name: string;
   public value: ValueReference<string>;
 
   constructor({ namespace, name, value }: StaticAttrOptions) {
@@ -227,11 +227,11 @@ export class StaticAttrOpcode extends Opcode {
 
 export class ModifierOpcode extends Opcode {
   public type = "modifier";
-  public name: InternedString;
+  public name: string;
   public args: CompiledArgs;
   private manager: ModifierManager<Opaque>;
 
-  constructor({ name, manager, args }: { name: InternedString, manager: ModifierManager<Opaque>, args: CompiledArgs }) {
+  constructor({ name, manager, args }: { name: string, manager: ModifierManager<Opaque>, args: CompiledArgs }) {
     super();
     this.name = name;
     this.manager = manager;
@@ -320,11 +320,11 @@ export class Attribute {
   private cache: ReferenceCache<Opaque>;
   private namespace: string | undefined;
 
-  protected name: InternedString;
+  protected name: string;
 
   public tag: RevisionTag;
 
-  constructor(element: Element, changeList: IChangeList, name: InternedString, reference: Reference<Opaque>, namespace?: string) {
+  constructor(element: Element, changeList: IChangeList, name: string, reference: Reference<Opaque>, namespace?: string) {
     this.element = element;
     this.reference = reference;
     this.changeList = changeList;
@@ -389,15 +389,15 @@ function formatElement(element: Element): string {
 }
 
 export interface DynamicAttrNSOptions {
-  name: InternedString;
-  namespace: InternedString;
+  name: string;
+  namespace: string;
   isTrusting: boolean;
 }
 
 export class DynamicAttrNSOpcode extends Opcode {
   public type = "dynamic-attr";
-  public name: InternedString;
-  public namespace: InternedString;
+  public name: string;
+  public namespace: string;
   public isTrusting: boolean;
 
   constructor({ name, namespace, isTrusting }: DynamicAttrNSOptions) {
@@ -430,13 +430,13 @@ export class DynamicAttrNSOpcode extends Opcode {
 }
 
 export interface SimpleAttrOptions {
-  name: InternedString;
+  name: string;
   isTrusting: boolean;
 }
 
 export class DynamicAttrOpcode extends Opcode {
   public type = "dynamic-attr";
-  public name: InternedString;
+  public name: string;
   public isTrusting: boolean;
 
   constructor({ name, isTrusting }: SimpleAttrOptions) {
@@ -490,12 +490,12 @@ export class PatchElementOpcode extends UpdatingOpcode {
 }
 
 export interface CommentOptions {
-  comment: InternedString;
+  comment: string;
 }
 
 export class CommentOpcode extends Opcode {
   public type = "comment";
-  public comment: InternedString;
+  public comment: string;
 
   constructor({ comment }: CommentOptions) {
     super();

--- a/packages/glimmer-runtime/lib/compiled/opcodes/lists.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/lists.ts
@@ -2,7 +2,7 @@ import { Opcode, OpcodeJSON } from '../../opcodes';
 import { VM } from '../../vm';
 import { LabelOpcode } from '../../compiled/opcodes/vm';
 import { EvaluatedArgs } from '../expressions/args';
-import { FIXME, ListSlice, Slice } from 'glimmer-util';
+import { ListSlice, Slice } from 'glimmer-util';
 import { RevisionTag, Reference, ConstReference, ReferenceIterator, IterationArtifacts } from 'glimmer-reference';
 
 class IterablePresenceReference implements Reference<boolean> {
@@ -121,7 +121,7 @@ export class NextIterOpcode extends Opcode {
 
     if (item) {
       vm.frame.setCondition(TRUE_REF);
-      vm.frame.setKey(item.key as FIXME<'user str to InternedString'>);
+      vm.frame.setKey(item.key);
       vm.frame.setOperand(item.value);
       vm.frame.setArgs(EvaluatedArgs.positional([item.value, item.memo]));
     } else {

--- a/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -8,7 +8,7 @@ import { NULL_REFERENCE } from '../../references';
 import SymbolTable from '../../symbol-table';
 import { Reference, PathReference, ConstReference } from 'glimmer-reference';
 import { ValueReference } from '../expressions/value';
-import { ListSlice, Opaque, Slice, Dict, dict, assign, InternedString } from 'glimmer-util';
+import { ListSlice, Opaque, Slice, Dict, dict, assign } from 'glimmer-util';
 import { CONSTANT_TAG, ReferenceCache, Revision, RevisionTag, isConst, isModified } from 'glimmer-reference';
 import Scanner from '../../scanner';
 import Environment from '../../environment';
@@ -356,7 +356,7 @@ export class EvaluatePartialOpcode extends Opcode {
   evaluate(vm: VM) {
     let reference: PathReference<any> = this.name.evaluate(vm);
     let referenceCache = new ReferenceCache(reference);
-    let name: InternedString = referenceCache.revalidate();
+    let name: string = referenceCache.revalidate();
 
     let block = this.cache[name];
     if (!block) {
@@ -387,7 +387,7 @@ export class NameToPartialOpcode extends Opcode {
   evaluate(vm: VM) {
     let reference = vm.frame.getOperand();
     let referenceCache = new ReferenceCache(reference);
-    let name: InternedString = referenceCache.revalidate();
+    let name: string = referenceCache.revalidate();
     let partial = name && vm.env.hasPartial([name]) ? vm.env.lookupPartial([name]) : false;
     vm.frame.setOperand(new ValueReference(partial));
 

--- a/packages/glimmer-runtime/lib/compiler.ts
+++ b/packages/glimmer-runtime/lib/compiler.ts
@@ -1,4 +1,4 @@
-import { FIXME, Opaque, Slice, LinkedList, InternedString } from 'glimmer-util';
+import { Opaque, Slice, LinkedList } from 'glimmer-util';
 import { OpSeq, Opcode } from './opcodes';
 
 import * as Syntax from './syntax/core';
@@ -83,15 +83,15 @@ export class EntryPointCompiler extends Compiler {
     this.ops.append(op);
   }
 
-  getLocalSymbol(name: InternedString): number {
+  getLocalSymbol(name: string): number {
     return this.symbolTable.getLocal(name);
   }
 
-  getNamedSymbol(name: InternedString): number {
+  getNamedSymbol(name: string): number {
     return this.symbolTable.getNamed(name);
   }
 
-  getYieldSymbol(name: InternedString): number {
+  getYieldSymbol(name: string): number {
     return this.symbolTable.getYield(name);
   }
 }
@@ -128,13 +128,13 @@ export class InlineBlockCompiler extends Compiler {
 }
 
 export interface ComponentParts {
-  tag: InternedString;
+  tag: string;
   attrs: Slice<AttributeSyntax<Opaque>>;
   body: Slice<StatementSyntax>;
 }
 
 export interface CompiledComponentParts {
-  tag: InternedString;
+  tag: string;
   preamble: CompileIntoList;
   main: CompileIntoList;
 }
@@ -351,10 +351,10 @@ function isOpenElement(syntax: StatementSyntax): syntax is OpenElement {
 class ComponentTagBuilder implements Component.ComponentTagBuilder {
   public isDynamic = null;
   public isStatic = null;
-  public staticTagName: InternedString = null;
+  public staticTagName: string = null;
   public dynamicTagName: Expression<string> = null;
 
-  static(tagName: InternedString) {
+  static(tagName: string) {
     this.isStatic = true;
     this.staticTagName = tagName;
   }
@@ -369,11 +369,11 @@ class ComponentAttrsBuilder implements Component.ComponentAttrsBuilder {
   private buffer: AttributeSyntax<string>[] = [];
 
   static(name: string, value: string) {
-    this.buffer.push(new Syntax.StaticAttr({ name: name as FIXME<'intern'>, value: value as FIXME<'intern'> }));
+    this.buffer.push(new Syntax.StaticAttr({ name, value }));
   }
 
   dynamic(name: string, value: FunctionExpression<string>) {
-    this.buffer.push(new Syntax.DynamicAttr({ name: name as FIXME<'intern'>, value: makeFunctionExpression(value), isTrusting: false }));
+    this.buffer.push(new Syntax.DynamicAttr({ name, value: makeFunctionExpression(value), isTrusting: false }));
   }
 }
 
@@ -424,31 +424,31 @@ export class CompileIntoList extends LinkedList<Opcode> implements OpcodeBuilder
     this.component = new ComponentBuilder(dsl);
   }
 
-  getLocalSymbol(name: InternedString): number {
+  getLocalSymbol(name: string): number {
     return this.block.symbolTable.getLocal(name);
   }
 
-  hasLocalSymbol(name: InternedString): boolean {
+  hasLocalSymbol(name: string): boolean {
     return typeof this.block.symbolTable.getLocal(name) === 'number';
   }
 
-  getNamedSymbol(name: InternedString): number {
+  getNamedSymbol(name: string): number {
     return this.block.symbolTable.getNamed(name);
   }
 
-  hasNamedSymbol(name: InternedString): boolean {
+  hasNamedSymbol(name: string): boolean {
     return typeof this.block.symbolTable.getNamed(name) === 'number';
   }
 
-  getBlockSymbol(name: InternedString): number {
+  getBlockSymbol(name: string): number {
     return this.block.symbolTable.getYield(name);
   }
 
-  hasBlockSymbol(name: InternedString): boolean {
+  hasBlockSymbol(name: string): boolean {
     return typeof this.block.symbolTable.getYield(name) === 'number';
   }
 
-  hasKeyword(name: InternedString): boolean {
+  hasKeyword(name: string): boolean {
     return this.env.hasKeyword(name);
   }
 

--- a/packages/glimmer-runtime/lib/dom/sanitized-values.ts
+++ b/packages/glimmer-runtime/lib/dom/sanitized-values.ts
@@ -1,4 +1,5 @@
-import { FIXME, Opaque } from 'glimmer-util';
+import { Opaque } from 'glimmer-util';
+import { normalizeTextValue } from '../compiled/opcodes/content';
 import { isSafeString } from '../upsert';
 import { DOMHelper } from './helper';
 
@@ -48,7 +49,7 @@ export function requiresSanitization(tagName: string, attribute: string): boolea
   return checkURI(tagName, attribute) || checkDataURI(tagName, attribute);
 }
 
-export function sanitizeAttributeValue(dom: DOMHelper, element: Element, attribute: string, value: Opaque): Opaque {
+export function sanitizeAttributeValue(dom: DOMHelper, element: Element, attribute: string, value: Opaque): string {
   let tagName;
 
   if (isSafeString(value)) {
@@ -61,16 +62,18 @@ export function sanitizeAttributeValue(dom: DOMHelper, element: Element, attribu
     tagName = element.tagName.toUpperCase();
   }
 
+  let str = normalizeTextValue(value);
+
   if (checkURI(tagName, attribute)) {
-    let protocol = dom.protocolForURL(value as FIXME<string>);
+    let protocol = dom.protocolForURL(str);
     if (has(badProtocols, protocol)) {
-      return `unsafe:${value}`;
+      return `unsafe:${str}`;
     }
   }
 
   if (checkDataURI(tagName, attribute)) {
-    return `unsafe:${value}`;
+    return `unsafe:${str}`;
   }
 
-  return value;
+  return str;
 }

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -31,8 +31,6 @@ import {
   Dict,
   Opaque,
   HasGuid,
-  InternedString,
-  intern,
   ensureGuid
 } from 'glimmer-util';
 
@@ -137,8 +135,8 @@ export abstract class Environment {
 
   getDOM(): DOMHelper { return this.dom; }
 
-  getIdentity(object: HasGuid): InternedString {
-    return intern(ensureGuid(object) + '');
+  getIdentity(object: HasGuid): string {
+    return ensureGuid(object) + '';
   }
 
   statement(statement: StatementSyntax, blockMeta: BlockMeta): StatementSyntax {
@@ -215,24 +213,24 @@ export abstract class Environment {
     }
   }
 
-  hasKeyword(string: InternedString): boolean {
+  hasKeyword(string: string): boolean {
     return false;
   }
 
-  abstract hasHelper(helperName: InternedString[], blockMeta: BlockMeta): boolean;
-  abstract lookupHelper(helperName: InternedString[], blockMeta: BlockMeta): Helper;
+  abstract hasHelper(helperName: string[], blockMeta: BlockMeta): boolean;
+  abstract lookupHelper(helperName: string[], blockMeta: BlockMeta): Helper;
 
-  attributeFor(element: Element, attr: InternedString, reference: Reference<Opaque>, isTrusting: boolean, namespace?: InternedString): IChangeList {
+  attributeFor(element: Element, attr: string, reference: Reference<Opaque>, isTrusting: boolean, namespace?: string): IChangeList {
     return defaultChangeLists(element, attr, isTrusting, namespace);
   }
 
-  abstract hasPartial(partialName: InternedString[]): boolean;
-  abstract lookupPartial(PartialName: InternedString[]): PartialDefinition;
-  abstract hasComponentDefinition(tagName: InternedString[]): boolean;
-  abstract getComponentDefinition(tagName: InternedString[]): ComponentDefinition<Opaque>;
+  abstract hasPartial(partialName: string[]): boolean;
+  abstract lookupPartial(PartialName: string[]): PartialDefinition;
+  abstract hasComponentDefinition(tagName: string[]): boolean;
+  abstract getComponentDefinition(tagName: string[]): ComponentDefinition<Opaque>;
 
-  abstract hasModifier(modifierName: InternedString[]): boolean;
-  abstract lookupModifier(modifierName: InternedString[]): ModifierManager<Opaque>;
+  abstract hasModifier(modifierName: string[]): boolean;
+  abstract lookupModifier(modifierName: string[]): ModifierManager<Opaque>;
 }
 
 export default Environment;
@@ -246,8 +244,8 @@ export interface Helper {
 
 export interface ParsedStatement {
   isSimple: boolean;
-  path: InternedString[];
-  key: InternedString;
+  path: string[];
+  key: string;
   appendType: string;
   args: Syntax.Args;
   isInline: boolean;
@@ -266,7 +264,7 @@ function parseStatement(statement: StatementSyntax): ParsedStatement {
 
     type AppendValue = Syntax.Unknown | Syntax.Get;
     let args: Syntax.Args;
-    let path: InternedString[];
+    let path: string[];
 
     if (block) {
       args = block.args;
@@ -284,7 +282,7 @@ function parseStatement(statement: StatementSyntax): ParsedStatement {
       args = modifier.args;
     }
 
-    let key: InternedString, isSimple: boolean;
+    let key: string, isSimple: boolean;
 
     if (path) {
       isSimple = path.length === 1;

--- a/packages/glimmer-runtime/lib/opcode-builder.ts
+++ b/packages/glimmer-runtime/lib/opcode-builder.ts
@@ -12,14 +12,13 @@ import {
 } from './syntax/core';
 
 import {
-  Opaque,
-  InternedString
+  Opaque
 } from 'glimmer-util';
 
 export interface StaticComponentOptions {
   definition: ComponentDefinition<Opaque>;
   args: Args;
-  shadow: InternedString[];
+  shadow: string[];
   templates: Templates;
 }
 
@@ -27,7 +26,7 @@ export interface DynamicComponentOptions {
   definitionArgs: Args;
   definition: FunctionExpression<ComponentDefinition<Opaque>>;
   args: Args;
-  shadow: InternedString[];
+  shadow: string[];
   templates: Templates;
 }
 

--- a/packages/glimmer-runtime/lib/symbol-table.ts
+++ b/packages/glimmer-runtime/lib/symbol-table.ts
@@ -1,4 +1,4 @@
-import { InternedString, dict } from 'glimmer-util';
+import { dict } from 'glimmer-util';
 import { Block, InlineBlock, Layout, EntryPoint } from './compiled/blocks';
 
 export default class SymbolTable {
@@ -32,33 +32,33 @@ export default class SymbolTable {
     return this;
   }
 
-  initBlock({ locals }: { locals: InternedString[] }): this {
+  initBlock({ locals }: { locals: string[] }): this {
     this.initPositionals(locals);
     return this;
   }
 
-  initLayout({ named, yields }: { named: InternedString[], yields: InternedString[] }): this {
+  initLayout({ named, yields }: { named: string[], yields: string[] }): this {
     this.initNamed(named);
     this.initYields(yields);
     return this;
   }
 
-  initPositionals(positionals: InternedString[]): this {
+  initPositionals(positionals: string[]): this {
     if (positionals) positionals.forEach(s => this.locals[<string>s] = this.top.size++);
     return this;
   }
 
-  initNamed(named: InternedString[]): this {
+  initNamed(named: string[]): this {
     if (named) named.forEach(s => this.named[<string>s] = this.top.size++);
     return this;
   }
 
-  initYields(yields: InternedString[]): this {
+  initYields(yields: string[]): this {
     if (yields) yields.forEach(b => this.yields[<string>b] = this.top.size++);
     return this;
   }
 
-  getYield(name: InternedString): number {
+  getYield(name: string): number {
     let { yields, parent } = this;
 
     let symbol = yields[<string>name];
@@ -70,7 +70,7 @@ export default class SymbolTable {
     return symbol;
   }
 
-  getNamed(name: InternedString): number {
+  getNamed(name: string): number {
     let { named, parent } = this;
 
     let symbol = named[<string>name];
@@ -82,7 +82,7 @@ export default class SymbolTable {
     return symbol;
   }
 
-  getLocal(name: InternedString): number {
+  getLocal(name: string): number {
     let { locals, parent } = this;
 
     let symbol = locals[<string>name];

--- a/packages/glimmer-runtime/lib/syntax.ts
+++ b/packages/glimmer-runtime/lib/syntax.ts
@@ -1,4 +1,4 @@
-import { LinkedListNode, Slice, InternedString } from 'glimmer-util';
+import { LinkedListNode, Slice } from 'glimmer-util';
 import { BlockScanner } from './scanner';
 import { Environment } from './environment';
 import { CompiledExpression } from './compiled/expressions';
@@ -54,15 +54,15 @@ export abstract class Expression<T> {
 }
 
 export interface SymbolLookup {
-  getLocalSymbol(name: InternedString): number;
-  hasLocalSymbol(name: InternedString): boolean;
-  getNamedSymbol(name: InternedString): number;
-  hasNamedSymbol(name: InternedString): boolean;
-  getBlockSymbol(name: InternedString): number;
-  hasBlockSymbol(name: InternedString): boolean;
+  getLocalSymbol(name: string): number;
+  hasLocalSymbol(name: string): boolean;
+  getNamedSymbol(name: string): number;
+  hasNamedSymbol(name: string): boolean;
+  getBlockSymbol(name: string): number;
+  hasBlockSymbol(name: string): boolean;
 
   // only used for {{view.name}}
-  hasKeyword(name: InternedString): boolean;
+  hasKeyword(name: string): boolean;
 }
 
 export interface CompileInto {
@@ -82,15 +82,15 @@ export type Parameter<T> = Attribute<T> | Argument<T>;
 
 export abstract class Attribute<T> extends Statement {
   "e1185d30-7cac-4b12-b26a-35327d905d92" = true;
-  name: InternedString;
-  namespace: InternedString;
+  name: string;
+  namespace: string;
   abstract valueSyntax(): Expression<T>;
 }
 
 export abstract class Argument<T> extends Statement {
   "0f3802314-d747-bbc5-0168-97875185c3rt" = true;
-  name: InternedString;
-  namespace: InternedString;
+  name: string;
+  namespace: string;
   abstract valueSyntax(): Expression<T>;
 }
 

--- a/packages/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/glimmer-runtime/lib/syntax/core.ts
@@ -73,10 +73,8 @@ import { Environment } from '../environment';
 
 import {
   Opaque,
-  InternedString,
   Dict,
-  dict,
-  intern,
+  dict
 } from 'glimmer-util';
 
 import {
@@ -112,8 +110,8 @@ export class Block extends StatementSyntax {
     let [, path, params, hash, templateId, inverseId] = sexp;
 
     return new Block({
-      path: path as InternedString[],
-      args: Args.fromSpec(params as InternedString[], hash),
+      path,
+      args: Args.fromSpec(params, hash),
       templates: Templates.fromSpec([templateId, inverseId], children)
     });
   }
@@ -122,11 +120,11 @@ export class Block extends StatementSyntax {
     return new this(options);
   }
 
-  path: InternedString[];
+  path: string[];
   args: Args;
   templates: Templates;
 
-  constructor(options: { path: InternedString[], args: Args, templates: Templates }) {
+  constructor(options: { path: string[], args: Args, templates: Templates }) {
     super();
     this.path = options.path;
     this.args = options.args;
@@ -153,7 +151,7 @@ export class Unknown extends ExpressionSyntax<any> {
   static fromSpec(sexp: SerializedExpressions.Unknown): Unknown {
     let [, path] = sexp;
 
-    return new Unknown({ ref: new Ref({ parts: path as InternedString[] }) });
+    return new Unknown({ ref: new Ref({ parts: path }) });
   }
 
   static build(path: string, unsafe: boolean): Unknown {
@@ -179,7 +177,7 @@ export class Unknown extends ExpressionSyntax<any> {
     }
   }
 
-  simplePath(): InternedString {
+  simplePath(): string {
     return this.ref.simplePath();
   }
 }
@@ -242,7 +240,7 @@ export class Modifier extends StatementSyntax {
   "c0420397-8ff1-4241-882b-4b7a107c9632" = true;
 
   public type: string = "modifier";
-  public path: InternedString[];
+  public path: string[];
   public args: Args;
 
   static fromSpec(node) {
@@ -285,17 +283,16 @@ export class Modifier extends StatementSyntax {
 
 export class StaticArg extends ArgumentSyntax<string> {
   public type = "static-arg";
-  name: InternedString;
-  value: InternedString;
+  name: string;
+  value: string;
 
   static fromSpec(node: SerializedStatements.StaticArg): StaticArg {
     let [, name, value] = node;
-
-    return new StaticArg({ name: name as InternedString, value: value as InternedString });
+    return new StaticArg({ name, value });
   }
 
   static build(name: string, value: string, namespace: string=null): StaticArg {
-    return new this({ name: intern(name), value: intern(value) });
+    return new this({ name, value });
   }
 
   constructor({ name, value }) {
@@ -309,7 +306,7 @@ export class StaticArg extends ArgumentSyntax<string> {
   }
 
   valueSyntax(): ExpressionSyntax<string> {
-    return Value.build(this.value as string);
+    return Value.build(this.value);
   }
 }
 
@@ -319,21 +316,20 @@ export class DynamicArg extends ArgumentSyntax<Opaque> {
     let [, name, value] = sexp;
 
     return new DynamicArg({
-      name: name as InternedString,
+      name,
       value: buildExpression(value)
     });
   }
 
-  static build(_name: string, value: ExpressionSyntax<string>): DynamicArg {
-    let name = intern(_name);
+  static build(name: string, value: ExpressionSyntax<string>): DynamicArg {
     return new this({ name, value });
   }
 
-  name: InternedString;
+  name: string;
   value: ExpressionSyntax<Opaque>;
-  namespace: InternedString;
+  namespace: string;
 
-  constructor({ name, value, namespace = null }: { name: InternedString, value: ExpressionSyntax<Opaque>, namespace?: InternedString }) {
+  constructor({ name, value, namespace = null }: { name: string, value: ExpressionSyntax<Opaque>, namespace?: string }) {
     super();
     this.name = name;
     this.value = value;
@@ -353,16 +349,14 @@ export class TrustingAttr {
   static fromSpec(sexp: SerializedStatements.TrustingAttr): DynamicAttr {
     let [, name, value, namespace] = sexp;
     return new DynamicAttr({
-      name: name as InternedString,
-      namespace: namespace as InternedString,
+      name,
+      namespace,
       isTrusting: true,
       value: buildExpression(value)
     });
   }
 
-  static build(_name: string, value: ExpressionSyntax<string>, isTrusting: boolean, _namespace: string=null): DynamicAttr {
-    let name = intern(_name);
-    let namespace = _namespace ? intern(_namespace) : null;
+  static build(name: string, value: ExpressionSyntax<string>, isTrusting: boolean, namespace: string=null): DynamicAttr {
     return new DynamicAttr({ name, value, namespace, isTrusting });
   }
 
@@ -375,19 +369,19 @@ export class StaticAttr extends AttributeSyntax<string> {
 
   static fromSpec(node: SerializedStatements.StaticAttr): StaticAttr {
     let [, name, value, namespace] = node;
-    return new StaticAttr({ name: name as InternedString, value: value as InternedString, namespace: namespace as InternedString });
+    return new StaticAttr({ name, value: value as string, namespace });
   }
 
   static build(name: string, value: string, namespace: string=null): StaticAttr {
-    return new this({ name: intern(name), value: intern(value), namespace: namespace && intern(namespace) });
+    return new this({ name, value, namespace });
   }
 
-  name: InternedString;
-  value: InternedString;
-  namespace: InternedString;
+  name: string;
+  value: string;
+  namespace: string;
   isTrusting = false;
 
-  constructor({ name, value, namespace = null }: { name: InternedString, value: InternedString, namespace?: InternedString }) {
+  constructor({ name, value, namespace = null }: { name: string, value: string, namespace?: string }) {
     super();
     this.name = name;
     this.value = value;
@@ -399,7 +393,7 @@ export class StaticAttr extends AttributeSyntax<string> {
   }
 
   valueSyntax(): ExpressionSyntax<string> {
-    return Value.build(this.value as string);
+    return Value.build(this.value);
   }
 }
 
@@ -410,24 +404,22 @@ export class DynamicAttr extends AttributeSyntax<string> {
   static fromSpec(sexp: SerializedStatements.DynamicAttr): DynamicAttr {
     let [, name, value, namespace] = sexp;
     return new DynamicAttr({
-      name: name as InternedString,
-      namespace: namespace as InternedString,
+      name,
+      namespace,
       value: buildExpression(value)
     });
   }
 
-  static build(_name: string, value: ExpressionSyntax<string>, isTrusting = false, _namespace: string=null): DynamicAttr {
-    let name = intern(_name);
-    let namespace = _namespace ? intern(_namespace) : null;
+  static build(name: string, value: ExpressionSyntax<string>, isTrusting = false, namespace: string=null): DynamicAttr {
     return new this({ name, value, namespace, isTrusting });
   }
 
-  name: InternedString;
+  name: string;
   value: ExpressionSyntax<string>;
-  namespace: InternedString;
+  namespace: string;
   isTrusting: boolean;
 
-  constructor({ name, value, isTrusting = false, namespace = null }: { name: InternedString, isTrusting?: boolean, value: ExpressionSyntax<string>, namespace?: InternedString }) {
+  constructor({ name, value, isTrusting = false, namespace = null }: { name: string, isTrusting?: boolean, value: ExpressionSyntax<string>, namespace?: string }) {
     super();
     this.name = name;
     this.value = value;
@@ -471,17 +463,16 @@ export class Text extends StatementSyntax {
 
   static fromSpec(node: SerializedStatements.Text): Text {
     let [, content] = node;
-
-    return new Text({ content: content as InternedString });
+    return new Text({ content });
   }
 
   static build(content): Text {
     return new this({ content });
   }
 
-  public content: InternedString;
+  public content: string;
 
-  constructor(options: { content: InternedString }) {
+  constructor(options: { content: string }) {
     super();
     this.content = options.content;
   }
@@ -501,10 +492,10 @@ export class Comment extends StatementSyntax {
   }
 
   static build(value: string): Comment {
-    return new this({ value: intern(value) });
+    return new this({ value: value });
   }
 
-  public comment: InternedString;
+  public comment: string;
 
   constructor(options) {
     super();
@@ -523,19 +514,19 @@ export class OpenElement extends StatementSyntax {
     let [, tag, blockParams] = sexp;
 
     return new OpenElement({
-      tag: tag as InternedString,
-      blockParams: blockParams as InternedString[]
+      tag,
+      blockParams: blockParams
     });
   }
 
   static build(tag: string, blockParams: string[]): OpenElement {
-    return new this({ tag: intern(tag), blockParams: blockParams && blockParams.map(intern) });
+    return new this({ tag, blockParams });
   }
 
-  public tag: InternedString;
-  public blockParams: InternedString[];
+  public tag: string;
+  public blockParams: string[];
 
-  constructor(options: { tag: InternedString, blockParams: InternedString[] }) {
+  constructor(options: { tag: string, blockParams: string[] }) {
     super();
     this.tag = options.tag;
     this.blockParams = options.blockParams;
@@ -564,10 +555,10 @@ export class OpenElement extends StatementSyntax {
     return new OpenPrimitiveElement({ tag });
   }
 
-  private parameters(scanner: BlockScanner): { args: Args, attrs: InternedString[] } {
+  private parameters(scanner: BlockScanner): { args: Args, attrs: string[] } {
     let current = scanner.next();
     let args = dict<ExpressionSyntax<Opaque>>();
-    let attrs: InternedString[] = [];
+    let attrs: string[] = [];
 
     while (current[ATTRIBUTE_SYNTAX] || current[MODIFIER_SYNTAX] || current[ARGUMENT_SYNTAX]) {
       if (current[MODIFIER_SYNTAX]) {
@@ -609,16 +600,16 @@ export class OpenElement extends StatementSyntax {
 }
 
 interface ComponentOptions {
-  tag: InternedString;
-  attrs: InternedString[];
+  tag: string;
+  attrs: string[];
   args: Args;
   template: InlineBlock;
 }
 
 export class Component extends StatementSyntax {
   public type = 'component';
-  public tag: InternedString;
-  public attrs: InternedString[];
+  public tag: string;
+  public attrs: string[];
   public args: Args;
   public template: InlineBlock;
 
@@ -645,13 +636,13 @@ export class Component extends StatementSyntax {
 export class OpenPrimitiveElement extends StatementSyntax {
   type = "open-primitive-element";
 
-  public tag: InternedString;
+  public tag: string;
 
   static build(tag: string): OpenPrimitiveElement {
-    return new this({ tag: intern(tag) });
+    return new this({ tag });
   }
 
-  constructor(options: { tag: InternedString }) {
+  constructor(options: { tag: string }) {
     super();
     this.tag = options.tag;
   }
@@ -667,19 +658,19 @@ export class Yield extends StatementSyntax {
 
     let args = Args.fromSpec(params, null);
 
-    return new Yield({ to: to as InternedString, args });
+    return new Yield({ to, args });
   }
 
   static build(params: ExpressionSyntax<Opaque>[], to: string): Yield {
     let args = Args.fromPositionalArgs(PositionalArgs.build(params));
-    return new this({ to: intern(to), args });
+    return new this({ to, args });
   }
 
   type = "yield";
-  public to: InternedString;
+  public to: string;
   public args: Args;
 
-  constructor({ to, args }: { to: InternedString, args: Args }) {
+  constructor({ to, args }: { to: string, args: Args }) {
     super();
     this.to = to;
     this.args = args;
@@ -696,10 +687,10 @@ export class Yield extends StatementSyntax {
 class OpenBlockOpcode extends Opcode {
   type = "open-block";
   public to: number;
-  public label: InternedString;
+  public label: string;
   public args: CompiledArgs;
 
-  constructor({ to, label, args }: { to: number, label: InternedString, args: CompiledArgs }) {
+  constructor({ to, label, args }: { to: number, label: string, args: CompiledArgs }) {
     super();
     this.to = to;
     this.label = label;
@@ -763,8 +754,7 @@ export class Get extends ExpressionSyntax<Opaque> {
 
   static fromSpec(sexp: SerializedExpressions.Get): Get {
     let [, parts] = sexp;
-
-    return new Get({ ref: new Ref({ parts: parts as InternedString[] }) });
+    return new Get({ ref: new Ref({ parts }) });
   }
 
   static build(path: string): Get {
@@ -789,7 +779,7 @@ export class SelfGet extends ExpressionSyntax<Opaque> {
   static fromSpec(sexp: SerializedExpressions.SelfGet): SelfGet {
     let [, parts] = sexp;
 
-    return new SelfGet({ ref: new Ref({ parts: parts as InternedString[] }) });
+    return new SelfGet({ ref: new Ref({ parts }) });
   }
 
   public ref: Ref;
@@ -810,16 +800,16 @@ export class GetArgument<T> extends ExpressionSyntax<T> {
   static fromSpec(sexp: SerializedExpressions.Arg): GetArgument<Opaque> {
     let [, parts] = sexp;
 
-    return new GetArgument<Opaque>({ parts: parts as InternedString[] });
+    return new GetArgument<Opaque>({ parts });
   }
 
   static build(path: string): GetArgument<Opaque> {
-    return new this<Opaque>({ parts: path.split('.').map(intern) });
+    return new this<Opaque>({ parts: path.split('.') });
   }
 
-  public parts: InternedString[];
+  public parts: string[];
 
-  constructor(options: { parts: InternedString[] }) {
+  constructor(options: { parts: string[] }) {
     super();
     this.parts = options.parts;
   }
@@ -834,23 +824,18 @@ export class GetArgument<T> extends ExpressionSyntax<T> {
   }
 }
 
-// intern paths because they will be used as keys
-function internPath(path: string): InternedString[] {
-  return path.split('.').map(intern);
-}
-
 // this is separated out from Get because Unknown also has a ref, but it
 // may turn out to be a helper
 export class Ref extends ExpressionSyntax<Opaque> {
   type = "ref";
 
   static build(path: string): Ref {
-    return new this({ parts: internPath(path) });
+    return new this({ parts: path.split('.') });
   }
 
-  public parts: InternedString[];
+  public parts: string[];
 
-  constructor({ parts }: { parts: InternedString[] }) {
+  constructor({ parts }: { parts: string[] }) {
     super();
     this.parts = parts;
   }
@@ -870,11 +855,11 @@ export class Ref extends ExpressionSyntax<Opaque> {
     }
   }
 
-  path(): InternedString[] {
+  path(): string[] {
     return this.parts;
   }
 
-  simplePath(): InternedString {
+  simplePath(): string {
     if (this.parts.length === 1) {
       return this.parts[0];
     }
@@ -888,7 +873,7 @@ export class Helper extends ExpressionSyntax<Opaque> {
     let [, path, params, hash] = sexp;
 
     return new Helper({
-      ref: new Ref({ parts: path as InternedString[] }),
+      ref: new Ref({ parts: path }),
       args: Args.fromSpec(params, hash)
     });
   }
@@ -916,7 +901,7 @@ export class Helper extends ExpressionSyntax<Opaque> {
     }
   }
 
-  simplePath(): InternedString {
+  simplePath(): string {
     return this.ref.simplePath();
   }
 }
@@ -926,19 +911,16 @@ export class HasBlock extends ExpressionSyntax<boolean> {
 
   static fromSpec(sexp: SerializedExpressions.HasBlock): HasBlock {
     let [, blockName] = sexp;
-
-    return new HasBlock({
-      blockName: blockName as InternedString
-    });
+    return new HasBlock({ blockName });
   }
 
-  static build(blockName: InternedString): HasBlock {
+  static build(blockName: string): HasBlock {
     return new this({ blockName });
   }
 
-  blockName: InternedString;
+  blockName: string;
 
-  constructor({ blockName }: { blockName: InternedString }) {
+  constructor({ blockName }: { blockName: string }) {
     super();
     this.blockName = blockName;
   }
@@ -956,19 +938,16 @@ export class HasBlockParams extends ExpressionSyntax<boolean> {
 
   static fromSpec(sexp: SerializedExpressions.HasBlockParams): HasBlockParams {
     let [, blockName] = sexp;
-
-    return new HasBlockParams({
-      blockName: blockName as InternedString
-    });
+    return new HasBlockParams({ blockName });
   }
 
-  static build(blockName: InternedString): HasBlockParams {
+  static build(blockName: string): HasBlockParams {
     return new this({ blockName });
   }
 
-  blockName: InternedString;
+  blockName: string;
 
-  constructor({ blockName }: { blockName: InternedString }) {
+  constructor({ blockName }: { blockName: string }) {
     super();
     this.blockName = blockName;
   }
@@ -1091,12 +1070,12 @@ export class NamedArgs {
 
   static fromSpec(sexp: SerializedCore.Hash): NamedArgs {
     if (sexp === null || sexp === undefined) { return NamedArgs.empty(); }
-    let keys: InternedString[] = [];
+    let keys: string[] = [];
     let values = [];
     let map = dict<ExpressionSyntax<Opaque>>();
 
     Object.keys(sexp).forEach(key => {
-      keys.push(key as InternedString);
+      keys.push(key);
       let value = map[key] = buildExpression(sexp[key]);
       values.push(value);
     });
@@ -1110,7 +1089,7 @@ export class NamedArgs {
 
     Object.keys(map).forEach(k => {
       let value = map[k];
-      keys.push(k as InternedString);
+      keys.push(k);
       values.push(value);
     });
 
@@ -1130,15 +1109,15 @@ export class NamedArgs {
     this.map = map;
   }
 
-  add(key: InternedString, value: ExpressionSyntax<Opaque>) {
+  add(key: string, value: ExpressionSyntax<Opaque>) {
     this.map[<string>key] = value;
   }
 
-  at(key: InternedString): ExpressionSyntax<Opaque> {
+  at(key: string): ExpressionSyntax<Opaque> {
     return this.map[<string>key];
   }
 
-  has(key: InternedString): boolean {
+  has(key: string): boolean {
     return !!this.map[<string>key];
   }
 

--- a/packages/glimmer-runtime/lib/utils.ts
+++ b/packages/glimmer-runtime/lib/utils.ts
@@ -1,14 +1,5 @@
-import { intern } from 'glimmer-util';
-
 export const EMPTY_ARRAY = [];
 export const EMPTY_OBJECT = {};
-
-const KEY = intern(`__glimmer${+ new Date()}`);
-
-export function symbol(debugName): string {
-  let num = Math.floor(Math.random() * (+new Date()));
-  return intern(`${debugName} [id=${KEY}${num}]`);
-}
 
 export function turbocharge(object: Object): Object {
   // function Constructor() {}

--- a/packages/glimmer-runtime/lib/vm/append.ts
+++ b/packages/glimmer-runtime/lib/vm/append.ts
@@ -1,6 +1,6 @@
 import { Scope, DynamicScope, Environment } from '../environment';
 import { ElementStack } from '../builder';
-import { Destroyable, Dict, Stack, LinkedList, ListSlice, LOGGER, InternedString, Opaque } from 'glimmer-util';
+import { Destroyable, Dict, Stack, LinkedList, ListSlice, LOGGER, Opaque } from 'glimmer-util';
 import { PathReference, ReferenceIterator, combineSlice } from 'glimmer-reference';
 import Template from '../template';
 import { Templates } from '../syntax/core';
@@ -34,13 +34,13 @@ interface Registers {
   args: EvaluatedArgs;
   condition: PathReference<boolean>;
   iterator: ReferenceIterator;
-  key: InternedString;
+  key: string;
   templates: Dict<Template>;
 }
 
 interface InvokeLayoutOptions {
   args: EvaluatedArgs;
-  shadow: InternedString[];
+  shadow: string[];
   layout: CompiledBlock;
   templates: Templates;
   callerScope: Scope;
@@ -137,7 +137,7 @@ export default class VM implements PublicVM {
     this.didEnter(tryOpcode, updating);
   }
 
-  enterWithKey(key: InternedString, ops: OpSeq) {
+  enterWithKey(key: string, ops: OpSeq) {
     let updating = new LinkedList<UpdatingOpcode>();
 
     this.stack().pushBlock();
@@ -344,7 +344,7 @@ export default class VM implements PublicVM {
     let scope = this.scope();
 
     for(let i=0; i < keys.length; i++) {
-      scope.bindSymbol(entries[keys[i]], named.get(<InternedString>keys[i]));
+      scope.bindSymbol(entries[keys[i]], named.get(<string>keys[i]));
     }
   }
 

--- a/packages/glimmer-runtime/lib/vm/frame.ts
+++ b/packages/glimmer-runtime/lib/vm/frame.ts
@@ -1,5 +1,4 @@
 import { Scope } from '../environment';
-import { InternedString } from 'glimmer-util';
 import { Reference, PathReference, ReferenceIterator } from 'glimmer-reference';
 import { InlineBlock } from '../compiled/blocks';
 import { EvaluatedArgs } from '../compiled/expressions/args';
@@ -15,7 +14,7 @@ class Frame {
   blocks: Blocks = null;
   condition: Reference<boolean> = null;
   iterator: ReferenceIterator = null;
-  key: InternedString = null;
+  key: string = null;
 
   constructor(ops: OpSeq) {
     this.ops = ops;
@@ -93,11 +92,11 @@ export class FrameStack {
     return this.frames[this.frame].iterator = iterator;
   }
 
-  getKey(): InternedString {
+  getKey(): string {
     return this.frames[this.frame].key;
   }
 
-  setKey(key: InternedString): InternedString {
+  setKey(key: string): string {
     return this.frames[this.frame].key = key;
   }
 

--- a/packages/glimmer-runtime/lib/vm/update.ts
+++ b/packages/glimmer-runtime/lib/vm/update.ts
@@ -1,7 +1,7 @@
 import { Scope, DynamicScope, Environment } from '../environment';
 import { Bounds, clear, move as moveBounds } from '../bounds';
 import { ElementStack, Tracker } from '../builder';
-import { LOGGER, Destroyable, Opaque, Stack, LinkedList, InternedString, Dict, dict } from 'glimmer-util';
+import { LOGGER, Destroyable, Opaque, Stack, LinkedList, Dict, dict } from 'glimmer-util';
 import {
   ConstReference,
   PathReference,
@@ -222,7 +222,7 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     this.marker = marker;
   }
 
-  insert(key: InternedString, item: PathReference<Opaque>, memo: PathReference<Opaque>, before: InternedString) {
+  insert(key: string, item: PathReference<Opaque>, memo: PathReference<Opaque>, before: string) {
     let { map, opcode, updating } = this;
     let nextSibling: Node = null;
     let reference = null;
@@ -259,10 +259,10 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     this.didInsert = true;
   }
 
-  retain(key: InternedString, item: PathReference<Opaque>, memo: PathReference<Opaque>) {
+  retain(key: string, item: PathReference<Opaque>, memo: PathReference<Opaque>) {
   }
 
-  move(key: InternedString, item: PathReference<Opaque>, memo: PathReference<Opaque>, before: InternedString) {
+  move(key: string, item: PathReference<Opaque>, memo: PathReference<Opaque>, before: string) {
     let { map, updating } = this;
 
     let entry = map[<string>key];
@@ -278,7 +278,7 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     updating.insertBefore(entry, reference);
   }
 
-  delete(key: InternedString) {
+  delete(key: string) {
     let { map } = this;
     let opcode = map[<string>key];
     clear(opcode);

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -228,7 +228,7 @@ function testComponent(title: string, { kind, layout, invokeAs = {}, expected, s
     test(`curly: ${title}`, assert => {
       if (typeof layout !== 'string') throw new Error('Only string layouts are supported for curly tests');
 
-      env.registerEmberishCurlyComponent('test-component', EmberishCurlyComponent, layout as string);
+      env.registerEmberishCurlyComponent('test-component', EmberishCurlyComponent, layout);
       let list = ['test-component'];
 
       Object.keys(attributes).forEach(key => {
@@ -332,7 +332,7 @@ function testComponent(title: string, { kind, layout, invokeAs = {}, expected, s
       let layoutOptions: TagOptions;
 
       if (typeof layout === 'string') {
-        layoutOptions = { attributes: {}, args: {}, template: layout as string };
+        layoutOptions = { attributes: {}, args: {}, template: layout };
       } else {
         layoutOptions = layout;
       }

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -59,11 +59,9 @@ import {
 } from "./helpers";
 
 import {
-  FIXME,
   Destroyable,
   Opaque,
   Dict,
-  InternedString,
   assign,
   dict
 } from 'glimmer-util';
@@ -500,7 +498,7 @@ class EmberishCurlyComponentManager implements ComponentManager<EmberishCurlyCom
 
     if (bindings) {
       for (let i=0; i<bindings.length; i++) {
-        let attribute = bindings[i] as InternedString;
+        let attribute = bindings[i];
         let reference = rootRef.get(attribute) as PathReference<string>;
 
         operations.addAttribute(attribute, reference, false);
@@ -557,10 +555,10 @@ class EmberishConditionalReference extends ConditionalReference {
 
 export class SimplePathReference<T> implements PathReference<T> {
   private parent: Reference<T>;
-  private property: InternedString;
+  private property: string;
   public tag = VOLATILE_TAG;
 
-  constructor(parent: Reference<T>, property: InternedString) {
+  constructor(parent: Reference<T>, property: string) {
     this.parent = parent;
     this.property = property;
   }
@@ -569,7 +567,7 @@ export class SimplePathReference<T> implements PathReference<T> {
     return this.parent.value()[<string>this.property];
   }
 
-  get(prop: InternedString): PathReference<Opaque> {
+  get(prop: string): PathReference<Opaque> {
     return new SimplePathReference(this, prop);
   }
 }
@@ -592,7 +590,7 @@ class HelperReference implements PathReference<Opaque> {
     return helper(positional.value(), named.value());
   }
 
-  get(prop: InternedString): SimplePathReference<Opaque> {
+  get(prop: string): SimplePathReference<Opaque> {
     return new SimplePathReference(this, prop);
   }
 }
@@ -779,7 +777,7 @@ export class TestEnvironment extends Environment {
     return super.refineStatement(statement, parentMeta);
   }
 
-  hasHelper(helperName: InternedString[]) {
+  hasHelper(helperName: string[]) {
     return helperName.length === 1 && (<string>helperName[0] in this.helpers);
   }
 
@@ -793,7 +791,7 @@ export class TestEnvironment extends Environment {
     return helper;
   }
 
-  hasPartial(partialName: InternedString[]) {
+  hasPartial(partialName: string[]) {
     return partialName.length === 1 && (<string>partialName[0] in this.partials);
   }
 
@@ -807,19 +805,19 @@ export class TestEnvironment extends Environment {
     return partial;
   }
 
-  hasComponentDefinition(name: InternedString[]): boolean {
+  hasComponentDefinition(name: string[]): boolean {
     return !!this.components[<string>name[0]];
   }
 
-  getComponentDefinition(name: InternedString[]): ComponentDefinition<any> {
+  getComponentDefinition(name: string[]): ComponentDefinition<any> {
     return this.components[<string>name[0]];
   }
 
-  hasModifier(modifierName: InternedString[]): boolean {
+  hasModifier(modifierName: string[]): boolean {
     return modifierName.length === 1 && (<string>modifierName[0] in this.modifiers);
   }
 
-  lookupModifier(modifierName: InternedString[]): ModifierManager<Opaque> {
+  lookupModifier(modifierName: string[]): ModifierManager<Opaque> {
     let [name] = modifierName;
 
     let modifier = this.modifiers[name];
@@ -841,7 +839,7 @@ export class TestEnvironment extends Environment {
   }
 
   iterableFor(ref: Reference<Opaque>, args: EvaluatedArgs): OpaqueIterable {
-    let keyPath = args.named.get("key" as InternedString).value();
+    let keyPath = args.named.get("key").value();
     let keyFor: KeyFor<Opaque>;
 
     if (!keyPath) {
@@ -884,7 +882,7 @@ class CurlyComponentSyntax extends StatementSyntax implements StaticComponentOpt
   public type = "curly-component";
   public definition: ComponentDefinition<any>;
   public args: ArgsSyntax;
-  public shadow: InternedString[] = null;
+  public shadow: string[] = null;
   public templates: Templates;
 
   constructor({ args, definition, templates }: { args: ArgsSyntax, definition: ComponentDefinition<any>, templates: Templates }) {
@@ -916,7 +914,7 @@ class DynamicComponentReference implements PathReference<ComponentDefinition<Opa
     let name = nameRef.value();
 
     if (typeof name === 'string') {
-      return env.getComponentDefinition([name as FIXME<'user str InternedString'> as InternedString]);
+      return env.getComponentDefinition([name]);
     } else {
       return null;
     }
@@ -939,7 +937,7 @@ class DynamicComponentSyntax extends StatementSyntax implements DynamicComponent
   public definitionArgs: ArgsSyntax;
   public definition: FunctionExpression<ComponentDefinition<Opaque>>;
   public args: ArgsSyntax;
-  public shadow: InternedString[] = null;
+  public shadow: string[] = null;
   public templates: Templates;
 
   constructor({ args, templates }: { args: ArgsSyntax, templates: Templates }) {

--- a/packages/glimmer-util/index.ts
+++ b/packages/glimmer-util/index.ts
@@ -5,7 +5,7 @@ export interface Destroyable {
 }
 
 export { getAttrNamespace } from './lib/namespaces';
-export { LITERAL, InternedString, Opaque, opaque, symbol, intern, numberKey } from './lib/platform-utils';
+export { Opaque, opaque } from './lib/platform-utils';
 export { default as assert } from './lib/assert';
 export { forEach, map, isArray, indexOfArray } from './lib/array-utils';
 export { default as voidMap } from './lib/void-tag-names';

--- a/packages/glimmer-util/lib/collections.ts
+++ b/packages/glimmer-util/lib/collections.ts
@@ -1,5 +1,4 @@
 import { HasGuid, ensureGuid } from './guid';
-import { InternedString } from './platform-utils';
 
 export interface Dict<T> {
   [index: string]: T;
@@ -36,7 +35,7 @@ export function dict<T>(): Dict<T> {
   return new EmptyObject();
 }
 
-export type SetMember = HasGuid | InternedString | string;
+export type SetMember = HasGuid | string;
 
 export class DictSet<T extends SetMember> implements Set<T> {
   private dict: Dict<T>;
@@ -61,8 +60,8 @@ export class DictSet<T extends SetMember> implements Set<T> {
     Object.keys(dict).forEach(key => callback(dict[key]));
   }
 
-  toArray(): InternedString[] {
-    return Object.keys(this.dict) as InternedString[];
+  toArray(): string[] {
+    return Object.keys(this.dict);
   }
 }
 

--- a/packages/glimmer-util/lib/platform-utils.ts
+++ b/packages/glimmer-util/lib/platform-utils.ts
@@ -1,33 +1,5 @@
-interface InternedStringMarker {
-  "d0850007-25c2-47d8-bb63-c4054016d539": boolean;
-}
-
-export type InternedString = InternedStringMarker & string;
-
-export function intern(str: string): InternedString {
-  return <InternedString>str;
-  // let obj = {};
-  // obj[str] = 1;
-  // for (let key in obj) return <InternedString>key;
-}
-
 export type Opaque = {} | void;
 
 export function opaque(value: Opaque): Opaque {
   return value;
-}
-
-export function numberKey(num: number): InternedString {
-  return <InternedString>String(num);
-}
-
-export function LITERAL(str: string): InternedString {
-  return <InternedString>str;
-}
-
-let BASE_KEY = intern(`__glimmer{+ new Date()}`);
-
-export function symbol(debugName): InternedString {
-  let number = +(new Date());
-  return intern(debugName + ' [id=' + BASE_KEY + Math.floor(Math.random() * number) + ']');
 }

--- a/packages/glimmer-wire-format/index.ts
+++ b/packages/glimmer-wire-format/index.ts
@@ -1,4 +1,4 @@
-import { Dict, InternedString } from 'glimmer-util';
+import { Dict } from 'glimmer-util';
 
 type JsonValue =
     string
@@ -146,14 +146,14 @@ export interface BlockMeta {
 
 export interface SerializedTemplate {
   statements: Statements.Statement[];
-  locals: InternedString[];
-  named: InternedString[];
-  yields: InternedString[];
+  locals: string[];
+  named: string[];
+  yields: string[];
   blocks: SerializedBlock[];
   meta: BlockMeta;
 }
 
 export interface SerializedBlock {
   statements: Statements.Statement[];
-  locals: InternedString[];
+  locals: string[];
 }


### PR DESCRIPTION
The intent of this distinction was to differentiate between possible
ropes and strings, and make sure we convert ropes into strings for hot
paths. However, since JavaScript does not provide an official mechanism
for that conversion, and the Known Trick™ for doing that is too slow,
the experiment didn’t really work out. (We commented out the body of
`intern` for a while.)

Recent versions of TypeScript broke the branding trick on strings, so we
decided it’s time to remove this.