### PR TITLE
Expose compileSpec to node's main export.

### DIFF
--- a/packages/glimmer/index.ts
+++ b/packages/glimmer/index.ts
@@ -5,3 +5,4 @@
  *            See https://raw.githubusercontent.com/tildeio/glimmer/master/LICENSE
  * @version   VERSION_STRING_PLACEHOLDER
  */
+export { compileSpec } from 'glimmer-compiler';


### PR DESCRIPTION
Allows the following:

```js
var glimmer = require('glimmer-engine');
glimmer.compileSpec('{{foo-bar}}');
```

This will be used to replace the usage of glimmer-engine-precompiler (an
obsolete package still used to build Ember's internal templates) with
the compiler for the actual glimmer version being used.