### PR TITLE
Use SymbolTable throughout runtime.

### DIFF
--- a/packages/glimmer-compiler/tests/compile-options-test.ts
+++ b/packages/glimmer-compiler/tests/compile-options-test.ts
@@ -15,5 +15,5 @@ QUnit.test('moduleName option is passed into meta', function() {
     env,
     moduleName
   });
-  equal(template.raw.meta.moduleName, moduleName, 'Template has the moduleName');
+  equal(template.raw.symbolTable.getMeta().moduleName, moduleName, 'Template has the moduleName');
 });

--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -44,9 +44,9 @@ export {
 } from './lib/compiler';
 
 export {
-  default as OpcodeBuilder,
-  DynamicComponentOptions,
-  StaticComponentOptions
+  ComponentBuilder,
+  StaticDefinition,
+  DynamicDefinition
 } from './lib/opcode-builder';
 
 export {
@@ -55,12 +55,9 @@ export {
 
 export {
   Block,
-  BlockOptions,
   CompiledBlock,
   Layout,
-  LayoutOptions,
   InlineBlock,
-  InlineBlockOptions,
   EntryPoint
 } from './lib/compiled/blocks';
 

--- a/packages/glimmer-runtime/lib/compiled/blocks.ts
+++ b/packages/glimmer-runtime/lib/compiled/blocks.ts
@@ -22,12 +22,12 @@ export class CompiledBlock {
 export abstract class Block {
   protected compiled: CompiledBlock = null;
 
-  constructor(public children: InlineBlock[], public program: Program, public symbolTable: SymbolTable) {}
+  constructor(public program: Program, public symbolTable: SymbolTable) {}
 }
 
 export class InlineBlock extends Block {
-  constructor(children: InlineBlock[], program: Program, symbolTable: SymbolTable, public locals: string[] = EMPTY_ARRAY) {
-    super(children, program, symbolTable);
+  constructor(program: Program, symbolTable: SymbolTable, public locals: string[] = EMPTY_ARRAY) {
+    super(program, symbolTable);
   }
 
   hasPositionalParameters(): boolean {
@@ -60,8 +60,8 @@ export class EntryPoint extends TopLevelTemplate {
 }
 
 export class Layout extends TopLevelTemplate {
-  constructor(children: InlineBlock[], program: Program, symbolTable: SymbolTable, public named: string[], public yields: string[]) {
-    super(children, program, symbolTable);
+  constructor(program: Program, symbolTable: SymbolTable, public named: string[], public yields: string[]) {
+    super(program, symbolTable);
   }
 
   hasNamedParameters(): boolean {

--- a/packages/glimmer-runtime/lib/compiled/expressions/function.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/function.ts
@@ -2,8 +2,9 @@ import { PathReference } from 'glimmer-reference';
 import { Expression as ExpressionSyntax } from '../../syntax';
 import { CompiledExpression } from '../expressions';
 import { PublicVM as VM } from '../../vm';
+import SymbolTable from '../../symbol-table';
 
-export type FunctionExpression<T> = (VM) => PathReference<T>;
+export type FunctionExpression<T> = (VM: VM, symbolTable: SymbolTable) => PathReference<T>;
 
 export default function make<T>(func: FunctionExpression<T>): ExpressionSyntax<T> {
   return new FunctionExpressionSyntax(func);
@@ -18,23 +19,22 @@ class FunctionExpressionSyntax<T> extends ExpressionSyntax<T> {
     this.func = func;
   }
 
-  compile(): CompiledExpression<T> {
-    return new CompiledFunctionExpression(this.func);
+  compile(lookup, env, symbolTable: SymbolTable): CompiledExpression<T> {
+    return new CompiledFunctionExpression(this.func, symbolTable);
   }
 }
 
 class CompiledFunctionExpression<T> extends CompiledExpression<T> {
   public type = "function";
-  private func: FunctionExpression<T>;
 
-  constructor(func: FunctionExpression<T>) {
+  constructor(private func: FunctionExpression<T>, private symbolTable: SymbolTable) {
     super();
     this.func = func;
   }
 
   evaluate(vm: VM): PathReference<T> {
-    let { func } = this;
-    return func(vm);
+    let { func, symbolTable } = this;
+    return func(vm, symbolTable);
   }
 
   toJSON(): string {

--- a/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/helper.ts
@@ -2,25 +2,20 @@ import { CompiledExpression } from '../expressions';
 import { CompiledArgs } from './args';
 import VM from '../../vm/append';
 import { Helper } from '../../environment';
+import SymbolTable from '../../symbol-table';
 import { PathReference } from 'glimmer-reference';
 import { Opaque } from 'glimmer-util';
 
 export default class CompiledHelper extends CompiledExpression<Opaque> {
   public type = "helper";
-  public name: string[];
-  public helper: Helper;
-  public args: CompiledArgs;
 
-  constructor({ name, helper, args }: { name: string[], helper: Helper, args: CompiledArgs }) {
+  constructor(public name: string[], public helper: Helper, public args: CompiledArgs, public symbolTable: SymbolTable) {
     super();
-    this.name = name;
-    this.helper = helper;
-    this.args = args;
   }
 
   evaluate(vm: VM): PathReference<Opaque> {
     let { helper } = this;
-    return helper(vm, this.args.evaluate(vm));
+    return helper(vm, this.args.evaluate(vm), this.symbolTable);
   }
 
   toJSON(): string {

--- a/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
@@ -6,18 +6,15 @@ import * as vm from './vm';
 import * as Syntax from '../../syntax/core';
 
 import { Stack, Dict, Opaque, dict } from 'glimmer-util';
-import { StatementCompilationBuffer } from '../../syntax';
+import { StatementCompilationBuffer, CompilesInto } from '../../syntax';
 import { Opcode, OpSeq } from '../../opcodes';
 import { CompiledArgs } from '../expressions/args';
 import { CompiledExpression } from '../expressions';
 import { ComponentDefinition } from '../../component/interfaces';
 import Environment from '../../environment';
-import { InlineBlock, Layout, Block } from '../blocks';
+import { InlineBlock, Layout } from '../blocks';
 import { EMPTY_ARRAY } from '../../utils';
-
-interface CompilesInto<T> {
-  compile(dsl: OpcodeBuilder, env: Environment, block: Block): T;
-}
+import SymbolTable from '../../symbol-table';
 
 type Represents<E> = CompilesInto<E> | E;
 
@@ -68,7 +65,7 @@ export abstract class BasicOpcodeBuilder extends StatementCompilationBufferProxy
   private labelsStack = new Stack<Dict<vm.LabelOpcode>>();
   private templatesStack = new Stack<Syntax.Templates>();
 
-  constructor(inner: StatementCompilationBuffer, public _block: Block, public env: Environment) {
+  constructor(inner: StatementCompilationBuffer, protected symbolTable: SymbolTable, public env: Environment) {
     super(inner);
   }
 
@@ -315,7 +312,7 @@ const SIMPLE_BLOCK: BlockArgs = { templates: null };
 export default class OpcodeBuilder extends BasicOpcodeBuilder {
   compile<E>(expr: Represents<E>): E {
     if (isCompilableExpression(expr)) {
-      return expr.compile(this, this.env, this._block);
+      return expr.compile(this, this.env, this.symbolTable);
     } else {
       return expr;
     }

--- a/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/content.ts
@@ -27,6 +27,7 @@ import { ConditionalReference } from '../../references';
 import { Args } from '../../syntax/core';
 import { Environment } from '../../environment';
 import { UpdatableBlockTracker } from '../../builder';
+import SymbolTable from '../../symbol-table';
 
 function isEmpty(value: Opaque): boolean {
   return value === null || value === undefined || typeof value['toString'] !== 'function';
@@ -108,12 +109,10 @@ export abstract class AppendOpcode<T extends Insertion> extends Opcode {
 
 export abstract class GuardedAppendOpcode<T extends Insertion> extends AppendOpcode<T> {
   protected abstract AppendOpcode: typeof OptimizedCautiousAppendOpcode | typeof OptimizedTrustingAppendOpcode;
-  private expression: CompiledExpression<any>;
   private deopted: OpSeq = null;
 
-  constructor(expression: CompiledExpression<any>) {
+  constructor(private expression: CompiledExpression<any>, private symbolTable: SymbolTable) {
     super();
-    this.expression = expression;
   }
 
   evaluate(vm: VM) {
@@ -178,7 +177,7 @@ export abstract class GuardedAppendOpcode<T extends Insertion> extends AppendOpc
     // code on the update side (scroll down for the next big block of comment).
 
     let buffer = new CompileIntoList(env, null);
-    let dsl = new OpcodeBuilderDSL(buffer, null, env);
+    let dsl = new OpcodeBuilderDSL(buffer, this.symbolTable, env);
 
     dsl.block({ templates: null }, (dsl, BEGIN, END) => {
       dsl.putValue(this.expression);

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -1,5 +1,7 @@
 import { Statement as StatementSyntax } from './syntax';
 
+import SymbolTable from './symbol-table';
+
 import * as Simple from './dom/interfaces';
 import { DOMChanges, DOMTreeConstruction } from './dom/helper';
 import { Reference, OpaqueIterable } from 'glimmer-reference';
@@ -144,11 +146,11 @@ export abstract class Environment {
     return ensureGuid(object) + '';
   }
 
-  statement(statement: StatementSyntax, blockMeta: BlockMeta): StatementSyntax {
-    return this.refineStatement(parseStatement(statement), blockMeta) || statement;
+  statement(statement: StatementSyntax, symbolTable: SymbolTable): StatementSyntax {
+    return this.refineStatement(parseStatement(statement), symbolTable) || statement;
   }
 
-  protected refineStatement(statement: ParsedStatement, blockMeta: BlockMeta): StatementSyntax {
+  protected refineStatement(statement: ParsedStatement, symbolTable: SymbolTable): StatementSyntax {
     let {
       isSimple,
       isBlock,
@@ -160,7 +162,7 @@ export abstract class Environment {
 
     if (isSimple && isInline) {
       if (key === 'partial') {
-        return new PartialSyntax({ args, blockMeta });
+        return new PartialSyntax({ args, symbolTable });
       }
     }
 
@@ -225,19 +227,19 @@ export abstract class Environment {
     return defaultChangeLists(element, attr, isTrusting, namespace);
   }
 
-  abstract hasPartial(partialName: string[], blockMeta: BlockMeta): boolean;
-  abstract lookupPartial(PartialName: string[], blockMeta: BlockMeta): PartialDefinition;
-  abstract hasComponentDefinition(tagName: string[]): boolean;
-  abstract getComponentDefinition(tagName: string[]): ComponentDefinition<Opaque>;
+  abstract hasPartial(partialName: string[], symbolTable: SymbolTable): boolean;
+  abstract lookupPartial(PartialName: string[], symbolTable: SymbolTable): PartialDefinition;
+  abstract hasComponentDefinition(tagName: string[], symbolTable: SymbolTable): boolean;
+  abstract getComponentDefinition(tagName: string[], symbolTable: SymbolTable): ComponentDefinition<Opaque>;
 
-  abstract hasModifier(modifierName: string[]): boolean;
-  abstract lookupModifier(modifierName: string[]): ModifierManager<Opaque>;
+  abstract hasModifier(modifierName: string[], blockMeta: BlockMeta): boolean;
+  abstract lookupModifier(modifierName: string[], blockMeta: BlockMeta): ModifierManager<Opaque>;
 }
 
 export default Environment;
 
 export interface Helper {
-  (vm: PublicVM, args: EvaluatedArgs): PathReference<Opaque>;
+  (vm: PublicVM, args: EvaluatedArgs, symbolTable: SymbolTable): PathReference<Opaque>;
 }
 
 export interface ParsedStatement {

--- a/packages/glimmer-runtime/lib/opcode-builder.ts
+++ b/packages/glimmer-runtime/lib/opcode-builder.ts
@@ -11,30 +11,16 @@ import {
   Templates,
 } from './syntax/core';
 
+import SymbolTable from './symbol-table';
+
 import {
   Opaque
 } from 'glimmer-util';
 
-export interface StaticComponentOptions {
-  definition: ComponentDefinition<Opaque>;
-  args: Args;
-  shadow: string[];
-  templates: Templates;
-}
+export type StaticDefinition = ComponentDefinition<Opaque>;
+export type DynamicDefinition = FunctionExpression<ComponentDefinition<Opaque>>;
 
-export interface DynamicComponentOptions {
-  definitionArgs: Args;
-  definition: FunctionExpression<ComponentDefinition<Opaque>>;
-  args: Args;
-  shadow: string[];
-  templates: Templates;
+export interface ComponentBuilder {
+  static(definition: ComponentDefinition<Opaque>, args: Args, templates: Templates, symbolTable: SymbolTable, shadow?: string[]);
+  dynamic(definitionArgs: Args, definition: DynamicDefinition, args: Args, templates: Templates, symbolTable: SymbolTable, shadow?: string[]);
 }
-
-interface OpcodeBuilder {
-  component: {
-    static(options: StaticComponentOptions);
-    dynamic(options: DynamicComponentOptions);
-  };
-}
-
-export default OpcodeBuilder;

--- a/packages/glimmer-runtime/lib/syntax.ts
+++ b/packages/glimmer-runtime/lib/syntax.ts
@@ -18,7 +18,7 @@ interface StatementClass<T extends SerializedStatement, U extends Statement> {
 }
 
 export abstract class Statement implements LinkedListNode {
-  static fromSpec<T extends SerializedStatement>(spec: T, symbolTable: SymbolTable, blocks?: InlineBlock[]): Statement {
+  static fromSpec<T extends SerializedStatement>(spec: T, symbolTable: SymbolTable, scanner?: BlockScanner): Statement {
     throw new Error(`You need to implement fromSpec on ${this}`);
   }
 

--- a/packages/glimmer-runtime/lib/syntax/builtins/partial.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/partial.ts
@@ -6,6 +6,8 @@ import {
   Statement as StatementSyntax
 } from '../../syntax';
 
+import SymbolTable from '../../symbol-table';
+
 import {
   LabelOpcode,
   EnterOpcode,
@@ -18,28 +20,23 @@ import {
   ExitOpcode
 } from '../../compiled/opcodes/vm';
 
-import {
-  BlockMeta
-} from 'glimmer-wire-format';
-
 import * as Syntax from '../core';
 import Environment from '../../environment';
-import { Block } from '../../compiled/blocks';
 
 export default class PartialSyntax extends StatementSyntax {
   type = "partial-statement";
 
   public args: Syntax.Args;
   public isStatic = false;
-  private blockMeta: BlockMeta;
+  private symbolTable: SymbolTable;
 
-  constructor({ args, blockMeta }: { args: Syntax.Args, blockMeta: BlockMeta }) {
+  constructor({ args, symbolTable }: { args: Syntax.Args, symbolTable: SymbolTable }) {
     super();
     this.args = args;
-    this.blockMeta = blockMeta;
+    this.symbolTable = symbolTable;
   }
 
-  compile(compiler: CompileInto & SymbolLookup, env: Environment, block: Block) {
+  compile(compiler: CompileInto & SymbolLookup, env: Environment, symbolTable: SymbolTable) {
 
     /*
     //        Enter(BEGIN, END)
@@ -56,22 +53,21 @@ export default class PartialSyntax extends StatementSyntax {
     assert(this.args.positional.values.length > 0, `Partial found with no arguments. You must specify a template.`);
     assert(this.args.positional.values.length < 2, `Partial found with more than one argument. You can only specify a single template.`);
 
-    let compiledPartialNameExpression = this.args.positional.values[0].compile(compiler, env, block.meta);
+    let compiledPartialNameExpression = this.args.positional.values[0].compile(compiler, env, symbolTable);
 
     let BEGIN = new LabelOpcode("BEGIN");
     let END = new LabelOpcode("END");
 
     compiler.append(new EnterOpcode({ begin: BEGIN, end: END }));
     compiler.append(BEGIN);
-    compiler.append(new PutArgsOpcode({ args: this.args.compile(compiler, env, block.meta) }));
-    compiler.append(new NameToPartialOpcode(this.blockMeta));
+    compiler.append(new PutArgsOpcode({ args: this.args.compile(compiler, env, symbolTable) }));
+    compiler.append(new NameToPartialOpcode(this.symbolTable));
     compiler.append(new TestOpcode(SimpleTest));
 
     compiler.append(new JumpUnlessOpcode({ target: END }));
     compiler.append(new EvaluatePartialOpcode({
       name: compiledPartialNameExpression,
-      symbolTable: block.symbolTable,
-      blockMeta: this.blockMeta
+      symbolTable
     }));
 
     compiler.append(END);

--- a/packages/glimmer-runtime/lib/syntax/statements.ts
+++ b/packages/glimmer-runtime/lib/syntax/statements.ts
@@ -15,6 +15,7 @@ import {
   TrustingAttr
 } from './core';
 
+import SymbolTable from '../symbol-table';
 import { InlineBlock } from '../compiled/blocks';
 import { Statement as StatementSyntax } from '../syntax';
 import {
@@ -39,16 +40,16 @@ const {
   isTrustingAttr
 } = SerializedStatements;
 
-export default function(sexp: SerializedStatement, blocks: InlineBlock[]): StatementSyntax {
+export default function(sexp: SerializedStatement, blocks: InlineBlock[], symbolTable: SymbolTable): StatementSyntax {
   if (isYield(sexp)) return Yield.fromSpec(sexp);
-  if (isBlock(sexp)) return Block.fromSpec(sexp, blocks);
+  if (isBlock(sexp)) return Block.fromSpec(sexp, symbolTable, blocks);
   if (isAppend(sexp)) return OptimizedAppend.fromSpec(sexp);
   if (isDynamicAttr(sexp)) return DynamicAttr.fromSpec(sexp);
   if (isDynamicArg(sexp)) return DynamicArg.fromSpec(sexp);
   if (isTrustingAttr(sexp)) return TrustingAttr.fromSpec(sexp);
   if (isText(sexp)) return Text.fromSpec(sexp);
   if (isComment(sexp)) return Comment.fromSpec(sexp);
-  if (isOpenElement(sexp)) return OpenElement.fromSpec(sexp);
+  if (isOpenElement(sexp)) return OpenElement.fromSpec(sexp, symbolTable);
   if (isFlushElement(sexp)) return FlushElement.fromSpec();
   if (isCloseElement(sexp)) return CloseElement.fromSpec();
   if (isStaticAttr(sexp)) return StaticAttr.fromSpec(sexp);

--- a/packages/glimmer-runtime/lib/syntax/statements.ts
+++ b/packages/glimmer-runtime/lib/syntax/statements.ts
@@ -16,12 +16,12 @@ import {
 } from './core';
 
 import SymbolTable from '../symbol-table';
-import { InlineBlock } from '../compiled/blocks';
 import { Statement as StatementSyntax } from '../syntax';
 import {
   Statements as SerializedStatements,
   Statement as SerializedStatement
 } from 'glimmer-wire-format';
+import { BlockScanner  } from '../scanner';
 
 const {
   isYield,
@@ -40,9 +40,9 @@ const {
   isTrustingAttr
 } = SerializedStatements;
 
-export default function(sexp: SerializedStatement, blocks: InlineBlock[], symbolTable: SymbolTable): StatementSyntax {
+export default function(sexp: SerializedStatement, symbolTable: SymbolTable, scanner: BlockScanner): StatementSyntax {
   if (isYield(sexp)) return Yield.fromSpec(sexp);
-  if (isBlock(sexp)) return Block.fromSpec(sexp, symbolTable, blocks);
+  if (isBlock(sexp)) return Block.fromSpec(sexp, symbolTable, scanner);
   if (isAppend(sexp)) return OptimizedAppend.fromSpec(sexp);
   if (isDynamicAttr(sexp)) return DynamicAttr.fromSpec(sexp);
   if (isDynamicArg(sexp)) return DynamicArg.fromSpec(sexp);

--- a/packages/glimmer-runtime/lib/utils.ts
+++ b/packages/glimmer-runtime/lib/utils.ts
@@ -1,7 +1,7 @@
 import { dict } from 'glimmer-util';
 
-export const EMPTY_ARRAY = [];
-export const EMPTY_DICT = dict<any>();
+export const EMPTY_ARRAY = Object.freeze([]);
+export const EMPTY_DICT = Object.freeze(dict<any>());
 
 export function turbocharge(object: Object): Object {
   // function Constructor() {}

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -510,7 +510,6 @@ testComponent('yielding to an non-existent block', {
 });
 
 testComponent('yield', {
-  skip: 'glimmer',
   layout: '{{#if @predicate}}Yes:{{yield @someValue}}{{else}}No:{{yield to="inverse"}}{{/if}}',
 
   invokeAs: {
@@ -2817,7 +2816,7 @@ QUnit.test('deeply nested destructions', function(assert) {
   env.registerEmberishGlimmerComponent('destroy-me1', DestroyMe1Component as any, '<div>{{#destroy-me2 item=@item from="destroy-me1"}}{{yield}}{{/destroy-me2}}</div>');
   env.registerEmberishCurlyComponent('destroy-me2', DestroyMe2Component as any, 'Destroy me! {{yield}}');
 
-  appendViewFor(`{{#each list key='@primitive' as |item|}}<destroy-me1 item={{item}}>{{#destroy-me2 from="root" item=item}}{{/destroy-me2}}</destroy-me1>{{/each}}`, { list: [1,2,3,4,5] });
+  appendViewFor(`{{#each list key='@primitive' as |item|}}<destroy-me1 @item={{item}}>{{#destroy-me2 from="root" item=item}}{{/destroy-me2}}</destroy-me1>{{/each}}`, { list: [1,2,3,4,5] });
 
   assert.strictEqual(destroyed.length, 0, 'destroy should not be called');
 

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -1049,6 +1049,76 @@ testComponent('correct scope - conflicting block param and attr names', {
   expected: 'Outer: from attr Inner: from attr Block: from block'
 });
 
+QUnit.test('correct scope - accessing local variable in yielded block (glimmer component)', assert => {
+  class FooBar extends BasicComponent {}
+
+  env.registerBasicComponent('foo-bar', FooBar, `[Layout: {{zomg}}][Layout: {{lol}}][Layout: {{@foo}}]{{yield}}`);
+
+  appendViewFor(
+    stripTight`
+      <div>
+        [Outside: {{zomg}}]
+        {{#with zomg as |lol|}}
+          [Inside: {{zomg}}]
+          [Inside: {{lol}}]
+          <foo-bar @foo={{zomg}}>
+            [Block: {{zomg}}]
+            [Block: {{lol}}]
+          </foo-bar>
+        {{/with}}
+      </div>`,
+    { zomg: "zomg" }
+  );
+
+  equalsElement(view.element, 'div', {},
+      stripTight`
+        [Outside: zomg]
+        [Inside: zomg]
+        [Inside: zomg]
+        [Layout: ]
+        [Layout: ]
+        [Layout: zomg]
+        [Block: zomg]
+        [Block: zomg]`
+  );
+});
+
+QUnit.test('correct scope - accessing local variable in yielded block (curly component)', assert => {
+  class FooBar extends EmberishCurlyComponent {
+    public tagName = '';
+  }
+
+  env.registerEmberishCurlyComponent('foo-bar', FooBar, `[Layout: {{zomg}}][Layout: {{lol}}][Layout: {{foo}}]{{yield}}`);
+
+  appendViewFor(
+    stripTight`
+      <div>
+        [Outside: {{zomg}}]
+        {{#with zomg as |lol|}}
+          [Inside: {{zomg}}]
+          [Inside: {{lol}}]
+          {{#foo-bar foo=zomg}}
+            [Block: {{zomg}}]
+            [Block: {{lol}}]
+          {{/foo-bar}}
+        {{/with}}
+      </div>`,
+    { zomg: "zomg" }
+  );
+
+  equalsElement(view.element, 'div', {},
+      stripTight`
+        [Outside: zomg]
+        [Inside: zomg]
+        [Inside: zomg]
+        [Layout: ]
+        [Layout: ]
+        [Layout: zomg]
+        [Block: zomg]
+        [Block: zomg]`
+  );
+});
+
 QUnit.test('correct scope - self', assert => {
   class FooBar extends BasicComponent {
     public foo = 'foo';

--- a/packages/glimmer-wire-format/index.ts
+++ b/packages/glimmer-wire-format/index.ts
@@ -150,16 +150,14 @@ export interface BlockMeta {
   moduleName?: string;
 }
 
-export interface SerializedTemplate {
+export interface SerializedBlock {
   statements: Statements.Statement[];
   locals: string[];
+}
+
+export interface SerializedTemplate extends SerializedBlock {
   named: string[];
   yields: string[];
   blocks: SerializedBlock[];
   meta: BlockMeta;
-}
-
-export interface SerializedBlock {
-  statements: Statements.Statement[];
-  locals: string[];
 }


### PR DESCRIPTION
The SymbolTable conceptually represents the static semtantics of a particular piece of Handlebars code. Previously, we passed around blocks, block metas, symbol tables, etc. interchangably, on an as-needed basis.

This commit attempts to reliably pass around SymbolTable whenever static information for a block is needed.

Note that BlockMeta, which is static information supplied by a host environment compiler, is part of this static information, and is now accessed using symbolTable.getMeta().

Also note that there are a number of places that were cheating in various ways to avoid appearing to need the static information, and that is cleaned up in this commit.