### PR TITLE
Remove unused “keyword” feature

### DIFF
--- a/packages/glimmer-runtime/lib/compiled/expressions/ref.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/ref.ts
@@ -33,33 +33,6 @@ export abstract class CompiledSymbolRef extends CompiledExpression<any> {
   }
 }
 
-export class CompiledKeywordRef {
-  public type = "keyword-ref";
-  public name: string;
-  public path: string[];
-
-  constructor({ name, path }: { name: string, path: string[] }) {
-    this.name = name;
-    this.path = path;
-  }
-
-  evaluate(vm: VM): PathReference<any> {
-    let base = vm.dynamicScope()[this.name] as PathReference<any>;;
-    return referenceFromParts(base, this.path);
-  }
-
-  toJSON(): string {
-    let { name, path } = this;
-
-    if (path.length) {
-      return `$KEYWORDS[${name}].${path.join('.')}`;
-    } else {
-      return `$KEYWORDS[${name}]`;
-    }
-  }
-
-}
-
 export class CompiledLocalRef extends CompiledSymbolRef {
   public type = "local-ref";
 

--- a/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
@@ -62,11 +62,6 @@ class StatementCompilationBufferProxy implements StatementCompilationBuffer {
   hasBlockSymbol(name: string): boolean {
     return this.inner.hasBlockSymbol(name);
   }
-
-  // only used for {{view.name}}
-  hasKeyword(name: string): boolean {
-    return this.inner.hasKeyword(name);
-  }
 }
 
 export abstract class BasicOpcodeBuilder extends StatementCompilationBufferProxy {

--- a/packages/glimmer-runtime/lib/compiler.ts
+++ b/packages/glimmer-runtime/lib/compiler.ts
@@ -459,10 +459,6 @@ export class CompileIntoList extends LinkedList<Opcode> implements OpcodeBuilder
     return typeof this.block.symbolTable.getYield(name) === 'number';
   }
 
-  hasKeyword(name: string): boolean {
-    return this.env.hasKeyword(name);
-  }
-
   toOpSeq(): OpSeq {
     return this;
   }

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -218,10 +218,6 @@ export abstract class Environment {
     }
   }
 
-  hasKeyword(string: string): boolean {
-    return false;
-  }
-
   abstract hasHelper(helperName: string[], blockMeta: BlockMeta): boolean;
   abstract lookupHelper(helperName: string[], blockMeta: BlockMeta): Helper;
 

