### PR TITLE
Revert "Ensure dist is built when referencing via git SHA."

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "tslint": "tslint ./packages/**/*.ts",
     "vscode-build": "tslint -s ./.vscode/tslint-formatters -t vscode ./packages/**/*.ts; tsc -p . --noEmit",
     "sauce:connect": "ember sauce:connect",
-    "sauce:disconnect": "ember sauce:disconnect",
-    "postinstall": "postinstall-build dist 'npm run build'"
+    "sauce:disconnect": "ember sauce:disconnect"
   },
   "repository": {
     "type": "git",
@@ -37,7 +36,6 @@
     "exists-sync": "0.0.3",
     "git-repo-version": "^0.1.2",
     "handlebars": "^3.0.2",
-    "postinstall-build": "^0.2.1",
     "qunit": "^0.7.2",
     "simple-html-tokenizer": "^0.2.5",
     "typescript": "next"


### PR DESCRIPTION
Reverts tildeio/glimmer#263

There are a number of issues still even after this:

* much longer `npm install` time in `emberjs/ember.js`
* didn't account for `bower` dependencies

---

We should instead, switch to using tags in Ember.