### PR TITLE
Expose dynamicScope to prepareArgs hook

### DIFF
--- a/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/component.ts
@@ -73,7 +73,7 @@ export class OpenComponentOpcode extends Opcode {
 
     let manager = definition.manager;
     let hasDefaultBlock = templates && !!templates.default; // TODO Cleanup?
-    let args = manager.prepareArgs(definition, rawArgs.evaluate(vm));
+    let args = manager.prepareArgs(definition, rawArgs.evaluate(vm), dynamicScope);
     let component = manager.create(vm.env, definition, args, dynamicScope, vm.getSelf(), hasDefaultBlock);
     let destructor = manager.getDestructor(component);
     if (destructor) vm.newDestroyable(destructor);

--- a/packages/glimmer-runtime/lib/component/interfaces.ts
+++ b/packages/glimmer-runtime/lib/component/interfaces.ts
@@ -18,7 +18,7 @@ export interface ComponentManager<T extends Component> {
   // for `create`. This allows for things like closure components where the
   // args need to be curried before constructing the instance of the state
   // bucket.
-  prepareArgs(definition: ComponentDefinition<T>, args: EvaluatedArgs): EvaluatedArgs;
+  prepareArgs(definition: ComponentDefinition<T>, args: EvaluatedArgs, dynamicScope: DynamicScope): EvaluatedArgs;
 
   // Then, the component manager is asked to create a bucket of state for
   // the supplied arguments. From the perspective of Glimmer, this is

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -1428,6 +1428,22 @@ QUnit.test('correct scope - self', assert => {
   );
 });
 
+module('Curly Components - smoke test dynamicScope access');
+
+QUnit.test('component has access to dynamic scope', function() {
+  class SampleComponent extends EmberishCurlyComponent {
+    static fromDynamicScope = ['theme'];
+  }
+
+  SampleComponent[CLASS_META].seal();
+
+  env.registerEmberishCurlyComponent('sample-component', SampleComponent, '{{theme}}');
+
+  appendViewFor('{{#-with-dynamic-vars theme="light"}}{{sample-component}}{{/-with-dynamic-vars}}');
+
+  assertEmberishElement('div', 'light');
+});
+
 module('Curly Components - positional arguments');
 
 QUnit.skip('static named positional parameters', function() {


### PR DESCRIPTION
This allows a component manager to choose to consume some arguments from the dynamic scope.