### PR TITLE
Failing tests for `<select multiple>`.

### DIFF
--- a/packages/glimmer-runtime/tests/initial-render-test.ts
+++ b/packages/glimmer-runtime/tests/initial-render-test.ts
@@ -319,6 +319,82 @@ test("Mountain range of nesting", function() {
              'FOO<span>BAR<a>BAZ<em>BOOBREW</em>BAT</a></span><span><span>FLUTE</span></span>ARGH', context);
 });
 
+test("Static <option selected> is preserved properly", function() {
+  let template = compile(`
+    <select>
+      <option>1</option>
+      <option selected>2</option>
+      <option>3</option>
+    </select>
+  `);
+  render(template, {});
+
+  let selectNode: any = root.childNodes[1];
+
+  equal(selectNode.selectedIndex, 1, 'second item is selected');
+});
+
+test("Static <option selected> for multi-select is preserved properly", function() {
+  let template = compile(`
+    <select multiple>
+      <option selected>1</option>
+      <option selected>2</option>
+      <option>3</option>
+    </select>
+  `);
+  render(template, {});
+
+  let selectNode: any = root.childNodes[1];
+
+  let options = selectNode.querySelectorAll('option[selected]');
+
+  equal(options.length, 2, 'three options are selected');
+});
+
+test("Dynamic <option selected> is preserved properly", function() {
+  let template = compile(`
+    <select>
+      <option>1</option>
+      <option selected={{selected}}>2</option>
+      <option>3</option>
+    </select>
+  `);
+  render(template, { selected: true });
+
+  let selectNode: any = root.childNodes[1];
+
+  equal(selectNode.selectedIndex, 1, 'second item is selected');
+});
+
+test("Dynamic <option selected> for multi-select is preserved properly", function() {
+  let template = compile(`
+    <select multiple>
+      <option>0</option>
+      <option selected={{somethingTrue}}>1</option>
+      <option selected={{somethingTruthy}}>2</option>
+      <option selected={{somethingUndefined}}>3</option>
+      <option selected={{somethingNull}}>4</option>
+      <option selected={{somethingFalse}}>5</option>
+    </select>
+  `);
+
+  render(template, {
+    somethingTrue: true,
+    somethingTruthy: 'is-true',
+    somethingUndefined: undefined,
+    somethingNull: null,
+    somethingFalse: false
+  });
+
+  let selectNode: any = root.childNodes[1];
+
+  let options = selectNode.querySelectorAll('option[selected]');
+
+  equal(options.length, 2, 'two options are selected');
+  equal(options[0].value, '1', 'first selected item is "1"');
+  equal(options[1].value, '2', 'second selected item is "2"');
+});
+
 module("Initial render - simple blocks");
 
 test("The compiler can handle unescaped tr in top of content", function() {


### PR DESCRIPTION
This is a follow-up to https://github.com/tildeio/glimmer/pull/266 and adds tests for dynamic selected attributes (as opposed to only static).

Related to https://github.com/emberjs/ember.js/issues/13992.