### PR TITLE
Fix `lastIterated` not getting populated correctly

### DIFF
--- a/packages/glimmer-runtime/lib/vm/update.ts
+++ b/packages/glimmer-runtime/lib/vm/update.ts
@@ -281,9 +281,7 @@ class ListRevalidationDelegate implements IteratorSynchronizerDelegate {
   }
 
   done() {
-    if (this.didInsert || this.didDelete) {
-      this.opcode.didInitializeChildren();
-    }
+    this.opcode.didInitializeChildren(this.didInsert || this.didDelete);
   }
 }
 
@@ -302,9 +300,12 @@ export class ListBlockOpcode extends BlockOpcode {
     this.tag = combine([artifacts.tag, _tag]);
   }
 
-  didInitializeChildren() {
+  didInitializeChildren(listDidChange = true) {
     this.lastIterated = this.artifacts.tag.value();
-    this._tag.update(combineSlice(this.children));
+
+    if (listDidChange) {
+      this._tag.update(combineSlice(this.children));
+    }
   }
 
   evaluate(vm: UpdatingVM) {


### PR DESCRIPTION
When nothing is inserted or deleted, we don't call `didInitializeChildren` which causes `lastIterated` to not be populated. This causes us to reiterate the list unnecessarily.

This is reported via https://github.com/emberjs/ember.js/issues/14332 and tested in https://github.com/emberjs/ember.js/pull/14347.

Unfortunately, since this relies on objects having useful validation tags, we don't really have the infrastructure to test it in Glimmer yet.