### PR TITLE
Default block param to UNDEFINED_REFERENCE.

### DIFF
--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -2,7 +2,7 @@ import { Statement as StatementSyntax } from './syntax';
 
 import { DOMHelper } from './dom/helper';
 import { Reference, OpaqueIterable } from 'glimmer-reference';
-import { NULL_REFERENCE, ConditionalReference } from './references';
+import { UNDEFINED_REFERENCE, NULL_REFERENCE, ConditionalReference } from './references';
 import {
   defaultChangeLists,
   IChangeList
@@ -94,7 +94,7 @@ export class Scope {
     return this.slots[symbol] as InlineBlock;
   }
 
-  bindSymbol(symbol: number, value: PathReference<Opaque>) {
+  bindSymbol(symbol: number, value: PathReference<Opaque>=UNDEFINED_REFERENCE) {
     this.slots[symbol] = value;
   }
 

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -524,6 +524,19 @@ testComponent('yield', {
   expected: 'Yes:Hello42outer'
 });
 
+testComponent('use a non-existent block param', {
+  skip: 'glimmer',
+  layout: '{{yield someValue}}',
+
+  invokeAs: {
+    args: { someValue: '42' },
+    blockParams: ['val1', 'val2'],
+    template: '{{val1}} - {{val2}}'
+  },
+
+  expected: '42 - '
+});
+
 testComponent('yield to inverse', {
   skip: 'glimmer',
   layout: '{{#if @predicate}}Yes:{{yield @someValue}}{{else}}No:{{yield to="inverse"}}{{/if}}',


### PR DESCRIPTION
This prevents an error condition when the user specifies more block params than were yielded.