### PR TITLE
Fix `assign` utility to skip `null` / `undefined`.

### DIFF
--- a/packages/glimmer-util/lib/object-utils.ts
+++ b/packages/glimmer-util/lib/object-utils.ts
@@ -18,6 +18,10 @@ export function assign(target: any, ...sources: any[]): any;
 
 export function assign(obj, ...assignments) {
   return assignments.reduce((obj, extensions) => {
+    if (typeof extensions !== 'object' || extensions === null) {
+      return obj;
+    }
+
     Object.keys(extensions).forEach(key => obj[key] = extensions[key]);
     return obj;
   }, obj);

--- a/packages/glimmer-util/tests/object-utils-test.ts
+++ b/packages/glimmer-util/tests/object-utils-test.ts
@@ -1,0 +1,9 @@
+import { assign } from '../lib/object-utils';
+
+QUnit.module('object-utils tests');
+
+QUnit.test('assign should ignore null/undefined arguments', function(assert) {
+  let result = assign({}, { foo: 'bar' }, null, undefined, { derp: "herk" });
+
+  assert.deepEqual(result, { foo: 'bar', derp: 'herk' }, 'has correct result');
+});


### PR DESCRIPTION
`Object.assign` ignores `null` / `undefined` arguments, but our internal `assign` does not (prior to these changes it errored if it received `null` / `undefined`).

This now handles it like native `Object.assign`:

![screenshot of Object.assign from Chrome](https://monosnap.com/file/ybIyZY6iBt53Mv2o5iKX3wjDWLxeyY.png)