### PR TITLE
Allow consumer to strip runtime checks.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -40,8 +40,11 @@ function buildTSOptions(compilerOptions) {
 
 function buildBabelOptions(options) {
   var externalHelpers = options.shouldExternalizeHelpers || false;
+  var stripRuntimeChecks = options.stripRuntimeChecks || false;
+
   return {
     externalHelpers: externalHelpers,
+    stripRuntimeChecks: stripRuntimeChecks,
     sourceMaps: 'inline'
   };
 }


### PR DESCRIPTION
When running in glimmer itself, the runtime checks will still be present but when compiling for Ember as part of its build they will be stripped.