### PR TITLE
Prevent setting properties to an initial value of `undefined`.

### DIFF
--- a/packages/glimmer-runtime/lib/dom/change-lists.ts
+++ b/packages/glimmer-runtime/lib/dom/change-lists.ts
@@ -73,14 +73,14 @@ export function readDOMAttr(element: Element, attr: string) {
 
 export const PropertyChangeList: IChangeList = {
   setAttribute(env: Environment, element: Simple.Element, attr: string, value: Opaque, namespace?: DOMNamespace) {
-    if (value !== null) {
+    if (value !== null && value !== undefined) {
       let normalized = attr.toLowerCase();
       element[normalized] = normalizePropertyValue(value); // TODO: This doesn't work
     }
   },
 
   updateAttribute(env: Environment, element: Element, attr: string, value: Opaque, namespace?: DOMNamespace) {
-    if (value === null) {
+    if (value === null || value === undefined) {
       let normalized = attr.toLowerCase();
       element[normalized] = value;
     } else {
@@ -99,7 +99,7 @@ export const AttributeChangeList: IChangeList = new class {
   }
 
   updateAttribute(env: Environment, element: Element, attr: string, value: Opaque, namespace?: DOMNamespace) {
-    if (value === null) {
+    if (value === null || value === undefined) {
       if (namespace) {
         env.getDOM().removeAttributeNS(element, namespace, attr);
       } else {


### PR DESCRIPTION
This matches expected Ember and HTMLBars behavior. See the following for where this was implemented in HTMLBars:

* https://github.com/tildeio/htmlbars/blob/master/packages/dom-helper/lib/prop.js#L1-L3
* https://github.com/tildeio/htmlbars/blob/master/packages/morph-attr/lib/main.js#L11

Addresses https://github.com/emberjs/ember.js/issues/14243.