### PR TITLE
Misc cleanup, tag-based `isConst`

### DIFF
--- a/packages/glimmer-reference/lib/const.ts
+++ b/packages/glimmer-reference/lib/const.ts
@@ -1,22 +1,14 @@
 import { CONSTANT_TAG, VersionedReference } from './validators';
-import Reference from './reference';
 import { Opaque } from 'glimmer-util';
 
-export const CONST_REFERENCE = "503c5a44-e4a9-4bb5-85bc-102d35af6985";
-
 export class ConstReference<T> implements VersionedReference<T> {
-  protected inner: T;
   public tag = CONSTANT_TAG;
 
-  public "503c5a44-e4a9-4bb5-85bc-102d35af6985" = true;
-
-  constructor(inner: T) {
-    this.inner = inner;
-  }
+  constructor(protected inner: T) { }
 
   value(): T { return this.inner; }
 }
 
-export function isConst(reference: Reference<Opaque>): boolean {
-  return !!reference[CONST_REFERENCE];
+export function isConst(reference: VersionedReference<Opaque>): boolean {
+  return reference.tag === CONSTANT_TAG;
 }

--- a/packages/glimmer-runtime/lib/compiled/expressions/args.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/args.ts
@@ -1,7 +1,6 @@
 import { COMPILED_EMPTY_POSITIONAL_ARGS, EVALUATED_EMPTY_POSITIONAL_ARGS, CompiledPositionalArgs, EvaluatedPositionalArgs } from './positional-args';
 import { COMPILED_EMPTY_NAMED_ARGS, EVALUATED_EMPTY_NAMED_ARGS, CompiledNamedArgs, EvaluatedNamedArgs } from './named-args';
 import VM from '../../vm/append';
-import { Block  } from '../blocks';
 import { CONSTANT_TAG, RevisionTag, PathReference, combine } from 'glimmer-reference';
 import { Dict, dict, Opaque } from 'glimmer-util';
 
@@ -66,6 +65,9 @@ interface EvaluatedArgsOptions {
 
 export abstract class EvaluatedArgs {
   public tag: RevisionTag;
+  public positional: EvaluatedPositionalArgs;
+  public named: EvaluatedNamedArgs;
+  public internal: Dict<Opaque>;
 
   static empty(): EvaluatedArgs {
     return EMPTY_EVALUATED_ARGS;
@@ -78,12 +80,6 @@ export abstract class EvaluatedArgs {
   static positional(values: PathReference<any>[]): EvaluatedArgs {
     return new NonEmptyEvaluatedArgs({ positional: EvaluatedPositionalArgs.create({ values }), named: EvaluatedNamedArgs.empty() });
   }
-
-  public type: string;
-  public positional: EvaluatedPositionalArgs;
-  public named: EvaluatedNamedArgs;
-  public blocks: Block[];
-  public internal: Dict<Opaque>;
 
   public withInternal(): EvaluatedArgs {
     if (!this.internal) {

--- a/packages/glimmer-runtime/lib/compiled/expressions/positional-args.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/positional-args.ts
@@ -27,8 +27,8 @@ class CompiledNonEmptyPositionalArgs extends CompiledPositionalArgs {
 
   constructor({ values }: { values: CompiledExpression<any>[] }) {
     super();
-    this.length = values.length;
     this.values = values;
+    this.length = values.length;
   }
 
   evaluate(vm: VM): EvaluatedPositionalArgs {
@@ -63,6 +63,8 @@ export const COMPILED_EMPTY_POSITIONAL_ARGS: CompiledPositionalArgs = new (class
 
 export abstract class EvaluatedPositionalArgs {
   public tag: RevisionTag;
+  public values: PathReference<any>[];
+  public length: number;
 
   static empty(): EvaluatedPositionalArgs {
     return EVALUATED_EMPTY_POSITIONAL_ARGS;
@@ -71,10 +73,6 @@ export abstract class EvaluatedPositionalArgs {
   static create({ values }: { values: PathReference<any>[] }) {
     return new NonEmptyEvaluatedPositionalArgs({ values });
   }
-
-  public type: string;
-  public values: PathReference<any>[];
-  public length: number;
 
   forEach(callback: (value: PathReference<any>) => void) {
     let values = this.values;
@@ -93,8 +91,8 @@ class NonEmptyEvaluatedPositionalArgs extends EvaluatedPositionalArgs {
   constructor({ values }: { values: PathReference<any>[] }) {
     super();
     this.tag = combineTagged(values);
-    this.length = values.length;
     this.values = values;
+    this.length = values.length;
   }
 
   at(index: number): PathReference<any> {
@@ -113,14 +111,14 @@ class NonEmptyEvaluatedPositionalArgs extends EvaluatedPositionalArgs {
 
 export const EVALUATED_EMPTY_POSITIONAL_ARGS = new (class extends EvaluatedPositionalArgs {
   public tag = CONSTANT_TAG;
-  public length = 0;
   public values = [];
+  public length = 0;
 
   at(): PathReference<any> {
     return NULL_REFERENCE;
   }
 
   value(): any[] {
-    return [];
+    return this.values;
   }
 });


### PR DESCRIPTION
Since the tag cannot change once initialized, having a `CONSTANT_TAG` (as opposed to an `UpdatableTag` of `CONSTANT_TAG`) is the same as being a “const reference”.

This expands the `ConstReference` optimizations we do to more places. For example, `{{component (concat “foo” “-” “bar”)}}` is now the same as `{{component “foo-bar”}}`, which is the same as `{{foo-bar}}`.