### PR TITLE
Fix issue when yielding inside an `{{each`.

### DIFF
--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -73,8 +73,9 @@ export class Scope {
   private slots: ScopeSlot[];
   private callerScope: Scope = null;
 
-  constructor(references: ScopeSlot[]) {
+  constructor(references: ScopeSlot[], callerScope: Scope = null) {
     this.slots = references;
+    this.callerScope = callerScope;
   }
 
   init({ self }: { self: PathReference<Opaque> }): this {
@@ -111,7 +112,7 @@ export class Scope {
   }
 
   child(): Scope {
-    return new Scope(this.slots.slice());
+    return new Scope(this.slots.slice(), this.callerScope);
   }
 }
 

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -1189,6 +1189,40 @@ QUnit.test('correct scope - complex', assert => {
     );
 });
 
+QUnit.test('correct scope - complex yield', assert => {
+  env.registerEmberishCurlyComponent('item-list', EmberishCurlyComponent.extend() as any,
+    stripTight`
+      <ul>
+        {{#each items key="id" as |item|}}
+          <li>{{item.id}}: {{yield item}}</li>
+        {{/each}}
+      </ul>`
+  );
+
+  let items = [
+    { id: '1', name: 'Foo' },
+    { id: '2', name: 'Bar' },
+    { id: '3', name: 'Baz' }
+  ];
+
+  appendViewFor(
+    stripTight`
+      {{#item-list items=items as |item|}}
+        {{item.name}}
+      {{/item-list}}`
+    , { items }
+  );
+
+  assertEmberishElement('div',
+    stripTight`
+      <ul>
+        <li>1: Foo</li>
+        <li>2: Bar</li>
+        <li>3: Baz</li>
+      </ul>`
+  );
+});
+
 QUnit.test('correct scope - self', assert => {
   class FooBar extends BasicComponent {
     public foo = 'foo';


### PR DESCRIPTION
When we created a child scope, we did not properly pass through the `callerScope`. This lead to an error in the case when you `{{yield}}` from within an `{{#each` (the only place ATM we use `scope.child()`).

Addresses https://github.com/emberjs/ember.js/issues/13995