### PR TITLE
Ensure NodeDOMTreeConstruction can be instantiated without a document.

### DIFF
--- a/bin/run-node-tests.js
+++ b/bin/run-node-tests.js
@@ -4,7 +4,13 @@ var QUnit = global.QUnit = require('qunitjs');
 var path = require('path');
 var glob = require('glob');
 var qunitTap = require('qunit-tap');
-qunitTap(QUnit, function() { console.log.apply(console, arguments); });
+var tap = qunitTap(QUnit, function() { console.log.apply(console, arguments); });
+
+tap.done = function(results) {
+  if (results.failed) {
+    process.exit(1);
+  }
+}
 
 glob.sync('./dist/node_modules/glimmer-node/tests/**/*-test.js').forEach(function(file) {
   require(path.resolve(file));

--- a/packages/glimmer-node/lib/node-dom-helper.ts
+++ b/packages/glimmer-node/lib/node-dom-helper.ts
@@ -8,6 +8,9 @@ export default class NodeDOMTreeConstruction extends DOMTreeConstruction {
     super(doc);
   }
 
+  // override to prevent usage of `this.document` until after the constructor
+  protected setupUselessElement() { }
+
   insertHTMLBefore(parent: Simple.Element, html: string, reference: Simple.Node): Bounds {
     let prev = reference ? reference.previousSibling : parent.lastChild;
 

--- a/packages/glimmer-node/tests/node-test.ts
+++ b/packages/glimmer-node/tests/node-test.ts
@@ -231,3 +231,11 @@ QUnit.test("A simple block helper can return text", function(assert) {
   render(template, {});
   assert.equal(serializer.serialize(root), '<div>test</div>');
 });
+
+QUnit.test('can instantiate NodeDOMTreeConstruction without a document', function(assert) {
+  // this emulates what happens in Ember when using `App.visit('/', { shouldRender: false });`
+
+  helper = new NodeDOMTreeConstruction(null);
+
+  assert.ok(!!helper, 'helper was instantiated without errors');
+});

--- a/packages/glimmer-node/tests/node-test.ts
+++ b/packages/glimmer-node/tests/node-test.ts
@@ -73,10 +73,10 @@ QUnit.test("HTML tags re-rendered", function(assert) {
 });
 
 QUnit.test("HTML attributes", function(assert) {
-  let template = compile("<div class='foo' id='bar'>content</div>");
+  let template = compile("<div id='bar' class='foo'>content</div>");
   render(template, {});
 
-  assert.equal(serializer.serializeChildren(root), '<div class="foo" id="bar">content</div>');
+  assert.equal(serializer.serializeChildren(root), '<div id="bar" class="foo">content</div>');
 });
 
 QUnit.test("HTML tag with empty attribute", function(assert) {

--- a/packages/glimmer-runtime/lib/dom/helper.ts
+++ b/packages/glimmer-runtime/lib/dom/helper.ts
@@ -64,9 +64,13 @@ namespace DOM {
   type HTMLElement = Simple.HTMLElement;
 
   class TreeConstruction {
-    protected uselessElement: HTMLElement;
+    protected uselessElement: HTMLElement = null;
     constructor(protected document: Document) {
-      this.uselessElement = document.createElement('div');
+      this.setupUselessElement();
+    }
+
+    protected setupUselessElement() {
+      this.uselessElement = this.document.createElement('div');
     }
 
     createElement(tag: string, context?: Element): Element {
@@ -126,16 +130,12 @@ namespace DOM {
 }
 
 export class DOMChanges {
-  protected document: HTMLDocument;
   protected namespace: string;
-  private uselessElement: HTMLElement;
-  private uselessAnchor: HTMLAnchorElement;
+  private uselessElement: HTMLElement = null;
 
-  constructor(document: Document) {
-    this.document = document;
+  constructor(protected document: HTMLDocument) {
     this.namespace = null;
     this.uselessElement = this.document.createElement('div');
-    this.uselessAnchor = this.document.createElement('a');
   }
 
   setAttribute(element: Simple.Element, name: string, value: string) {


### PR DESCRIPTION
When using Ember's `visit` API, it is possible to request that no rendering be performed (via the `shouldRender` option). When this happens in the browser the `DOMTreeConstruction` object still gets a `document` passed in (because it is availble via the ambient global), however when running in node the visit options would not include a "fake document" (aka `SimpleDOM` document) and therefore the instantiation of `new NodeDOMTreeConstruction(null)` would fail.

This change adds an additional method to the `DOMTreeConstruction` class that can be overridden to make usage of the provided `document` lazy. This does not change the behavior when using `DOMTreeConstruction` (the `this.uselessElement` is still setup in the constructor), but it enables the subclass that we use in Node-land to make things work properly.