### PR TITLE
Initialize TryOpcode when emulating `enterWithKey`

### DIFF
--- a/packages/glimmer-runtime/lib/vm/update.ts
+++ b/packages/glimmer-runtime/lib/vm/update.ts
@@ -235,7 +235,7 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
     }
 
     let vm = opcode.vmForInsertion(nextSibling);
-    let tryOpcode;
+    let tryOpcode: TryOpcode;
 
     vm.execute(opcode.ops, vm => {
       vm.frame.setArgs(EvaluatedArgs.positional([item, memo]));
@@ -251,6 +251,8 @@ export class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
         children: vm.updatingOpcodeStack.current
       });
     });
+
+    tryOpcode.didInitializeChildren();
 
     updating.insertBefore(tryOpcode, reference);
 

--- a/packages/glimmer-runtime/tests/updating-test.ts
+++ b/packages/glimmer-runtime/tests/updating-test.ts
@@ -1632,6 +1632,8 @@ test('The each helper yields the index of the current item when using a non-@ind
   }
 });
 
+// TODO: port https://github.com/emberjs/ember.js/pull/14082
+
 function testEachHelper(testName, templateSource, testMethod=QUnit.test) {
   testMethod(testName, function() {
     let template = compile(templateSource);


### PR DESCRIPTION
The code here is to emulate the `enterWithKey` path on the append VM, however, it is missing the corresponding `exit`, i.e. we are not initializing the tag on the `TryOpcode`, incorrectly leaving it as an `UpdatableTag(CONSTANT_TAG)`.

When combined with other update-side optimizations like `JUMP-IF-NOT-MODIFIED`, this causes things to not update correctly.

This is tested via https://github.com/emberjs/ember.js/pull/14082 in Ember. Unfortunately, this is not currently easily testable on the Glimmer side due to our reliance on `VOLATILE_TAG`s in `glimmer-object-reference`.