### PR TITLE
Fix component hooks

### DIFF
--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -6,7 +6,7 @@ import { CompiledArgs, EvaluatedArgs } from '../../compiled/expressions/args';
 import { Templates } from '../../syntax/core';
 import { DynamicScope } from '../../environment';
 import Bounds from '../../bounds';
-import { CONSTANT_TAG, PathReference, ReferenceCache, Revision, combine, isConst } from 'glimmer-reference';
+import { CONSTANT_TAG, PathReference, ReferenceCache, combine, isConst } from 'glimmer-reference';
 import { FIXME } from 'glimmer-util';
 
 export class PutDynamicComponentDefinitionOpcode extends Opcode {
@@ -78,8 +78,6 @@ export class OpenComponentOpcode extends Opcode {
 export class UpdateComponentOpcode extends UpdatingOpcode {
   public type = "update-component";
 
-  private lastUpdated: Revision;
-
   constructor(
     private name: string,
     private component: Component,
@@ -89,26 +87,20 @@ export class UpdateComponentOpcode extends UpdatingOpcode {
   ) {
     super();
 
-    let tag;
     let componentTag = manager.getTag(component);
 
     if (componentTag) {
-      tag = this.tag = combine([args.tag, componentTag]);
+      this.tag = combine([args.tag, componentTag]);
     } else {
-      tag = this.tag = args.tag;
+      this.tag = args.tag;
     }
-
-    this.lastUpdated = tag.value();
   }
 
   evaluate(vm: UpdatingVM) {
-    let { component, manager, tag, args, dynamicScope, lastUpdated } = this;
+    let { component, manager, args, dynamicScope } = this;
 
-    if (!tag.validate(lastUpdated)) {
-      manager.update(component, args, dynamicScope);
-      vm.env.didUpdate(component, manager);
-      this.lastUpdated = tag.value();
-    }
+    manager.update(component, args, dynamicScope);
+    vm.env.didUpdate(component, manager);
   }
 
   toJSON(): OpcodeJSON {

--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -69,7 +69,6 @@ export class OpenComponentOpcode extends Opcode {
     vm.stack().pushSimpleBlock();
     vm.pushRootScope(selfRef, layout.symbols);
     vm.invokeLayout(args, layout, templates, callerScope, component, manager, shadow);
-    vm.env.didCreate(component, manager);
 
     vm.updateWith(new UpdateComponentOpcode(definition.name, component, manager, args, dynamicScope));
   }
@@ -100,7 +99,6 @@ export class UpdateComponentOpcode extends UpdatingOpcode {
     let { component, manager, args, dynamicScope } = this;
 
     manager.update(component, args, dynamicScope);
-    vm.env.didUpdate(component, manager);
   }
 
   toJSON(): OpcodeJSON {
@@ -167,6 +165,8 @@ export class DidRenderLayoutOpcode extends Opcode {
 
     manager.didRenderLayout(component, bounds);
 
+    vm.env.didCreate(component, manager);
+
     vm.updateWith(new DidUpdateLayoutOpcode(manager, component, bounds));
   }
 }
@@ -183,9 +183,12 @@ export class DidUpdateLayoutOpcode extends UpdatingOpcode {
     super();
   }
 
-  evaluate() {
+  evaluate(vm: UpdatingVM) {
     let { manager, component, bounds } = this;
+
     manager.didUpdateLayout(component, bounds);
+
+    vm.env.didUpdate(component, manager);
   }
 }
 

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -207,7 +207,7 @@ export abstract class Environment {
       manager.didCreate(component);
     }
 
-    for (let i=this.updatedComponents.length-1; i>=0; i--) {
+    for (let i=0; i<this.updatedComponents.length; i++) {
       let component = this.updatedComponents[i];
       let manager = this.updatedManagers[i];
       manager.didUpdate(component);

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -1059,8 +1059,8 @@ QUnit.test('dynamic attribute bindings', assert => {
     attributeBindings = ['style'];
     style: string = null;
 
-    constructor() {
-      super();
+    constructor(attrs) {
+      super(attrs);
       this.style = 'color: red;';
       fooBarInstance = this;
     }


### PR DESCRIPTION
This is required to fix component hooks in Ember:

1. `ComponentManager#{update,didUpdate}` always fire when re-rendering a subtree (see https://github.com/emberjs/ember.js/issues/13947)
2. Async hooks are queued and executed in "post-order": firstChild -> secondChild -> lastChild -> parent (see https://github.com/emberjs/ember.js/issues/13972)