### PR TITLE
Update testem config for sauce labs runs.

### DIFF
--- a/testem-sauce.json
+++ b/testem-sauce.json
@@ -7,39 +7,43 @@
   "launchers":
     {
       "SL_Chrome_Current": {
-        "command": "ember sauce:launch -b chrome -v 39 --no-ct -u <url>",
+        "command": "ember sauce:launch -p 'Windows 10' -b chrome -v latest --no-ct -u '<url>'",
         "protocol": "tap"
       },
       "SL_Chrome_Last": {
-        "command": "ember sauce:launch -b chrome -v 38 --no-ct -u <url>",
+        "command": "ember sauce:launch -p 'Windows 10' -b chrome -v latest-1 --no-ct -u '<url>'",
         "protocol": "tap"
       },
       "SL_Firefox_Current": {
-        "command": "ember sauce:launch -b firefox -v 34 --no-ct -u <url>",
+        "command": "ember sauce:launch -p 'Windows 10' -b firefox -v latest --no-ct -u '<url>'",
         "protocol": "tap"
       },
       "SL_Firefox_Last": {
-        "command": "ember sauce:launch -b firefox -v 33 --no-ct -u <url>",
+        "command": "ember sauce:launch -p 'Windows 10' -b firefox -v latest-1 --no-ct -u '<url>'",
         "protocol": "tap"
       },
       "SL_Safari_Current": {
-        "command": "ember sauce:launch -b safari -v 8 --no-ct -u <url>",
+        "command": "ember sauce:launch -b safari -v 9 --no-ct -u '<url>'",
         "protocol": "tap"
       },
       "SL_Safari_Last": {
-        "command": "ember sauce:launch -b safari -v 7 --no-ct -u <url>",
+        "command": "ember sauce:launch -b safari -v 8 --no-ct -u '<url>'",
+        "protocol": "tap"
+      },
+      "SL_MS_Edge": {
+        "command": "ember sauce:launch -p 'Windows 10' -b 'microsoftedge' -v latest --no-ct -u '<url>'",
         "protocol": "tap"
       },
       "SL_IE_11": {
-        "command": "ember sauce:launch -b 'internet explorer' -v 11 --no-ct -u <url>",
+        "command": "ember sauce:launch -p 'Windows 10' -b 'internet explorer' -v 11 --no-ct -u '<url>'",
         "protocol": "tap"
       },
       "SL_IE_10": {
-        "command": "ember sauce:launch -b 'internet explorer' -v 10 --no-ct -u <url>",
+        "command": "ember sauce:launch -p 'Windows 7' -b 'internet explorer' -v 10 --no-ct -u '<url>'",
         "protocol": "tap"
       },
       "SL_IE_9": {
-        "command": "ember sauce:launch -b 'internet explorer' -v 9 --no-ct -u <url>",
+        "command": "ember sauce:launch -p 'Windows 7' -b 'internet explorer' -v 9 --no-ct -u '<url>'",
         "protocol": "tap"
       }
     }
@@ -56,6 +60,7 @@
     "SL_Firefox_Last",
     "SL_Safari_Current",
     "SL_Safari_Last",
+    "SL_MS_Edge",
     "SL_IE_11",
     "SL_IE_10",
     "SL_IE_9"


### PR DESCRIPTION
* Adds Microsoft Edge
* Updates Chrome to use `latest` and `latest-1` (was using 39 and 38)
* Updates Firefox to use `latest` and `latest-1` (was using 34 and 33)
* Updates Safari to use 9 and 8 (was 8 and 7)
* Wraps `<url>` in quotes to avoid issues with quoting discovered in Ember.