### PR TITLE
Pass caller's self to component manager's create.

### DIFF
--- a/packages/glimmer-demos/lib/visualizer.ts
+++ b/packages/glimmer-demos/lib/visualizer.ts
@@ -3,7 +3,6 @@ import {
   TestDynamicScope
 } from 'glimmer-test-helpers';
 import { UpdatableReference } from 'glimmer-object-reference';
-
 import { compileSpec } from 'glimmer-compiler';
 
 import { EvaluatedArgs } from 'glimmer-runtime';
@@ -372,7 +371,7 @@ function renderContent() {
     let definition = env.getComponentDefinition([component]);
 
     let manager = definition.manager;
-    let instance = manager.create(definition, EvaluatedArgs.empty(), new TestDynamicScope(), false);
+    let instance = manager.create(env, definition, EvaluatedArgs.empty(), new TestDynamicScope(), null, false);
     let compiled = manager.layoutFor(definition, instance, env);
 
     return compiled.ops;

--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -53,16 +53,16 @@ export class OpenComponentOpcode extends Opcode {
 
     let definition = vm.frame.getComponentDefinition();
     let dynamicScope = vm.pushDynamicScope();
+    let callerScope = vm.scope();
 
     let manager = definition.manager;
     let hasDefaultBlock = templates && !!templates.default; // TODO Cleanup?
     let args = manager.prepareArgs(definition, rawArgs.evaluate(vm));
-    let component = manager.create(definition, args, dynamicScope, hasDefaultBlock);
+    let component = manager.create(vm.env, definition, args, dynamicScope, vm.getSelf(), hasDefaultBlock);
     let destructor = manager.getDestructor(component);
     if (destructor) vm.newDestroyable(destructor);
 
     let layout = manager.layoutFor(definition, component, vm.env);
-    let callerScope = vm.scope();
     let selfRef = manager.getSelf(component);
 
     vm.beginCacheGroup();

--- a/packages/glimmer-runtime/lib/component/interfaces.ts
+++ b/packages/glimmer-runtime/lib/component/interfaces.ts
@@ -23,7 +23,7 @@ export interface ComponentManager<T extends Component> {
   // Then, the component manager is asked to create a bucket of state for
   // the supplied arguments. From the perspective of Glimmer, this is
   // an opaque token, but in practice it is probably a component object.
-  create(definition: ComponentDefinition<T>, args: EvaluatedArgs, dynamicScope: DynamicScope, hasDefaultBlock: boolean): T;
+  create(env: Environment, definition: ComponentDefinition<T>, args: EvaluatedArgs, dynamicScope: DynamicScope, caller: PathReference<Opaque>, hasDefaultBlock: boolean): T;
 
   // Return the compiled layout to use for this component. This is called
   // *after* the component instance has been created, because you might

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -292,7 +292,7 @@ class BasicComponentManager implements ComponentManager<BasicComponent> {
     return args;
   }
 
-  create(definition: BasicComponentDefinition, args: EvaluatedArgs): BasicComponent {
+  create(environment: Environment, definition: BasicComponentDefinition, args: EvaluatedArgs): BasicComponent {
     let klass = definition.ComponentClass || BasicComponent;
     return new klass(args.named.value());
   }
@@ -361,7 +361,7 @@ class EmberishGlimmerComponentManager implements ComponentManager<EmberishGlimme
     return args;
   }
 
-  create(definition: EmberishGlimmerComponentDefinition, args: EvaluatedArgs, dynamicScope, hasDefaultBlock: boolean): EmberishGlimmerComponent {
+  create(environment: Environment, definition: EmberishGlimmerComponentDefinition, args: EvaluatedArgs, dynamicScope, callerSelf: PathReference<Opaque>, hasDefaultBlock: boolean): EmberishGlimmerComponent {
     let klass = definition.ComponentClass || BaseEmberishGlimmerComponent;
     let attrs = args.named.value();
     let component = klass.create({ attrs });
@@ -472,11 +472,12 @@ class EmberishCurlyComponentManager implements ComponentManager<EmberishCurlyCom
     return args;
   }
 
-  create(definition: EmberishCurlyComponentDefinition, args: EvaluatedArgs): EmberishCurlyComponent {
+  create(environment: Environment, definition: EmberishCurlyComponentDefinition, args: EvaluatedArgs, dynamicScope: DynamicScope, callerSelf: PathReference<Opaque>): EmberishCurlyComponent {
     let klass = definition.ComponentClass || BaseEmberishCurlyComponent;
     let processedArgs = processArgs(args, klass['positionalParams']);
     let { attrs } = processedArgs.value();
-    let merged = assign({}, attrs, { attrs }, { args: processedArgs });
+    let self = callerSelf.value();
+    let merged = assign({}, attrs, { attrs }, { args: processedArgs }, { targetObject: self });
     let component = klass.create(merged);
 
     component.didInitAttrs({ attrs });
@@ -1015,7 +1016,7 @@ class StaticTaglessComponentDefinition extends GenericComponentDefinition<BasicC
 
 interface EmberishCurlyComponentFactory {
   positionalParams?: string[];
-  create(options: { attrs: Attrs }): EmberishCurlyComponent;
+  create(options: { attrs: Attrs, targetObject }): EmberishCurlyComponent;
 }
 
 class EmberishCurlyComponentDefinition extends GenericComponentDefinition<EmberishCurlyComponent> {

--- a/packages/glimmer-util/lib/object-utils.ts
+++ b/packages/glimmer-util/lib/object-utils.ts
@@ -11,6 +11,10 @@ export function merge(options, defaults) {
 export function assign<T, U>(obj: T, assignments: U): T & U;
 export function assign<T, U, V>(obj: T, a: U, b: V): T & U & V;
 export function assign<T, U, V, W>(obj: T, a: U, b: V, c: W): T & U & V & W;
+export function assign<T, U, V, W, X>(obj: T, a: U, b: V, c: W, d: X): T & U & V & W & X;
+export function assign<T, U, V, W, X, Y>(obj: T, a: U, b: V, c: W, d: X, e: Y): T & U & V & W & X & Y;
+export function assign<T, U, V, W, X, Y, Z>(obj: T, a: U, b: V, c: W, d: X, e: Y, f: Z): T & U & V & W & X & Y & Z;
+export function assign(target: any, ...sources: any[]): any;
 
 export function assign(obj, ...assignments) {
   return assignments.reduce((obj, extensions) => {


### PR DESCRIPTION
In Ember we are only using `dynamicScope` (since that is all that is exposed), but the current `{{this}}` (aka `self`)  is also needed to allow  us to properly target actions to their calling context.

The `dynamicScope` tracks the direct component heirarchy without regard to blocks/yielding etc. This is a perfect analogue to the way Ember tracks `.parentView` through a component structure.

The caller self tracks the current calling context. This means it is aware of blocks yielding (which changes the `self` in the yielded block), and is the correct analogue to the way Ember tracks the target of any actions within a template block.

For example, given:

```hbs
{{#component-a}}
  {{component-b bar="bar"}}
{{/component-a}}
```

From within `component-b` the `.parentView` (derived from `dynamicScope`) should match `component-a`, but the `targetObject` of `component-b` should not be `component-a` (since `component-a` is not calling it).

This change allows us to completely remove the manual `DynamicScope#targetObject` tracking in Ember.

---

I also considered changing `DynamicScope#child` to accept the `callerScope` which would have let us calculate the proper `targetObject` in Ember, but it seems that calling context is directly related to `ComponentManager#create` (and completely unrelated to `DynamicScope`).