### PR TITLE
Ensure using `this` in path builder properly normalizes.

### DIFF
--- a/packages/glimmer-syntax/lib/builders.ts
+++ b/packages/glimmer-syntax/lib/builders.ts
@@ -103,10 +103,16 @@ function buildSexpr(path, params?, hash?, loc?) {
 function buildPath(original, loc?) {
   if (typeof original !== 'string') return original;
 
+  let parts = original.split('.');
+
+  if (parts[0] === 'this') {
+    parts[0] = null;
+  }
+
   return {
     type: "PathExpression",
-    original: original,
-    parts: original.split('.'),
+    original,
+    parts,
     data: false,
     loc: buildLoc(loc)
   };


### PR DESCRIPTION
Internally, `this` is translated to `parts === [null]` inside the Handlebars `PathExpression` handler, but the `builders.path` helper method does not go through `PathExpression` handler.

This commit updates the `builders.path` to be aware of the expected internal representation of `{{this}}`.

Related to:

* https://github.com/emberjs/ember.js/issues/14305
* https://github.com/tildeio/glimmer/pull/307