### PR TITLE
Ensure removal values are respected for safe attr/prop.

### DIFF
--- a/packages/glimmer-runtime/lib/dom/attribute-managers.ts
+++ b/packages/glimmer-runtime/lib/dom/attribute-managers.ts
@@ -143,7 +143,7 @@ class SafePropertyManager extends PropertyManager {
   }
 
   updateAttribute(env: Environment, element: Element, value: Opaque) {
-    this.setAttribute(env, element, value);
+    super.updateAttribute(env, element, sanitizeAttributeValue(env, element, this.attr, value));
   }
 }
 
@@ -200,6 +200,6 @@ class SafeAttributeManager extends AttributeManager {
   }
 
   updateAttribute(env: Environment, element: Element, value: Opaque, namespace?: DOMNamespace) {
-    this.setAttribute(env, element, value);
+    super.updateAttribute(env, element, sanitizeAttributeValue(env, element, this.attr, value));
   }
 }

--- a/packages/glimmer-runtime/tests/attributes-test.ts
+++ b/packages/glimmer-runtime/tests/attributes-test.ts
@@ -192,6 +192,23 @@ test("a[href] marks javascript: protocol as unsafe, http as safe", () => {
   equalTokens(root, '<a href="unsafe:javascript:foo()"></a>');
 });
 
+test("a[href] marks javascript: protocol as unsafe on updates", () => {
+  let template = compile('<a href="{{foo}}"></a>');
+
+  let context = { foo: 'http://foo.bar' };
+  render(template, context);
+
+  equalTokens(root, '<a href="http://foo.bar"></a>');
+
+  rerender({ foo: 'javascript:foo()' });
+
+  equalTokens(root, '<a href="unsafe:javascript:foo()"></a>');
+
+  rerender({ foo: 'http://foo.bar' });
+
+  equalTokens(root, '<a href="http://foo.bar"></a>');
+});
+
 test("a[href] marks vbscript: protocol as unsafe", () => {
   let template = compile('<a href="{{foo}}"></a>');
 
@@ -205,11 +222,54 @@ test("a[href] marks vbscript: protocol as unsafe", () => {
   equalTokens(root, '<a href="unsafe:vbscript:foo()"></a>');
 });
 
+test("a[href] can be removed by setting to `null`", () => {
+  let template = compile('<a href={{foo}}></a>');
+
+  let context = { foo: 'http://foo.bar/derp.jpg' };
+  render(template, context);
+
+  equalTokens(root, '<a href="http://foo.bar/derp.jpg"></a>');
+
+  rerender({ foo: null });
+
+  equalTokens(root, '<a></a>');
+});
+
+test("a[href] can be removed by setting to `undefined`", () => {
+  let template = compile('<a href={{foo}}></a>');
+
+  let context = { foo: 'http://foo.bar/derp.jpg' };
+  render(template, context);
+
+  equalTokens(root, '<a href="http://foo.bar/derp.jpg"></a>');
+
+  rerender({ foo: undefined });
+
+  equalTokens(root, '<a></a>');
+});
+
 test("img[src] marks javascript: protocol as unsafe", () => {
   let template = compile('<img src="{{foo}}">');
 
   let context = { foo: 'javascript:foo()' };
   render(template, context);
+
+  equalTokens(root, '<img src="unsafe:javascript:foo()">');
+
+  rerender();
+
+  equalTokens(root, '<img src="unsafe:javascript:foo()">');
+});
+
+test("img[src] marks javascript: protocol as unsafe on updates", () => {
+  let template = compile('<img src="{{foo}}">');
+
+  let context = { foo: 'http://foo.bar/derp.jpg' };
+  render(template, context);
+
+  equalTokens(root, '<img src="http://foo.bar/derp.jpg">');
+
+  rerender({ foo: 'javascript:foo()' });
 
   equalTokens(root, '<img src="unsafe:javascript:foo()">');
 
@@ -246,6 +306,32 @@ test("img[src] marks vbscript: protocol as unsafe", () => {
   rerender();
 
   equalTokens(root, '<img src="unsafe:vbscript:foo()">');
+});
+
+test("img[src] can be removed by setting to `null`", () => {
+  let template = compile('<img src={{foo}}>');
+
+  let context = { foo: 'http://foo.bar/derp.jpg' };
+  render(template, context);
+
+  equalTokens(root, '<img src="http://foo.bar/derp.jpg">');
+
+  rerender({ foo: null });
+
+  equalTokens(root, '<img>');
+});
+
+test("img[src] can be removed by setting to `undefined`", () => {
+  let template = compile('<img src={{foo}}>');
+
+  let context = { foo: 'http://foo.bar/derp.jpg' };
+  render(template, context);
+
+  equalTokens(root, '<img src="http://foo.bar/derp.jpg">');
+
+  rerender({ foo: undefined });
+
+  equalTokens(root, '<img>');
 });
 
 test("div[href] is not not marked as unsafe", () => {


### PR DESCRIPTION
Prior to this change it was not possible to remove one of our sanitized attributes/properties, because we always used the `setAttribute` logic (which explicitly noop's initial sets when a removal value is being used).

This updates to sanitize and call `super.*` properly for both `setAttribute` and `updateAttribute`.

Addresses https://github.com/emberjs/ember.js/issues/14595