### PR TITLE
Add meta to compiled template

### DIFF
--- a/packages/glimmer-compiler/lib/compiler.ts
+++ b/packages/glimmer-compiler/lib/compiler.ts
@@ -1,7 +1,13 @@
 import { preprocess } from "glimmer-syntax";
+import { BlockMeta } from "glimmer-wire-format";
 import TemplateCompiler from "./template-compiler";
 
-export type TemplateSpec = string;
+export type TemplateProgram = string;
+
+export type TemplateSpec = {
+  meta: BlockMeta;
+  template: TemplateProgram;
+}
 
 /*
  * Compile a string into a template spec string. The template spec is a string
@@ -19,7 +25,11 @@ export type TemplateSpec = string;
  * @return {TemplateSpec} A template spec string
  */
 export function compileSpec(string: string, options: any): TemplateSpec {
+  let meta: BlockMeta = typeof options === 'object' ? options.meta : {};
   let ast = preprocess(string, options);
   let program = TemplateCompiler.compile(options, ast);
-  return JSON.stringify(program);
+  return {
+    meta,
+    template: JSON.stringify(program)
+  };
 }

--- a/packages/glimmer-compiler/lib/template-compiler.ts
+++ b/packages/glimmer-compiler/lib/template-compiler.ts
@@ -6,7 +6,7 @@ import { assert } from "glimmer-util";
 
 export interface CompileOptions {
   buildMeta?: FIXME<Object, 'currently does nothing'>;
-  moduleName?: string;
+  meta?: Object;
 }
 
 function isTrustedValue(value) {
@@ -20,10 +20,7 @@ export default class TemplateCompiler {
 
     let compiler = new TemplateCompiler(options);
     let opcodes = compiler.process(templateVisitor.actions);
-    let meta = {
-      moduleName: options.moduleName
-    };
-    return JavaScriptCompiler.process(opcodes, meta);
+    return JavaScriptCompiler.process(opcodes, options.meta);
   }
 
   private options: CompileOptions;

--- a/packages/glimmer-compiler/tests/compile-options-test.ts
+++ b/packages/glimmer-compiler/tests/compile-options-test.ts
@@ -1,5 +1,6 @@
 import { compile } from "glimmer-test-helpers";
 import { TestEnvironment } from "glimmer-test-helpers";
+import { compileSpec } from "glimmer-compiler";
 
 let env: TestEnvironment;
 
@@ -13,7 +14,27 @@ QUnit.test('moduleName option is passed into meta', function() {
   let moduleName = 'It ain\'t hard to tell';
   let template = compile('Hi, {{name}}!', {
     env,
-    moduleName
+    meta: {
+      moduleName
+    }
   });
   equal(template.raw.symbolTable.getMeta().moduleName, moduleName, 'Template has the moduleName');
+});
+
+QUnit.module('compileSpec', {
+  setup() {
+    env = new TestEnvironment();
+  }
+});
+
+QUnit.test('returned meta is correct', function() {
+  let wire = compileSpec('Hi, {{name}}!', {
+    meta: {
+      moduleName: 'my/module-name',
+      metaIsOpaque: 'yes'
+    }
+  });
+
+  equal(wire.meta.moduleName, 'my/module-name', 'Template has correct meta');
+  equal((<any>wire.meta).metaIsOpaque, 'yes', 'Template has correct meta');
 });

--- a/packages/glimmer-demos/lib/visualizer.ts
+++ b/packages/glimmer-demos/lib/visualizer.ts
@@ -404,11 +404,11 @@ function renderContent() {
   ui.rendered = true;
 
   ui.template.source = $template.value;
-  ui.template.wireFormat = JSON.parse(compileSpec($template.value, {}));
+  ui.template.wireFormat = compileSpec($template.value, {}).template;
   ui.template.opcodes = toJSON(eagerCompile(templateOps));
 
   ui.layout.source = $layout.value;
-  ui.layout.wireFormat = JSON.parse(compileSpec($layout.value, {}));
+  ui.layout.wireFormat = compileSpec($template.value, {}).template;
   ui.layout.opcodes = toJSON(eagerCompile(layoutOps));
 
   ui.updatingOpcodes = toJSON(res['updating']);

--- a/packages/glimmer-test-helpers/lib/helpers.ts
+++ b/packages/glimmer-test-helpers/lib/helpers.ts
@@ -76,7 +76,7 @@ export function compileRealSpec(string: string, options: TestCompileOptions): Se
 }
 
 export function template(templateSpec: TemplateSpec): SerializedTemplate {
-  return JSON.parse(templateSpec);
+  return JSON.parse(templateSpec.template);
 }
 
 export function equalInnerHTML(fragment, html, msg?) {


### PR DESCRIPTION
Enables looking up the template meta without having to evaluate the actual template. This is a backwards incompatible change that will require changes in places like [here](https://github.com/emberjs/ember.js/blob/01110cb48f224790e717a15a0e5525e793ec5e23/packages/ember-glimmer/lib/template.js#L38-L49).

cc @krisselden @rwjblue 