### PR TITLE
Prevent accidentally pushing into queues after `commit`.

### DIFF
--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -216,6 +216,12 @@ export abstract class Environment {
     for (let i=0; i<this.destructors.length; i++) {
       this.destructors[i].destroy();
     }
+
+    this.createdComponents = null;
+    this.createdManagers = null;
+    this.updatedComponents = null;
+    this.updatedManagers = null;
+    this.destructors = null;
   }
 
   abstract hasHelper(helperName: string[], blockMeta: BlockMeta): boolean;


### PR DESCRIPTION
Resetting these to `null` ensures that anyone trying to enqueue outside of a `env.begin()` / `env.commit()` transaction get an error instead of silently "eating" the queued items.