### PR TITLE
Allow unquoted attributes before the end of a self-closing tag.

### DIFF
--- a/packages/glimmer-runtime/tests/initial-render-test.ts
+++ b/packages/glimmer-runtime/tests/initial-render-test.ts
@@ -143,7 +143,7 @@ test("Unquoted attribute with expression throws an exception", function () {
     return new Error(
       `An unquoted attribute value must be a string or a mustache, ` +
       `preceeded by whitespace or a '=' character, and ` +
-      `followed by whitespace or a '>' character (on line ${line})`
+      `followed by whitespace, a '>' character, or '/>' (on line ${line})`
     );
   }
 });

--- a/packages/glimmer-syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/glimmer-syntax/lib/parser/tokenizer-event-handlers.ts
@@ -194,13 +194,13 @@ function assembleAttributeValue(parts, isQuoted, isDynamic, line) {
     if (isQuoted) {
       return assembleConcatenatedValue(parts);
     } else {
-      if (parts.length === 1) {
+      if (parts.length === 1 || (parts.length === 2 && parts[1] === '/')) {
         return parts[0];
       } else {
         throw new Error(
           `An unquoted attribute value must be a string or a mustache, ` +
           `preceeded by whitespace or a '=' character, and ` +
-          `followed by whitespace or a '>' character (on line ${line})`
+          `followed by whitespace, a '>' character, or '/>' (on line ${line})`
         );
       }
     }

--- a/packages/glimmer-syntax/tests/parser-node-test.ts
+++ b/packages/glimmer-syntax/tests/parser-node-test.ts
@@ -137,6 +137,13 @@ test("Handlebars embedded in an attribute (unquoted)", function() {
   ]));
 });
 
+test("Handlebars embedded in an attribute of a self-closing tag (unqouted)", function() {
+  let t = '<input value={{foo}}/>';
+  astEqual(t, b.program([
+    b.element("input", [ b.attr("value", b.mustache(b.path('foo'))) ], [], []),
+  ]));
+});
+
 test("Handlebars embedded in an attribute (sexprs)", function() {
   let t = 'some <div class="{{foo (foo "abc")}}">content</div> done';
   astEqual(t, b.program([


### PR DESCRIPTION
As specified in emberjs/ember.js#12769,

```handlebars
<input type="text" value={{favoriteBand}} onblur={{action "bandDidChange"}}/>
```

is valid HTML but HTMLbars was raising the following exception:

    An unquoted attribute value must be a string or a mustache, preceeded by
    whitespace or a '=' character, and followed by whitespace or a '>'
    character (on line X)

This commit addresses the problem and rephrases the assertion message.

---

Cherry-picked from https://github.com/tildeio/htmlbars/pull/443.