### PR TITLE
Fix timing of expression evaluation in blocks

### DIFF
--- a/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
@@ -1,4 +1,5 @@
 import * as component from './component';
+import * as partial from '../../compiled/opcodes/partial';
 import * as content from './content';
 import * as dom from './dom';
 import * as lists from './lists';
@@ -11,6 +12,7 @@ import { Opcode, OpSeq } from '../../opcodes';
 import { CompiledArgs } from '../expressions/args';
 import { CompiledExpression } from '../expressions';
 import { ComponentDefinition } from '../../component/interfaces';
+import { PartialDefinition } from '../../partial';
 import Environment from '../../environment';
 import { InlineBlock, Layout } from '../blocks';
 import { EMPTY_ARRAY } from '../../utils';
@@ -115,6 +117,20 @@ export abstract class BasicOpcodeBuilder extends StatementCompilationBufferProxy
     }
 
     return label;
+  }
+
+  // partials
+
+  putPartialDefinition(definition: PartialDefinition<Opaque>) {
+    this.append(new partial.PutPartialDefinitionOpcode(definition));
+  }
+
+  putDynamicPartialDefinition() {
+    this.append(new partial.PutDynamicPartialDefinitionOpcode(this.symbolTable));
+  }
+
+  evaluatePartial() {
+    this.append(new partial.EvaluatePartialOpcode(this.symbolTable));
   }
 
   // components

