### PR TITLE
Fix issue with `<img src={{foo}}>`.

### DIFF
--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -65,8 +65,6 @@ export {
   AttributeManager as IAttributeManager,
   AttributeManager,
   PropertyManager,
-  SAFE_HREF_ATTRIBUTE_MANAGER,
-  SAFE_HREF_PROPERTY_MANAGER,
   INPUT_VALUE_PROPERTY_MANAGER,
   defaultManagers,
   defaultAttributeManagers,

--- a/packages/glimmer-runtime/lib/dom/attribute-managers.ts
+++ b/packages/glimmer-runtime/lib/dom/attribute-managers.ts
@@ -29,7 +29,7 @@ export function defaultManagers(element: Simple.Element, attr: string, isTrustin
 
 export function defaultPropertyManagers(tagName: string, attr: string) {
   if (requiresSanitization(tagName, attr)) {
-    return SAFE_HREF_PROPERTY_MANAGER;
+    return new SafePropertyManager(attr);
   }
 
   if (isUserInputValue(tagName, attr)) {
@@ -45,7 +45,7 @@ export function defaultPropertyManagers(tagName: string, attr: string) {
 
 export function defaultAttributeManagers(tagName: string, attr: string) {
   if (requiresSanitization(tagName, attr)) {
-    return SAFE_HREF_ATTRIBUTE_MANAGER;
+    return new SafeAttributeManager(attr);
   }
 
   return new AttributeManager(attr);
@@ -137,7 +137,7 @@ function isAttrRemovalValue(value) {
   return value === null || value === undefined;
 }
 
-class SafeHrefPropertyManager extends PropertyManager {
+class SafePropertyManager extends PropertyManager {
   setAttribute(env: Environment, element: Simple.Element, value: Opaque) {
     super.setAttribute(env, element, sanitizeAttributeValue(env, element, this.attr, value));
   }
@@ -146,8 +146,6 @@ class SafeHrefPropertyManager extends PropertyManager {
     this.setAttribute(env, element, value);
   }
 }
-
-export const SAFE_HREF_PROPERTY_MANAGER = new SafeHrefPropertyManager('href');
 
 function isUserInputValue(tagName: string, attribute: string) {
   return (tagName === 'INPUT' || tagName === 'TEXTAREA') && attribute === 'value';
@@ -196,7 +194,7 @@ class OptionSelectedManager extends PropertyManager {
 
 export const OPTION_SELECTED_MANAGER = new OptionSelectedManager('selected');
 
-class SafeHrefAttributeManager extends AttributeManager {
+class SafeAttributeManager extends AttributeManager {
   setAttribute(env: Environment, element: Element, value: Opaque) {
     super.setAttribute(env, element, sanitizeAttributeValue(env, element, this.attr, value));
   }
@@ -205,5 +203,3 @@ class SafeHrefAttributeManager extends AttributeManager {
     this.setAttribute(env, element, value);
   }
 }
-
-export const SAFE_HREF_ATTRIBUTE_MANAGER = new SafeHrefAttributeManager('href');

--- a/packages/glimmer-runtime/lib/dom/sanitized-values.ts
+++ b/packages/glimmer-runtime/lib/dom/sanitized-values.ts
@@ -50,8 +50,12 @@ export function requiresSanitization(tagName: string, attribute: string): boolea
   return checkURI(tagName, attribute) || checkDataURI(tagName, attribute);
 }
 
-export function sanitizeAttributeValue(env: Environment, element: Simple.Element, attribute: string, value: Opaque): string {
+export function sanitizeAttributeValue(env: Environment, element: Simple.Element, attribute: string, value: Opaque): Opaque {
   let tagName;
+
+  if (value === null || value === undefined) {
+    return value;
+  }
 
   if (isSafeString(value)) {
     return value.toHTML();

--- a/packages/glimmer-runtime/tests/attributes-test.ts
+++ b/packages/glimmer-runtime/tests/attributes-test.ts
@@ -205,6 +205,49 @@ test("a[href] marks vbscript: protocol as unsafe", () => {
   equalTokens(root, '<a href="unsafe:vbscript:foo()"></a>');
 });
 
+test("img[src] marks javascript: protocol as unsafe", () => {
+  let template = compile('<img src="{{foo}}">');
+
+  let context = { foo: 'javascript:foo()' };
+  render(template, context);
+
+  equalTokens(root, '<img src="unsafe:javascript:foo()">');
+
+  rerender();
+
+  equalTokens(root, '<img src="unsafe:javascript:foo()">');
+});
+
+test("img[src] marks javascript: protocol as unsafe, http as safe", () => {
+  let template = compile('<img src="{{foo}}">');
+
+  let context = { foo: 'javascript:foo()' };
+  render(template, context);
+
+  equalTokens(root, '<img src="unsafe:javascript:foo()">');
+
+  rerender({ foo: 'http://foo.bar' });
+
+  equalTokens(root, '<img src="http://foo.bar">');
+
+  rerender({ foo: 'javascript:foo()' });
+
+  equalTokens(root, '<img src="unsafe:javascript:foo()">');
+});
+
+test("img[src] marks vbscript: protocol as unsafe", () => {
+  let template = compile('<img src="{{foo}}">');
+
+  let context = { foo: 'vbscript:foo()' };
+  render(template, context);
+
+  equalTokens(root, '<img src="unsafe:vbscript:foo()">');
+
+  rerender();
+
+  equalTokens(root, '<img src="unsafe:vbscript:foo()">');
+});
+
 test("div[href] is not not marked as unsafe", () => {
   let template = compile('<div href="{{foo}}"></div>');
 

--- a/packages/glimmer-runtime/tests/initial-render-test.ts
+++ b/packages/glimmer-runtime/tests/initial-render-test.ts
@@ -128,6 +128,69 @@ test("Unquoted attribute expression with string value is not coerced", function(
   equal(inputNode.value, 'oh my', 'string is set to property');
 });
 
+test("Unquoted img src attribute is rendered", function() {
+  let template = compile('<img src={{someURL}}>');
+  render(template, { someURL: "http://foo.com/foo.png"});
+
+  let imgNode: any = root.firstChild;
+
+  equalTokens(root, '<img src="http://foo.com/foo.png">');
+  equal(imgNode.tagName, 'IMG', 'img tag');
+  equal(imgNode.src, 'http://foo.com/foo.png', 'string is set to property');
+});
+
+test("Unquoted img src attribute is not rendered when set to `null`", function() {
+  let template = compile('<img src={{someURL}}>');
+  render(template, { someURL: null});
+
+  equalTokens(root, '<img>');
+});
+
+test("Unquoted img src attribute is not rendered when set to `undefined`", function() {
+  let template = compile('<img src={{someURL}}>');
+  render(template, { someURL: undefined });
+
+  equalTokens(root, '<img>');
+});
+
+test("Quoted img src attribute is rendered", function() {
+  let template = compile('<img src="{{someURL}}">');
+  render(template, { someURL: "http://foo.com/foo.png"});
+
+  let imgNode: any = root.firstChild;
+
+  equal(imgNode.tagName, 'IMG', 'img tag');
+  equal(imgNode.src, 'http://foo.com/foo.png', 'string is set to property');
+});
+
+test("Quoted img src attribute is not rendered when set to `null`", function() {
+  let template = compile('<img src="{{someURL}}">');
+  render(template, { someURL: null});
+
+  equalTokens(root, '<img>');
+});
+
+test("Quoted img src attribute is not rendered when set to `undefined`", function() {
+  let template = compile('<img src="{{someURL}}">');
+  render(template, { someURL: undefined });
+
+  equalTokens(root, '<img>');
+});
+
+test("Unquoted a href attribute is not rendered when set to `null`", function() {
+  let template = compile('<a href={{someURL}}></a>');
+  render(template, { someURL: null});
+
+  equalTokens(root, '<a></a>');
+});
+
+test("Unquoted img src attribute is not rendered when set to `undefined`", function() {
+  let template = compile('<a href={{someURL}}></a>');
+  render(template, { someURL: undefined});
+
+  equalTokens(root, '<a></a>');
+});
+
 test("Attribute expression can be followed by another attribute", function() {
   let template = compile('<div foo="{{funstuff}}" name="Alice"></div>');
   render(template, {funstuff: "oh my"});


### PR DESCRIPTION
Due to recent changes, the attribute managers were updated to store the attribute names they reference to (so that normalized attribute names are used when setting / updating values).

A few singleton attribute managers were kept around, because we believed that they were always the same attribute so there was no need to create additional instances (seemed wasteful).

Unfortunately, the SafeHrefAttributeManager and SafeHrefPropertyManager are used for much more than just `href` (see full listing in `glimmer-runtime/lib/dom/sanitized-value.ts`) so we cannot make the assumption that all the attributes/properties are the same (and therefore cannot use a singleton).

This updates to remove usage of singleton for the sanitized values, and adds a number of tests around ensuring they are properly handled in various cases.