### PR TITLE
Use `dom.setAttribute` for non-dynamic (static) attributes.

### DIFF
--- a/packages/glimmer-runtime/lib/builder.ts
+++ b/packages/glimmer-runtime/lib/builder.ts
@@ -11,6 +11,10 @@ import {
 } from 'glimmer-reference';
 
 import {
+  ValueReference
+} from './compiled/expressions/value';
+
+import {
   Attribute
 } from './compiled/opcodes/dom';
 
@@ -270,11 +274,19 @@ export class ElementStack implements Cursor {
     return comment;
   }
 
-  setAttribute(name: string, reference: PathReference<string>, isTrusting: boolean) {
+  setStaticAttribute(name: string, reference: ValueReference<string>) {
+    this.dom.setAttribute(this.element, name, reference.value());
+  }
+
+  setStaticAttributeNS(namespace: string, name: string, reference: ValueReference<string>) {
+    this.dom.setAttributeNS(this.element, namespace, name, reference.value());
+  }
+
+  setDynamicAttribute(name: string, reference: PathReference<string>, isTrusting: boolean) {
     this.elementOperations.addAttribute(name, reference, isTrusting);
   }
 
-  setAttributeNS(namespace: string, name: string, reference: PathReference<string>, isTrusting: boolean) {
+  setDynamicAttributeNS(namespace: string, name: string, reference: PathReference<string>, isTrusting: boolean) {
     this.elementOperations.addAttributeNS(namespace, name, reference, isTrusting);
   }
 

--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -190,7 +190,7 @@ export class ShadowAttributesOpcode extends Opcode {
     if (!shadow) return;
 
     shadow.forEach(name => {
-      vm.stack().setAttribute(name, named.get(name), false);
+      vm.stack().setDynamicAttribute(name, named.get(name), false);
     });
   }
 

--- a/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
@@ -203,9 +203,9 @@ export class StaticAttrOpcode extends Opcode {
   evaluate(vm: VM) {
     let { name, value, namespace } = this;
     if (namespace) {
-      vm.stack().setAttributeNS(namespace, name, value, false);
+      vm.stack().setStaticAttributeNS(namespace, name, value);
     } else {
-      vm.stack().setAttribute(name, value, false);
+      vm.stack().setStaticAttribute(name, value);
     }
   }
 
@@ -410,7 +410,7 @@ export class DynamicAttrNSOpcode extends Opcode {
   evaluate(vm: VM) {
     let { name, namespace, isTrusting } = this;
     let reference = vm.frame.getOperand();
-    vm.stack().setAttributeNS(namespace, name, reference, isTrusting);
+    vm.stack().setDynamicAttributeNS(namespace, name, reference, isTrusting);
   }
 
   toJSON(): OpcodeJSON {
@@ -448,7 +448,7 @@ export class DynamicAttrOpcode extends Opcode {
   evaluate(vm: VM) {
     let { name, isTrusting } = this;
     let reference = vm.frame.getOperand();
-    vm.stack().setAttribute(name, reference, isTrusting);
+    vm.stack().setDynamicAttribute(name, reference, isTrusting);
   }
 
   toJSON(): OpcodeJSON {

--- a/packages/glimmer-runtime/tests/initial-render-test.ts
+++ b/packages/glimmer-runtime/tests/initial-render-test.ts
@@ -327,7 +327,7 @@ test("Static <option selected> is preserved properly", function() {
       <option>3</option>
     </select>
   `);
-  render(template);
+  render(template, {});
 
   let selectNode: any = root.childNodes[1];
 
@@ -339,14 +339,16 @@ test("Static <option selected> for multi-select is preserved properly", function
     <select multiple>
       <option selected>1</option>
       <option selected>2</option>
-      <option selected>3</option>
+      <option>3</option>
     </select>
   `);
-  render(template);
+  render(template, {});
 
   let selectNode: any = root.childNodes[1];
 
-  equal(selectNode.selectedOptions.length, 3, 'three options are selected');
+  let options = selectNode.querySelectorAll('option[selected]');
+
+  equal(options.length, 2, 'three options are selected');
 });
 
 module("Initial render - simple blocks");
@@ -957,9 +959,18 @@ QUnit.module('Style attributes', {
   }
 });
 
-test(`using an inline style on an element gives you a warning`, function(assert) {
+test(`using an inline static style on an element does not give you a warning`, function(assert) {
   let template = compile(`<div style="background: red">Thing</div>`);
   render(template, {});
+
+  assert.equal(warnings, 0);
+
+  equalTokens(root, '<div style="background: red">Thing</div>', "initial render");
+});
+
+test(`using an inline dynamic style on an element gives you a warning`, function(assert) {
+  let template = compile(`<div style="background: {{color}}">Thing</div>`);
+  render(template, { color: 'red' });
 
   assert.equal(warnings, 1);
 
@@ -975,12 +986,22 @@ test(`triple curlies are trusted`, function(assert) {
   equalTokens(root, '<div style="background: red">Thing</div>', "initial render");
 });
 
-test(`using an inline style on an namespaced element gives you a warning`, function(assert) {
+test(`using an inline dynamic style on an namespaced element gives you a warning`, function(assert) {
+  let template = compile(`<svg xmlns:svg="http://www.w3.org/2000/svg" style="background: {{color}}" />`);
+
+  render(template, { color: 'red' });
+
+  assert.equal(warnings, 1);
+
+  equalTokens(root, '<svg xmlns:svg="http://www.w3.org/2000/svg" style="background: red"></svg>', "initial render");
+});
+
+test(`using an inline static style on an namespaced element does not give you a warning`, function(assert) {
   let template = compile(`<svg xmlns:svg="http://www.w3.org/2000/svg" style="background: red" />`);
 
   render(template, {});
 
-  assert.equal(warnings, 1);
+  assert.equal(warnings, 0);
 
   equalTokens(root, '<svg xmlns:svg="http://www.w3.org/2000/svg" style="background: red"></svg>', "initial render");
 });

--- a/packages/glimmer-runtime/tests/initial-render-test.ts
+++ b/packages/glimmer-runtime/tests/initial-render-test.ts
@@ -319,6 +319,36 @@ test("Mountain range of nesting", function() {
              'FOO<span>BAR<a>BAZ<em>BOOBREW</em>BAT</a></span><span><span>FLUTE</span></span>ARGH', context);
 });
 
+test("Static <option selected> is preserved properly", function() {
+  let template = compile(`
+    <select>
+      <option>1</option>
+      <option selected>2</option>
+      <option>3</option>
+    </select>
+  `);
+  render(template);
+
+  let selectNode: any = root.childNodes[1];
+
+  equal(selectNode.selectedIndex, 1, 'second item is selected');
+});
+
+test("Static <option selected> for multi-select is preserved properly", function() {
+  let template = compile(`
+    <select multiple>
+      <option selected>1</option>
+      <option selected>2</option>
+      <option selected>3</option>
+    </select>
+  `);
+  render(template);
+
+  let selectNode: any = root.childNodes[1];
+
+  equal(selectNode.selectedOptions.length, 3, 'three options are selected');
+});
+
 module("Initial render - simple blocks");
 
 test("The compiler can handle unescaped tr in top of content", function() {


### PR DESCRIPTION
This is a failing test for https://github.com/emberjs/ember.js/issues/13992.

Discussed with @wycats and will be implementing a separate
`addDynamicAttribute` (which will be what `addAttribute` will become)
and an `addStaticAttribute` to `ElementStack`.