### PR TITLE
Lock to typescript@2.1.0-dev.20160911.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "qunit": "^0.7.2",
     "simple-dom": "^0.3.0",
     "simple-html-tokenizer": "^0.2.5",
-    "typescript": "next"
+    "typescript": "2.1.0-dev.20160911"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",


### PR DESCRIPTION
Using typescript@2.1.0-dev.20160912 leads to the following error during
`npm run vscode-build`:

```
packages/glimmer-runtime/lib/compiled/opcodes/content.ts(258,82): error TS2345: Argument of type 'string | T' is not assignable to parameter of type 'T'.
  Type 'string' is not assignable to type 'T'.
```