### PR TITLE
`{{this}}` `{{this.foo}}` will never be helpers

### DIFF
--- a/packages/glimmer-compiler/lib/template-compiler.ts
+++ b/packages/glimmer-compiler/lib/template-compiler.ts
@@ -160,7 +160,7 @@ export default class TemplateCompiler<T extends TemplateMeta> {
     } else if (isHelperInvocation(expr)) {
       this.prepareHelper(expr);
       this.opcode('helper', expr, expr.path.parts);
-    } else if (isLocalVariable(expr, this.symbols)) {
+    } else if (isSelfGet(expr) || isLocalVariable(expr, this.symbols)) {
       this.opcode('get', expr, expr.path.parts);
     } else {
       this.opcode('unknown', expr, expr.path.parts);
@@ -338,6 +338,11 @@ export default class TemplateCompiler<T extends TemplateMeta> {
 function isHelperInvocation(mustache) {
   return (mustache.params && mustache.params.length > 0) ||
     (mustache.hash && mustache.hash.pairs.length > 0);
+}
+
+function isSelfGet(mustache) {
+  let { parts } = mustache.path;
+  return parts[0] === null;
 }
 
 function isLocalVariable(mustache, symbols) {

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -820,7 +820,7 @@ export class TestEnvironment extends Environment {
       }
     }
 
-    if (!isSimple && appendType === 'unknown') {
+    if (isInline && !isSimple && appendType !== 'helper') {
       return (statement.original as OptimizedAppend).deopt();
     }
 


### PR DESCRIPTION
We can just triage them into `get` expressions in the precompiler (as opposed to `unknown`).