### PR TITLE
[WIP] Cleanup destroyed components before inserting new ones into DOM.

### DIFF
--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -201,6 +201,10 @@ export abstract class Environment {
   }
 
   commit() {
+    for (let i=0; i<this.destructors.length; i++) {
+      this.destructors[i].destroy();
+    }
+
     for (let i=0; i<this.createdComponents.length; i++) {
       let component = this.createdComponents[i];
       let manager = this.createdManagers[i];
@@ -211,10 +215,6 @@ export abstract class Environment {
       let component = this.updatedComponents[i];
       let manager = this.updatedManagers[i];
       manager.didUpdate(component);
-    }
-
-    for (let i=0; i<this.destructors.length; i++) {
-      this.destructors[i].destroy();
     }
 
     this.createdComponents = null;


### PR DESCRIPTION
This supports the Ember lifecycle better, and seems more logical (considering that the destruction may actually want to operate on DOM to clean things up before new components are inserted).