### PR TITLE
Remove more now-useless typecasts

### DIFF
--- a/packages/glimmer-object-reference/lib/meta.ts
+++ b/packages/glimmer-object-reference/lib/meta.ts
@@ -30,11 +30,11 @@ class ConstPath implements IPathReference<any> {
   notify() {}
 
   value() {
-    return this.parent[<string>this.property];
+    return this.parent[this.property];
   }
 
   get(prop: string): IPathReference<any> {
-    return new ConstPath(this.parent[<string>this.property], prop);
+    return new ConstPath(this.parent[this.property], prop);
   }
 }
 
@@ -94,11 +94,11 @@ class Meta implements IMeta, HasGuid {
 
     let MetaToUse: typeof Meta = Meta;
 
-    if (obj.constructor && obj.constructor[<string>CLASS_META]) {
-      let classMeta: ClassMeta = obj.constructor[<string>CLASS_META];
+    if (obj.constructor && obj.constructor[CLASS_META]) {
+      let classMeta: ClassMeta = obj.constructor[CLASS_META];
       MetaToUse = classMeta.InstanceMetaConstructor;
-    } else if (obj[<string>CLASS_META]) {
-      MetaToUse = obj[<string>CLASS_META].InstanceMetaConstructor;
+    } else if (obj[CLASS_META]) {
+      MetaToUse = obj[CLASS_META].InstanceMetaConstructor;
     }
 
     return (obj._meta = new MetaToUse(obj, {}));
@@ -130,23 +130,23 @@ class Meta implements IMeta, HasGuid {
 
   addReference(property: string, reference: IPathReference<any> & HasGuid) {
     let refs = this.references = this.references || dict<DictSet<IPathReference<any> & HasGuid>>();
-    let set = refs[<string>property] = refs[<string>property] || new DictSet<IPathReference<any> & HasGuid>();
+    let set = refs[property] = refs[property] || new DictSet<IPathReference<any> & HasGuid>();
     set.add(reference);
   }
 
   addReferenceTypeFor(property: string, type: PathReferenceFactory<any>) {
     this.referenceTypes = this.referenceTypes || dict<PathReferenceFactory<any>>();
-    this.referenceTypes[<string>property] = type;
+    this.referenceTypes[property] = type;
   }
 
   referenceTypeFor(property: string): InnerReferenceFactory<any> {
     if (!this.referenceTypes) return PropertyReference;
-    return this.referenceTypes[<string>property] || PropertyReference;
+    return this.referenceTypes[property] || PropertyReference;
   }
 
   removeReference(property: string, reference: IPathReference<any> & HasGuid) {
     if (!this.references) return;
-    let set = this.references[<string>property];
+    let set = this.references[property];
     set.delete(reference);
   }
 
@@ -157,7 +157,7 @@ class Meta implements IMeta, HasGuid {
 
   referencesFor(property: string): Set<IPathReference<any>> {
     if (!this.references) return;
-    return this.references[<string>property];
+    return this.references[property];
   }
 
   getSlots() {

--- a/packages/glimmer-object-reference/lib/object.ts
+++ b/packages/glimmer-object-reference/lib/object.ts
@@ -6,7 +6,7 @@ export function setProperty(parent: any, property: string, val: any) {
 
   // let referencesToNotify = metaFor(parent).referencesFor(property));
 
-  parent[<string>property] = val;
+  parent[property] = val;
 
   // if (referencesToNotify) {
   //   referencesToNotify.forEach(function(ref) { ref.notify(); });

--- a/packages/glimmer-object-reference/lib/references/descriptors.ts
+++ b/packages/glimmer-object-reference/lib/references/descriptors.ts
@@ -16,7 +16,7 @@ export class PropertyReference<T> implements Reference<T> {
     this.property = property;
   }
 
-  value() { return this.object[<string>this.property]; }
+  value() { return this.object[this.property]; }
 
   label() {
     return '[reference Property]';
@@ -51,7 +51,7 @@ export function ComputedReferenceBlueprint(property, dependencies) {
         this.installed = true;
       }
 
-      return this.object[<string>this.property];
+      return this.object[this.property];
     }
 
     label() {

--- a/packages/glimmer-object-reference/lib/references/path.ts
+++ b/packages/glimmer-object-reference/lib/references/path.ts
@@ -58,8 +58,8 @@ export default class PathReference<T> implements IPathReference<T>, HasGuid {
 
   get(prop: string): IPathReference<any> {
     let chains = this._getChains();
-    if (<string>prop in chains) return chains[<string>prop];
-    return (chains[<string>prop] = new PathReference(this, prop));
+    if (<string>prop in chains) return chains[prop];
+    return (chains[prop] = new PathReference(this, prop));
   }
 
   label(): string {

--- a/packages/glimmer-object-reference/lib/references/root.ts
+++ b/packages/glimmer-object-reference/lib/references/root.ts
@@ -21,13 +21,13 @@ export default class RootReference<T> implements IRootReference<T>, IPathReferen
 
   get<U>(prop: string): IPathReference<U> {
     let chains = this.chains;
-    if (<string>prop in chains) return chains[<string>prop];
-    return (chains[<string>prop] = new PathReference(this, prop));
+    if (<string>prop in chains) return chains[prop];
+    return (chains[prop] = new PathReference(this, prop));
   }
 
   chainFor<U>(prop: string): IPathReference<U> {
     let chains = this.chains;
-    if (<string>prop in chains) return chains[<string>prop];
+    if (<string>prop in chains) return chains[prop];
     return null;
   }
 

--- a/packages/glimmer-object/lib/computed.ts
+++ b/packages/glimmer-object/lib/computed.ts
@@ -101,7 +101,7 @@ function wrapAccessor(home: Object, accessorName: string, _desc: ComputedDescrip
 
   let cacheGet = function() {
     if (Meta.exists(this)) {
-      let slot = Meta.for(this).getSlots()[<string>accessorName];
+      let slot = Meta.for(this).getSlots()[accessorName];
       if (slot !== EMPTY_CACHE) return slot;
     }
 
@@ -118,14 +118,14 @@ function wrapAccessor(home: Object, accessorName: string, _desc: ComputedDescrip
       let ret = originalSet.call(this, value);
 
       if (ret !== undefined) {
-        slots[<string>accessorName] = ret;
+        slots[accessorName] = ret;
       }
     };
   } else {
     cacheSet = function(value) {
       let meta = Meta.for(this);
       let slots = meta.getSlots();
-      if (value !== undefined) slots[<string>accessorName] = value;
+      if (value !== undefined) slots[accessorName] = value;
     };
   }
 

--- a/packages/glimmer-object/lib/descriptors.ts
+++ b/packages/glimmer-object/lib/descriptors.ts
@@ -48,12 +48,12 @@ class AliasBlueprint extends ComputedBlueprint {
     let last = name[name.length - 1];
 
     let get = function() {
-      return name.reduce((obj, n) => obj[<string>n], this);
+      return name.reduce((obj, n) => obj[n], this);
     };
 
     let set = function(value) {
-      let p = parent.reduce((obj, n) => obj[<string>n], this);
-      p[<string>last] = value;
+      let p = parent.reduce((obj, n) => obj[n], this);
+      p[last] = value;
     };
 
     super({ get, set }, [name]);

--- a/packages/glimmer-object/lib/mixin.ts
+++ b/packages/glimmer-object/lib/mixin.ts
@@ -167,7 +167,7 @@ export class Mixin {
     if (meta.hasAppliedMixin(this)) return;
     meta.addAppliedMixin(this);
 
-    this.mergedProperties.forEach(k => meta.addMergedProperty(k, parent[<string>k]));
+    this.mergedProperties.forEach(k => meta.addMergedProperty(k, parent[k]));
     this.concatenatedProperties.forEach(k => meta.addConcatenatedProperty(k, []));
 
     new ValueDescriptor({ value: meta.getConcatenatedProperties() }).define(target, <string>'concatenatedProperties', null);
@@ -335,7 +335,7 @@ class MethodBlueprint extends DataBlueprint {
 export function wrapMethod(home: Object, methodName: string, original: (...args) => any) {
   if (!(<string>methodName in home)) return maybeWrap(original);
 
-  let superMethod = home[<string>methodName];
+  let superMethod = home[methodName];
 
   let func = function(...args) {
     if (!this) return original.apply(this, args);

--- a/packages/glimmer-object/lib/object.ts
+++ b/packages/glimmer-object/lib/object.ts
@@ -149,15 +149,15 @@ export class ClassMeta {
   }
 
   addPropertyMetadata(property: string, value: any) {
-    this.propertyMetadata[<string>property] = value;
+    this.propertyMetadata[property] = value;
   }
 
   metadataForProperty(property: string): Object {
-    return this.propertyMetadata[<string>property];
+    return this.propertyMetadata[property];
   }
 
   addReferenceTypeFor(property: string, type: InnerReferenceFactory<any>) {
-    this.referenceTypes[<string>property] = type;
+    this.referenceTypes[property] = type;
   }
 
   addSlotFor(property: string) {
@@ -170,7 +170,7 @@ export class ClassMeta {
   }
 
   getConcatenatedProperty(property: string): any[] {
-    return this.concatenatedProperties[<string>property];
+    return this.concatenatedProperties[property];
   }
 
   getConcatenatedProperties(): string[] {
@@ -181,10 +181,10 @@ export class ClassMeta {
     this.hasConcatenatedProperties = true;
 
     if (<string>property in this.concatenatedProperties) {
-      let val = this.concatenatedProperties[<string>property].concat(value);
-      this.concatenatedProperties[<string>property] = val;
+      let val = this.concatenatedProperties[property].concat(value);
+      this.concatenatedProperties[property] = val;
     } else {
-      this.concatenatedProperties[<string>property] = value;
+      this.concatenatedProperties[property] = value;
     }
   }
 
@@ -194,7 +194,7 @@ export class ClassMeta {
   }
 
   getMergedProperty(property: string): Object {
-    return this.mergedProperties[<string>property];
+    return this.mergedProperties[property];
   }
 
   getMergedProperties(): string[] {
@@ -208,11 +208,11 @@ export class ClassMeta {
       throw new Error(`You passed in \`${JSON.stringify(value)}\` as the value for \`foo\` but \`foo\` cannot be an Array`);
     }
 
-    if (<string>property in this.mergedProperties && this.mergedProperties[<string>property] && value) {
-      this.mergedProperties[<string>property] = mergeMergedProperties(value, this.mergedProperties[<string>property]);
+    if (<string>property in this.mergedProperties && this.mergedProperties[property] && value) {
+      this.mergedProperties[property] = mergeMergedProperties(value, this.mergedProperties[property]);
     } else {
       value = value === null ? value : value || {};
-      this.mergedProperties[<string>property] = value;
+      this.mergedProperties[property] = value;
     }
   }
 
@@ -270,7 +270,7 @@ export class ClassMeta {
     class Slots {
       constructor() {
         slots.forEach(name => {
-          this[<string>name] = EMPTY_CACHE;
+          this[name] = EMPTY_CACHE;
         });
       }
     }
@@ -284,7 +284,7 @@ export class ClassMeta {
       }
 
       referenceTypeFor(property: string): InnerReferenceFactory<any> {
-        return this.referenceTypes[<string>property] || PropertyReference;
+        return this.referenceTypes[property] || PropertyReference;
       }
 
       getSlots() {

--- a/packages/glimmer-reference/lib/iterable.ts
+++ b/packages/glimmer-reference/lib/iterable.ts
@@ -127,7 +127,7 @@ export class IterationArtifacts {
     let { list } = this;
 
     list.remove(item);
-    delete this.map[<string>item.key];
+    delete this.map[item.key];
   }
 
   nextNode(item: ListItem) {

--- a/packages/glimmer-runtime/lib/compiled/expressions/named-args.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/named-args.ts
@@ -114,11 +114,11 @@ class NonEmptyEvaluatedNamedArgs extends EvaluatedNamedArgs {
   }
 
   get(key: string): PathReference<any> {
-    return this.map[<string>key] || UNDEFINED_REFERENCE;
+    return this.map[key] || UNDEFINED_REFERENCE;
   }
 
   has(key: string): boolean {
-    return !!this.map[<string>key];
+    return !!this.map[key];
   }
 
   value(): Dict<any> {

--- a/packages/glimmer-runtime/lib/compiled/expressions/ref.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/ref.ts
@@ -44,7 +44,7 @@ export class CompiledKeywordRef {
   }
 
   evaluate(vm: VM): PathReference<any> {
-    let base = vm.dynamicScope()[<string>this.name] as PathReference<any>;;
+    let base = vm.dynamicScope()[this.name] as PathReference<any>;;
     return referenceFromParts(base, this.path);
   }
 

--- a/packages/glimmer-runtime/lib/compiled/expressions/value.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/value.ts
@@ -27,10 +27,10 @@ export class ValueReference<T> extends ConstReference<T> implements PathReferenc
 
   get(key: string) {
     let { children } = this;
-    let child = children[<string>key];
+    let child = children[key];
 
     if (!child) {
-      child = children[<string>key] = new ValueReference(this.inner[<string>key]);
+      child = children[key] = new ValueReference(this.inner[key]);
     }
 
     return child;

--- a/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -150,7 +150,7 @@ export class BindNamedArgsOpcode extends Opcode {
 
   static create(layout: Layout) {
     let named = layout['named'].reduce(
-      (obj, name) => assign(obj, { [<string>name]: layout.symbolTable.getNamed(name) }),
+      (obj, name) => assign(obj, { [name]: layout.symbolTable.getNamed(name) }),
       dict<number>()
     );
 
@@ -192,7 +192,7 @@ export class BindBlocksOpcode extends Opcode {
   static create(template: Layout) {
     let blocks = dict<number>();
     template['yields'].forEach(name => {
-      blocks[<string>name] = template.symbolTable.getYield(name);
+      blocks[name] = template.symbolTable.getYield(name);
     });
 
     return new BindBlocksOpcode({ blocks });

--- a/packages/glimmer-runtime/lib/symbol-table.ts
+++ b/packages/glimmer-runtime/lib/symbol-table.ts
@@ -44,24 +44,24 @@ export default class SymbolTable {
   }
 
   initPositionals(positionals: string[]): this {
-    if (positionals) positionals.forEach(s => this.locals[<string>s] = this.top.size++);
+    if (positionals) positionals.forEach(s => this.locals[s] = this.top.size++);
     return this;
   }
 
   initNamed(named: string[]): this {
-    if (named) named.forEach(s => this.named[<string>s] = this.top.size++);
+    if (named) named.forEach(s => this.named[s] = this.top.size++);
     return this;
   }
 
   initYields(yields: string[]): this {
-    if (yields) yields.forEach(b => this.yields[<string>b] = this.top.size++);
+    if (yields) yields.forEach(b => this.yields[b] = this.top.size++);
     return this;
   }
 
   getYield(name: string): number {
     let { yields, parent } = this;
 
-    let symbol = yields[<string>name];
+    let symbol = yields[name];
 
     if (!symbol && parent) {
       symbol = parent.getYield(name);
@@ -73,7 +73,7 @@ export default class SymbolTable {
   getNamed(name: string): number {
     let { named, parent } = this;
 
-    let symbol = named[<string>name];
+    let symbol = named[name];
 
     if (!symbol && parent) {
       symbol = parent.getNamed(name);
@@ -85,7 +85,7 @@ export default class SymbolTable {
   getLocal(name: string): number {
     let { locals, parent } = this;
 
-    let symbol = locals[<string>name];
+    let symbol = locals[name];
 
     if (!symbol && parent) {
       symbol = parent.getLocal(name);

--- a/packages/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/glimmer-runtime/lib/syntax/core.ts
@@ -1110,15 +1110,15 @@ export class NamedArgs {
   }
 
   add(key: string, value: ExpressionSyntax<Opaque>) {
-    this.map[<string>key] = value;
+    this.map[key] = value;
   }
 
   at(key: string): ExpressionSyntax<Opaque> {
-    return this.map[<string>key];
+    return this.map[key];
   }
 
   has(key: string): boolean {
-    return !!this.map[<string>key];
+    return !!this.map[key];
   }
 
   compile(compiler: SymbolLookup, env: Environment): CompiledNamedArgs {

--- a/packages/glimmer-runtime/lib/vm/append.ts
+++ b/packages/glimmer-runtime/lib/vm/append.ts
@@ -145,7 +145,7 @@ export default class VM implements PublicVM {
 
     let tryOpcode = new TryOpcode({ ops, state, children: updating });
 
-    this.listBlockStack.current.map[<string>key] = tryOpcode;
+    this.listBlockStack.current.map[key] = tryOpcode;
 
     this.didEnter(tryOpcode, updating);
   }

--- a/packages/glimmer-runtime/lib/vm/update.ts
+++ b/packages/glimmer-runtime/lib/vm/update.ts
@@ -228,7 +228,7 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     let reference = null;
 
     if (before) {
-      reference = map[<string>before];
+      reference = map[before];
       nextSibling = reference.bounds.firstNode();
     } else {
       nextSibling = this.marker;
@@ -254,7 +254,7 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
 
     updating.insertBefore(tryOpcode, reference);
 
-    map[<string>key] = tryOpcode;
+    map[key] = tryOpcode;
 
     this.didInsert = true;
   }
@@ -265,8 +265,8 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
   move(key: string, item: PathReference<Opaque>, memo: PathReference<Opaque>, before: string) {
     let { map, updating } = this;
 
-    let entry = map[<string>key];
-    let reference = map[<string>before] || null;
+    let entry = map[key];
+    let reference = map[before] || null;
 
     if (before) {
       moveBounds(entry, reference.firstNode());
@@ -280,11 +280,11 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
 
   delete(key: string) {
     let { map } = this;
-    let opcode = map[<string>key];
+    let opcode = map[key];
     clear(opcode);
     opcode.didDestroy();
     this.updating.remove(opcode);
-    delete map[<string>key];
+    delete map[key];
 
     this.didDelete = true;
   }

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -564,7 +564,7 @@ export class SimplePathReference<T> implements PathReference<T> {
   }
 
   value(): T {
-    return this.parent.value()[<string>this.property];
+    return this.parent.value()[this.property];
   }
 
   get(prop: string): PathReference<Opaque> {
@@ -806,11 +806,11 @@ export class TestEnvironment extends Environment {
   }
 
   hasComponentDefinition(name: string[]): boolean {
-    return !!this.components[<string>name[0]];
+    return !!this.components[name[0]];
   }
 
   getComponentDefinition(name: string[]): ComponentDefinition<any> {
-    return this.components[<string>name[0]];
+    return this.components[name[0]];
   }
 
   hasModifier(modifierName: string[]): boolean {
@@ -854,7 +854,7 @@ export class TestEnvironment extends Environment {
         keyFor = (item: Opaque) => String(item);
         break;
       default:
-        keyFor = (item: Opaque) => item[<string>keyPath];
+        keyFor = (item: Opaque) => item[keyPath];
         break;
     }
 


### PR DESCRIPTION
These were casting from `InternedString` to `string` for property access. They are now just strings.