### PR TITLE
Exporting NodeDOMTreeConstruction via glimmer-node's entry point

### DIFF
--- a/packages/glimmer-node/index.ts
+++ b/packages/glimmer-node/index.ts
@@ -1,0 +1,1 @@
+export { default as NodeDOMTreeConstruction } from './lib/node-dom-helper';


### PR DESCRIPTION
**Description**

Exporting glimmer-node module to enable ember-glimmer to import it for use in setup-registry.

**Status**

Ready to merge

**Changes**

- Exported `NodeDOMTreeConstruction` in gimmer-node/index.ts

**How to test this PR**

- run `npm test`
- run `node bin/run-node-tests.js`