--- a/packages/glimmer-runtime/lib/syntax.ts
+++ b/packages/glimmer-runtime/lib/syntax.ts
@@ -60,9 +60,6 @@ export interface SymbolLookup {
   hasNamedSymbol(name: string): boolean;
   getBlockSymbol(name: string): number;
   hasBlockSymbol(name: string): boolean;
-
-  // only used for {{view.name}}
-  hasKeyword(name: string): boolean;
 }
 
 export interface CompileInto {

--- a/packages/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/glimmer-runtime/lib/syntax/core.ts
@@ -53,7 +53,6 @@ import CompiledValue from '../compiled/expressions/value';
 
 import {
   CompiledLocalRef,
-  CompiledKeywordRef,
   CompiledSelfRef
 } from '../compiled/expressions/ref';
 
@@ -866,9 +865,7 @@ export class Ref extends ExpressionSyntax<Opaque> {
     let head = parts[0];
     let path = parts.slice(1);
 
-    if (lookup.hasKeyword(head)) {
-      return new CompiledKeywordRef({ name: head, path });
-    } if (lookup.hasLocalSymbol(head)) {
+    if (lookup.hasLocalSymbol(head)) {
       let symbol = lookup.getLocalSymbol(head);
       return new CompiledLocalRef({ debug: head, symbol, path });
     } else {

--- a/packages/glimmer-runtime/tests/updating-test.ts
+++ b/packages/glimmer-runtime/tests/updating-test.ts
@@ -637,30 +637,6 @@ test("helpers can add destroyables", assert => {
   strictEqual(destroyable.count, 1, 'is destroyed');
 });
 
-test("dynamically scoped keywords can be passed to render, and used in curlies", assert => {
-  let template = compile("{{view.name}}");
-  let view = { name: 'Godfrey' };
-  let viewRef = new UpdatableReference(view);
-
-  render(template, {}, viewRef);
-
-  equalTokens(root, 'Godfrey', "Initial render");
-
-  rerender();
-
-  equalTokens(root, 'Godfrey', "Noop rerender");
-
-  view.name = 'Godhuda';
-  rerender();
-
-  equalTokens(root, 'Godhuda', "Update with mutation");
-
-  viewRef.update({ name: 'Godfrey' });
-  rerender();
-
-  equalTokens(root, 'Godfrey', "Reset with replacement");
-});
-
 test("updating a curly with this", () => {
   let object = { value: 'hello world' };
   let template = compile('<div><p>{{this.value}}</p></div>');
@@ -679,67 +655,6 @@ test("updating a curly with this", () => {
 
   equalTokens(root, '<div><p>goodbye world</p></div>', "After updating and dirtying");
   strictEqual(root.firstChild.firstChild.firstChild, valueNode, "The text node was not blown away");
-});
-
-test("changing dynamic scope", assert => {
-  let template = compile("{{view.name}} {{#with-keywords view=innerView}}{{view.name}}{{/with-keywords}} {{view.name}}");
-  let view = { name: 'Godfrey' };
-  let viewRef = new UpdatableReference(view);
-  let innerView = { name: 'Yehuda' };
-
-  render(template, { innerView }, viewRef);
-
-  equalTokens(root, 'Godfrey Yehuda Godfrey', "Initial render");
-
-  rerender();
-
-  equalTokens(root, 'Godfrey Yehuda Godfrey', "Noop rerender");
-
-  innerView.name = 'Tom';
-  rerender();
-
-  equalTokens(root, 'Godfrey Tom Godfrey', "Update with mutation");
-
-  view.name = 'Godhuda';
-  rerender();
-
-  equalTokens(root, 'Godhuda Tom Godhuda', "Update with mutation");
-
-  self.update({ innerView: { name: 'Yehuda' } });
-  viewRef.update({ name: 'Godfrey' });
-  rerender();
-
-  equalTokens(root, 'Godfrey Yehuda Godfrey', "Reset with replacement");
-});
-
-test("changing dynamic scope derived from another keyword from the outer scope", assert => {
-  let template = compile("{{view.name}} {{#with-keywords view=view.innerView}}{{view.name}}{{/with-keywords}} {{view.name}}");
-  let innerView = { name: 'Yehuda' };
-  let view = { name: 'Godfrey', innerView };
-  let viewRef = new UpdatableReference(view);
-
-  render(template, { innerView }, viewRef);
-
-  equalTokens(root, 'Godfrey Yehuda Godfrey', "Initial render");
-
-  rerender();
-
-  equalTokens(root, 'Godfrey Yehuda Godfrey', "Noop rerender");
-
-  innerView.name = 'Tom';
-  rerender();
-
-  equalTokens(root, 'Godfrey Tom Godfrey', "Update with mutation");
-
-  view.name = 'Godhuda';
-  rerender();
-
-  equalTokens(root, 'Godhuda Tom Godhuda', "Update with mutation");
-
-  viewRef.update({ name: 'Godfrey', innerView: { name: 'Yehuda' } });
-  rerender();
-
-  equalTokens(root, 'Godfrey Yehuda Godfrey', "Reset with replacement");
 });
 
 test("a simple implementation of a dirtying rerender", function() {

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -793,8 +793,6 @@ export class TestEnvironment extends Environment {
           return new IdentitySyntax({ args, templates });
         case 'render-inverse':
           return new RenderInverseIdentitySyntax({ args, templates });
-        case 'with-keywords':
-          return new WithKeywordsSyntax({ args, templates });
       }
     }
 
@@ -872,10 +870,6 @@ export class TestEnvironment extends Environment {
 
   compileLayout(template: string) {
     return rawCompileLayout(template, { env: this });
-  }
-
-  hasKeyword(name: string): boolean {
-    return name === 'view';
   }
 
   iterableFor(ref: Reference<Opaque>, args: EvaluatedArgs): OpaqueIterable {
@@ -1177,39 +1171,6 @@ class RenderInverseIdentitySyntax extends StatementSyntax {
 
   compile(dsl: OpcodeBuilderDSL) {
     dsl.evaluate('inverse', this.templates.inverse);
-  }
-}
-
-class WithKeywordsSyntax extends StatementSyntax {
-  type = "with-keywords";
-
-  public args: ArgsSyntax;
-  public templates: Templates;
-
-  constructor({ args, templates }: { args: ArgsSyntax, templates: Templates }) {
-    super();
-    this.args = args;
-    this.templates = templates;
-  }
-
-  compile(dsl: OpcodeBuilderDSL, env: Environment) {
-    let callback = (_vm: VM, _scope: DynamicScope) => {
-      let vm = _vm as any;
-      let scope = _scope as any as TestDynamicScope;
-
-      let args: EvaluatedArgs = vm.frame.getArgs();
-
-      scope.set(args.named.map);
-    };
-
-    let { args, templates } = this;
-
-    dsl.unit({ templates }, dsl => {
-      dsl.putArgs(args);
-      dsl.setupDynamicScope(callback);
-      dsl.evaluate('default');
-      dsl.popDynamicScope();
-    });
   }
 }
 


### PR DESCRIPTION
This was added for Ember to support the legacy {{view}} keyword, but we didn’t end up using it.