### PR TITLE
Ensure dist is built when referencing via git SHA.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "tslint": "tslint ./packages/**/*.ts",
     "vscode-build": "tslint -s ./.vscode/tslint-formatters -t vscode ./packages/**/*.ts; tsc -p . --noEmit",
     "sauce:connect": "ember sauce:connect",
-    "sauce:disconnect": "ember sauce:disconnect"
+    "sauce:disconnect": "ember sauce:disconnect",
+    "postinstall": "postinstall-build dist 'npm run build'"
   },
   "repository": {
     "type": "git",
@@ -36,6 +37,7 @@
     "exists-sync": "0.0.3",
     "git-repo-version": "^0.1.2",
     "handlebars": "^3.0.2",
+    "postinstall-build": "^0.2.1",
     "qunit": "^0.7.2",
     "simple-html-tokenizer": "^0.2.5",
     "typescript": "next"


### PR DESCRIPTION
In order to allow consumers to `require('glimmer-engine')` a `dist/` build is required. Normally, this is done as part of the publishing process for tagged builds, but in order to allow consumers to use git SHA's and still `require('glimmer-engine')` (which is required for the Ember build to precompile Ember's internal templates) we are adding a new `postinstall` script that checks if `dist/` is present and if not run the build.

This is required for https://github.com/emberjs/ember.js/pull/14061.