--- a/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
@@ -362,12 +362,12 @@ export default class OpcodeBuilder extends BasicOpcodeBuilder {
   // TODO
   // come back to this
   block({ templates, args }: BlockArgs, callback: BlockCallback) {
+    if (args) this.putArgs(args);
+
     this.startLabels();
     this.startBlock(templates);
     this.enter('BEGIN', 'END');
     this.label('BEGIN');
-
-    if (args) this.putArgs(args);
 
     callback(this, 'BEGIN', 'END');
 

--- a/packages/glimmer-runtime/lib/compiler.ts
+++ b/packages/glimmer-runtime/lib/compiler.ts
@@ -401,9 +401,9 @@ class ComponentBuilder implements IComponentBuilder {
     this.dsl.unit({ templates }, dsl => {
       dsl.putArgs(definitionArgs);
       dsl.putValue(makeFunctionExpression(definition));
+      dsl.test('simple');
       dsl.enter('BEGIN', 'END');
       dsl.label('BEGIN');
-      dsl.test('simple');
       dsl.jumpUnless('END');
       dsl.putDynamicComponentDefinition();
       dsl.openComponent(args, shadow);

--- a/packages/glimmer-runtime/lib/compiler.ts
+++ b/packages/glimmer-runtime/lib/compiler.ts
@@ -399,10 +399,10 @@ class ComponentBuilder implements IComponentBuilder {
 
   dynamic(definitionArgs: Syntax.Args, definition: DynamicDefinition, args: Syntax.Args, templates: Syntax.Templates, symbolTable: SymbolTable, shadow: string[] = EMPTY_ARRAY) {
     this.dsl.unit({ templates }, dsl => {
-      dsl.enter('BEGIN', 'END');
-      dsl.label('BEGIN');
       dsl.putArgs(definitionArgs);
       dsl.putValue(makeFunctionExpression(definition));
+      dsl.enter('BEGIN', 'END');
+      dsl.label('BEGIN');
       dsl.test('simple');
       dsl.jumpUnless('END');
       dsl.putDynamicComponentDefinition();

--- a/packages/glimmer-runtime/lib/syntax/builtins/if.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/if.ts
@@ -20,9 +20,9 @@ export default class IfSyntax extends StatementSyntax {
   }
 
   compile(dsl: OpcodeBuilderDSL) {
+    //        PutArgs
     //        Enter(BEGIN, END)
     // BEGIN: Noop
-    //        PutArgs
     //        Test(Environment)
     //        JumpUnless(ELSE)
     //        Evaluate(default)

--- a/packages/glimmer-runtime/lib/syntax/builtins/if.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/if.ts
@@ -21,9 +21,9 @@ export default class IfSyntax extends StatementSyntax {
 
   compile(dsl: OpcodeBuilderDSL) {
     //        PutArgs
+    //        Test(Environment)
     //        Enter(BEGIN, END)
     // BEGIN: Noop
-    //        Test(Environment)
     //        JumpUnless(ELSE)
     //        Evaluate(default)
     //        Jump(END)
@@ -34,9 +34,10 @@ export default class IfSyntax extends StatementSyntax {
 
     let { args, templates } = this;
 
-    dsl.block({ templates, args }, (dsl, BEGIN, END) => {
-      dsl.test('environment');
+    dsl.putArgs(args);
+    dsl.test('environment');
 
+    dsl.block({ templates }, (dsl, BEGIN, END) => {
       if (templates.inverse) {
         dsl.jumpUnless('ELSE');
         dsl.evaluate('default');

--- a/packages/glimmer-runtime/lib/syntax/builtins/in-element.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/in-element.ts
@@ -23,7 +23,6 @@ export default class InElementSyntax extends StatementSyntax {
     let { args, templates } = this;
 
     dsl.block({ templates, args }, (dsl, BEGIN, END) => {
-      dsl.putArgs(args);
       dsl.test('simple');
       dsl.jumpUnless(END);
       dsl.pushRemoteElement();

--- a/packages/glimmer-runtime/lib/syntax/builtins/in-element.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/in-element.ts
@@ -22,8 +22,10 @@ export default class InElementSyntax extends StatementSyntax {
   compile(dsl: OpcodeBuilderDSL, env: Environment) {
     let { args, templates } = this;
 
-    dsl.block({ templates, args }, (dsl, BEGIN, END) => {
-      dsl.test('simple');
+    dsl.putArgs(args);
+    dsl.test('simple');
+
+    dsl.block({ templates }, (dsl, BEGIN, END) => {
       dsl.jumpUnless(END);
       dsl.pushRemoteElement();
       dsl.evaluate('default');

--- a/packages/glimmer-runtime/lib/syntax/builtins/partial.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/partial.ts
@@ -60,12 +60,12 @@ export class DynamicPartialSyntax extends StatementSyntax {
     let name = this.name.compile(compiler, env, symbolTable);
 
     /*
-    //        PutArgs
+    //        PutValue(name)
+    //        Test(Simple)
     //        Enter(BEGIN, END)
     // BEGIN: Noop
-    //        NameToPartial
-    //        Test
     //        JumpUnless(END)
+    //        PutDynamicPartialDefinition
     //        EvaluatePartial
     // END:   Noop
     //        Exit
@@ -75,9 +75,9 @@ export class DynamicPartialSyntax extends StatementSyntax {
     let END = new LabelOpcode("END");
 
     compiler.append(new PutValueOpcode(name));
+    compiler.append(new TestOpcode(SimpleTest));
     compiler.append(new EnterOpcode(BEGIN, END));
     compiler.append(BEGIN);
-    compiler.append(new TestOpcode(SimpleTest));
     compiler.append(new JumpUnlessOpcode(END));
     compiler.append(new PutDynamicPartialDefinitionOpcode(symbolTable));
     compiler.append(new EvaluatePartialOpcode(symbolTable));

--- a/packages/glimmer-runtime/lib/syntax/builtins/partial.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/partial.ts
@@ -60,9 +60,9 @@ export class DynamicPartialSyntax extends StatementSyntax {
     let name = this.name.compile(compiler, env, symbolTable);
 
     /*
+    //        PutArgs
     //        Enter(BEGIN, END)
     // BEGIN: Noop
-    //        PutArgs
     //        NameToPartial
     //        Test
     //        JumpUnless(END)
@@ -74,9 +74,9 @@ export class DynamicPartialSyntax extends StatementSyntax {
     let BEGIN = new LabelOpcode("BEGIN");
     let END = new LabelOpcode("END");
 
+    compiler.append(new PutValueOpcode(name));
     compiler.append(new EnterOpcode(BEGIN, END));
     compiler.append(BEGIN);
-    compiler.append(new PutValueOpcode(name));
     compiler.append(new TestOpcode(SimpleTest));
     compiler.append(new JumpUnlessOpcode(END));
     compiler.append(new PutDynamicPartialDefinitionOpcode(symbolTable));

--- a/packages/glimmer-runtime/lib/syntax/builtins/unless.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/unless.ts
@@ -22,9 +22,9 @@ export default class UnlessSyntax extends StatementSyntax {
   }
 
   compile(dsl: OpcodeBuilderDSL, env: Environment) {
+    //        PutArgs
     //        Enter(BEGIN, END)
     // BEGIN: Noop
-    //        PutArgs
     //        Test(Environment)
     //        JumpIf(ELSE)
     //        Evaluate(default)

--- a/packages/glimmer-runtime/lib/syntax/builtins/unless.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/unless.ts
@@ -36,9 +36,10 @@ export default class UnlessSyntax extends StatementSyntax {
 
     let { args, templates } = this;
 
-    dsl.block({ templates, args }, dsl => {
-      dsl.test('environment');
+    dsl.putArgs(args);
+    dsl.test('environment');
 
+    dsl.block({ templates }, dsl => {
       if (templates.inverse) {
         dsl.jumpIf('ELSE');
         dsl.evaluate('default');

--- a/packages/glimmer-runtime/lib/syntax/builtins/with.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/with.ts
@@ -21,9 +21,9 @@ export default class WithSyntax extends StatementSyntax {
   }
 
   compile(dsl: OpcodeBuilderDSL, env: Environment) {
+    //        PutArgs
     //        Enter(BEGIN, END)
     // BEGIN: Noop
-    //        PutArgs
     //        Test(Environment)
     //        JumpUnless(ELSE)
     //        Evaluate(default)

--- a/packages/glimmer-runtime/lib/syntax/builtins/with.ts
+++ b/packages/glimmer-runtime/lib/syntax/builtins/with.ts
@@ -22,9 +22,9 @@ export default class WithSyntax extends StatementSyntax {
 
   compile(dsl: OpcodeBuilderDSL, env: Environment) {
     //        PutArgs
+    //        Test(Environment)
     //        Enter(BEGIN, END)
     // BEGIN: Noop
-    //        Test(Environment)
     //        JumpUnless(ELSE)
     //        Evaluate(default)
     //        Jump(END)
@@ -35,9 +35,10 @@ export default class WithSyntax extends StatementSyntax {
 
     let { args, templates } = this;
 
-    dsl.block({ templates, args }, (dsl, BEGIN, END) => {
-      dsl.test('environment');
+    dsl.putArgs(args);
+    dsl.test('environment');
 
+    dsl.block({ templates }, (dsl, BEGIN, END) => {
       if (templates.inverse) {
         dsl.jumpUnless('ELSE');
         dsl.evaluate('default');

--- a/packages/glimmer-runtime/lib/vm/append.ts
+++ b/packages/glimmer-runtime/lib/vm/append.ts
@@ -75,7 +75,8 @@ export default class VM implements PublicVM {
       scope: this.scope(),
       dynamicScope: this.dynamicScope(),
       operand: this.frame.getOperand(),
-      args: this.frame.getArgs()
+      args: this.frame.getArgs(),
+      condition: this.frame.getCondition()
     };
   }
 

--- a/packages/glimmer-runtime/lib/vm/append.ts
+++ b/packages/glimmer-runtime/lib/vm/append.ts
@@ -73,7 +73,9 @@ export default class VM implements PublicVM {
     return {
       env: this.env,
       scope: this.scope(),
-      dynamicScope: this.dynamicScope()
+      dynamicScope: this.dynamicScope(),
+      operand: this.frame.getOperand(),
+      args: this.frame.getArgs()
     };
   }
 

--- a/packages/glimmer-runtime/lib/vm/append.ts
+++ b/packages/glimmer-runtime/lib/vm/append.ts
@@ -12,7 +12,7 @@ import { Range } from '../utils';
 import { Component, ComponentManager } from '../component/interfaces';
 import { VMState, ListBlockOpcode, TryOpcode, BlockOpcode } from './update';
 import RenderResult from './render-result';
-import { FrameStack, Blocks } from './frame';
+import { CapturedFrame, FrameStack, Blocks } from './frame';
 
 interface VMInitialOptions {
   self: PathReference<Opaque>;
@@ -74,9 +74,7 @@ export default class VM implements PublicVM {
       env: this.env,
       scope: this.scope(),
       dynamicScope: this.dynamicScope(),
-      operand: this.frame.getOperand(),
-      args: this.frame.getArgs(),
-      condition: this.frame.getCondition()
+      frame: this.frame.capture()
     };
   }
 
@@ -265,6 +263,10 @@ export default class VM implements PublicVM {
   }
 
   /// EXECUTION
+
+  resume(opcodes: OpSeq, frame: CapturedFrame): RenderResult {
+    return this.execute(opcodes, vm => vm.frame.restore(frame));
+  }
 
   execute(opcodes: OpSeq, initialize?: (vm: VM) => void): RenderResult {
     LOGGER.debug("[VM] Begin program execution");

--- a/packages/glimmer-runtime/lib/vm/frame.ts
+++ b/packages/glimmer-runtime/lib/vm/frame.ts
@@ -6,6 +6,12 @@ import { Opcode, OpSeq } from '../opcodes';
 import { LabelOpcode } from '../compiled/opcodes/vm';
 import { Component, ComponentManager } from '../component/interfaces';
 
+export interface CapturedFrame {
+  operand: PathReference<any>;
+  args: EvaluatedArgs;
+  condition: Reference<boolean>;
+}
+
 class Frame {
   ops: OpSeq;
   op: Opcode;
@@ -26,6 +32,20 @@ class Frame {
   ) {
     this.ops = ops;
     this.op = ops.head();
+  }
+
+  capture(): CapturedFrame {
+    return {
+      operand: this.operand,
+      args: this.args,
+      condition: this.condition
+    };
+  }
+
+  restore(frame: CapturedFrame) {
+    this.operand = frame.operand;
+    this.args = frame.args;
+    this.condition = frame.condition;
   }
 }
 
@@ -52,6 +72,14 @@ export class FrameStack {
     let { frames, frame } = this;
     frames[frame] = null;
     this.frame = frame === 0 ? undefined : frame - 1;
+  }
+
+  capture(): CapturedFrame {
+    return this.frames[this.frame].capture();
+  }
+
+  restore(frame: CapturedFrame) {
+    this.frames[this.frame].restore(frame);
   }
 
   getOps(): OpSeq {

--- a/packages/glimmer-runtime/lib/vm/frame.ts
+++ b/packages/glimmer-runtime/lib/vm/frame.ts
@@ -6,10 +6,12 @@ import { Opcode, OpSeq } from '../opcodes';
 import { LabelOpcode } from '../compiled/opcodes/vm';
 import { Component, ComponentManager } from '../component/interfaces';
 
-export interface CapturedFrame {
-  operand: PathReference<any>;
-  args: EvaluatedArgs;
-  condition: Reference<boolean>;
+export class CapturedFrame {
+  constructor(
+    private operand: PathReference<any>,
+    private args: EvaluatedArgs,
+    private condition: Reference<boolean>
+  ) {}
 }
 
 class Frame {
@@ -35,17 +37,13 @@ class Frame {
   }
 
   capture(): CapturedFrame {
-    return {
-      operand: this.operand,
-      args: this.args,
-      condition: this.condition
-    };
+    return new CapturedFrame(this.operand, this.args, this.condition);
   }
 
   restore(frame: CapturedFrame) {
-    this.operand = frame.operand;
-    this.args = frame.args;
-    this.condition = frame.condition;
+    this.operand = frame['operand'];
+    this.args = frame['args'];
+    this.condition = frame['condition'];
   }
 }
 


### PR DESCRIPTION
This commit fixes a compiler bug where certain built-in syntaxes would re-evaluate its arguments when the block's assertion causes a re-entry into the append VM, instead of reusing the argument references that were created the first time.

In practice, this is observable when a "stateful helper" is used as an argument to a syntax with an assertion (currently `#if`, `#unless`, `#with`, `#each`, `partial`, `InElementSyntax` and dynamic components).

Because the argument references are created every time, any state stored on the original instance of the helper will be observably wiped away when used as an argument to an asserting block helper. Of course, it is also observable by comparing the JavaScript identity of the helper in question over time.

This commit fixes the compiler bug by moving the evaluation of the expressions passed as arguments to the block syntaxes in question above the `Try` block, and capturing the relevant registers (args and operand, which store the results of evaluating the arguments) so they can be restored when the append VM is re-entered for the same block.

Fixes #336