### PR TITLE
Remove `ValueReference`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "loader.js": "^4.0.10",
     "qunit-tap": "^1.5.1",
     "qunitjs": "^2.0.1",
-    "tslint": "next"
+    "tslint": "^3.15.1"
   }
 }

--- a/packages/glimmer-runtime/index.ts
+++ b/packages/glimmer-runtime/index.ts
@@ -13,7 +13,7 @@ export { default as templateFactory, TemplateFactory, Template } from './lib/tem
 
 export { default as SymbolTable } from './lib/symbol-table';
 
-export { ConditionalReference, NULL_REFERENCE, UNDEFINED_REFERENCE } from './lib/references';
+export { NULL_REFERENCE, UNDEFINED_REFERENCE, PrimitiveReference, ConditionalReference } from './lib/references';
 
 export {
   Templates,
@@ -88,10 +88,6 @@ export {
   EvaluatedNamedArgs,
   EvaluatedPositionalArgs
 } from './lib/compiled/expressions/args';
-
-export {
-  ValueReference
-} from './lib/compiled/expressions/value';
 
 export {
   FunctionExpression

--- a/packages/glimmer-runtime/lib/compiled/expressions/has-block-params.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/has-block-params.ts
@@ -1,6 +1,7 @@
+import { PathReference } from 'glimmer-reference';
 import VM from '../../vm/append';
 import { CompiledExpression } from '../expressions';
-import { ValueReference } from './value';
+import { PrimitiveReference } from '../../references';
 
 export default class CompiledHasBlockParams extends CompiledExpression<boolean> {
   public type = "has-block-params";
@@ -9,9 +10,9 @@ export default class CompiledHasBlockParams extends CompiledExpression<boolean> 
     super();
   }
 
-  evaluate(vm: VM): ValueReference<boolean> {
+  evaluate(vm: VM): PathReference<boolean> {
     let blockRef = vm.scope().getBlock(this.blockSymbol);
-    return new ValueReference(!!(blockRef && blockRef.locals.length > 0));
+    return PrimitiveReference.create(!!(blockRef && blockRef.locals.length > 0));
   }
 
   toJSON(): string {

--- a/packages/glimmer-runtime/lib/compiled/expressions/has-block.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/has-block.ts
@@ -1,6 +1,7 @@
+import { PathReference } from 'glimmer-reference';
 import VM from '../../vm/append';
 import { CompiledExpression } from '../expressions';
-import { ValueReference } from './value';
+import { PrimitiveReference } from '../../references';
 
 export default class CompiledHasBlock extends CompiledExpression<boolean> {
   public type = "has-block";
@@ -9,9 +10,9 @@ export default class CompiledHasBlock extends CompiledExpression<boolean> {
     super();
   }
 
-  evaluate(vm: VM): ValueReference<boolean> {
+  evaluate(vm: VM): PathReference<boolean> {
     let blockRef = vm.scope().getBlock(this.blockSymbol);
-    return new ValueReference(!!blockRef);
+    return PrimitiveReference.create(!!blockRef);
   }
 
   toJSON(): string {

--- a/packages/glimmer-runtime/lib/compiled/expressions/value.ts
+++ b/packages/glimmer-runtime/lib/compiled/expressions/value.ts
@@ -1,40 +1,21 @@
 import { VM } from '../../vm';
 import { CompiledExpression } from '../expressions';
-import { ConstReference, PathReference } from 'glimmer-reference';
-import { Dict, dict } from 'glimmer-util';
+import { Primitive, PrimitiveReference } from '../../references';
 
-export default class CompiledValue<T> extends CompiledExpression<T> {
+export default class CompiledValue<T extends Primitive> extends CompiledExpression<T> {
   public type = "value";
-  private reference: ValueReference<T>;
+  private reference: PrimitiveReference<T>;
 
-  constructor(value: any) {
+  constructor(value: T) {
     super();
-    this.reference = new ValueReference(value);
+    this.reference = PrimitiveReference.create(value as any);
   }
 
-  evaluate(vm: VM): PathReference<T> {
+  evaluate(vm: VM): PrimitiveReference<T> {
     return this.reference;
   }
 
   toJSON(): string {
     return JSON.stringify(this.reference.value());
   }
-}
-
-export class ValueReference<T> extends ConstReference<T> implements PathReference<T> {
-  protected inner: T;
-  protected children: Dict<ValueReference<any>> = dict<ValueReference<any>>();
-
-  get(key: string) {
-    let { children } = this;
-    let child = children[key];
-
-    if (!child) {
-      child = children[key] = new ValueReference(this.inner[key]);
-    }
-
-    return child;
-  }
-
-  value(): any { return this.inner; }
 }

--- a/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/dom.ts
@@ -16,8 +16,7 @@ import {
   isModified
 } from 'glimmer-reference';
 import { ModifierManager } from '../../modifier/interfaces';
-import { NULL_REFERENCE } from '../../references';
-import { ValueReference } from '../../compiled/expressions/value';
+import { NULL_REFERENCE, PrimitiveReference } from '../../references';
 import { CompiledArgs, EvaluatedArgs } from '../../compiled/expressions/args';
 import { AttributeManager } from '../../dom/attribute-managers';
 import { ElementOperations } from '../../builder';
@@ -150,7 +149,7 @@ class ClassList {
 
     if (!list) return NULL_REFERENCE;
 
-    if (isConst) return new ValueReference(toClassName(list));
+    if (isConst) return PrimitiveReference.create(toClassName(list));
 
     return new ClassListReference(list);
   }
@@ -192,7 +191,7 @@ export class SimpleElementOperations implements ElementOperations {
 
   addStaticAttribute(element: Simple.Element, name: string, value: string) {
     if (name === 'class') {
-      this.addClass(new ValueReference(value));
+      this.addClass(PrimitiveReference.create(value));
     } else {
       this.env.getAppendOperations().setAttribute(element, name, value);
     }
@@ -277,7 +276,7 @@ export class ComponentElementOperations implements ElementOperations {
 
   addStaticAttribute(element: Simple.Element, name: string, value: string) {
     if (name === 'class') {
-      this.addClass(new ValueReference(value));
+      this.addClass(PrimitiveReference.create(value));
     } else if (this.shouldAddAttribute(name)) {
       this.addAttribute(name, new StaticAttribute(element, name, value));
     }

--- a/packages/glimmer-runtime/lib/references.ts
+++ b/packages/glimmer-runtime/lib/references.ts
@@ -1,13 +1,69 @@
 import { RevisionTag, ConstReference, PathReference, Reference } from 'glimmer-reference';
 import { Opaque } from 'glimmer-util';
 
-export type Primitive = string | number | boolean;
+export type Primitive = undefined | null | boolean | number | string;
 
-export class PrimitiveReference extends ConstReference<any> implements PathReference<Primitive> {
-  get(): PrimitiveReference {
+export class PrimitiveReference<T extends Primitive> extends ConstReference<T> implements PathReference<T> {
+  static create(value: undefined): PrimitiveReference<undefined>;
+  static create(value: null): PrimitiveReference<null>;
+  static create(value: boolean): PrimitiveReference<boolean>;
+  static create(value: number): PrimitiveReference<number>;
+  static create(value: string): PrimitiveReference<string>;
+  static create(value: Primitive): PrimitiveReference<Primitive> {
+    if (value === undefined) {
+      return UNDEFINED_REFERENCE;
+    } else if (value === null) {
+      return NULL_REFERENCE;
+    } else if (value === true) {
+      return TRUE_REFERENCE;
+    } else if (value === false) {
+      return FALSE_REFERENCE;
+    } else if (typeof value === 'number') {
+      return new ValueReference(value);
+    } else {
+      return new StringReference(value);
+    }
+  }
+
+  protected constructor(value: T) {
+    super(value);
+  }
+
+  get(key: string): PrimitiveReference<Primitive> {
     return UNDEFINED_REFERENCE;
   }
 }
+
+class StringReference extends PrimitiveReference<string> {
+  private lengthReference: PrimitiveReference<number> = null;
+
+  get(key: string): PrimitiveReference<Primitive> {
+    if (key === 'length') {
+      let { lengthReference } = this;
+
+      if (lengthReference === null) {
+        lengthReference = this.lengthReference = new ValueReference(this.inner.length);
+      }
+
+      return lengthReference;
+    } else {
+      return super.get(key);
+    }
+  }
+}
+
+type Value = undefined | null | number | boolean;
+
+class ValueReference<T extends Value> extends PrimitiveReference<T> {
+  constructor(value: T) {
+    super(value);
+  }
+}
+
+export const UNDEFINED_REFERENCE: PrimitiveReference<undefined> = new ValueReference(undefined);
+export const NULL_REFERENCE: PrimitiveReference<null> = new ValueReference(null);
+const TRUE_REFERENCE: PrimitiveReference<boolean> = new ValueReference(true);
+const FALSE_REFERENCE: PrimitiveReference<boolean> = new ValueReference(false);
 
 export class ConditionalReference implements Reference<boolean> {
   public tag: RevisionTag;
@@ -24,6 +80,3 @@ export class ConditionalReference implements Reference<boolean> {
     return !!value;
   }
 }
-
-export const NULL_REFERENCE = new PrimitiveReference(null);
-export const UNDEFINED_REFERENCE = new PrimitiveReference(undefined);

--- a/packages/glimmer-runtime/tests/ember-component-test.ts
+++ b/packages/glimmer-runtime/tests/ember-component-test.ts
@@ -522,6 +522,50 @@ testComponent('yield', {
   expected: 'Yes:Hello42outer'
 });
 
+[
+  {
+    value: 'true',
+    output: 'true'
+  }, {
+    value: 'false',
+    output: 'false'
+  }, {
+    value: 'null',
+    output: ''
+  }, {
+    value: 'undefined',
+    output: ''
+  }, {
+    value: '1',
+    output: '1'
+  }, {
+    value: '"foo"',
+    output: 'foo'
+  }
+].forEach(({ value, output }) => {
+  testComponent(`yielding ${value}`, {
+    layout: `{{yield ${value}}}`,
+
+    invokeAs: {
+      blockParams: ['yielded'],
+      template: '{{yielded}}-{{yielded.foo.bar}}'
+    },
+
+    expected: `${output}-`
+  });
+});
+
+testComponent(`yielding a string and rendering its length`, {
+  layout: `{{yield "foo"}}-{{yield ""}}`,
+
+  invokeAs: {
+    blockParams: ['yielded'],
+    template: '{{yielded}}-{{yielded.length}}'
+  },
+
+  expected: `foo-3--0`
+});
+
 testComponent('use a non-existent block param', {
   skip: 'glimmer',
   layout: '{{yield someValue}}',

--- a/packages/glimmer-runtime/tests/updating-test.ts
+++ b/packages/glimmer-runtime/tests/updating-test.ts
@@ -1,6 +1,6 @@
-import { EvaluatedArgs, Template, RenderResult, SafeString, ValueReference, VM } from "glimmer-runtime";
+import { UNDEFINED_REFERENCE, EvaluatedArgs, Template, RenderResult, SafeString, PrimitiveReference, VM } from "glimmer-runtime";
 import { BasicComponent, TestEnvironment, TestDynamicScope, TestModifierManager, equalTokens, stripTight, trimLines } from "glimmer-test-helpers";
-import { PathReference } from "glimmer-reference";
+import { ConstReference, PathReference } from "glimmer-reference";
 import { UpdatableReference } from "glimmer-object-reference";
 import { Opaque } from "glimmer-util";
 
@@ -671,6 +671,12 @@ test("triple curlies with empty string initial value", assert => {
   equalTokens(root, '<div></div>', "back to empty string");
 });
 
+class ValueReference<T> extends ConstReference<T> {
+  get(): PrimitiveReference<undefined> {
+    return UNDEFINED_REFERENCE;
+  }
+}
+
 test("double curlies with const SafeString", assert => {
   let rawString = '<b>bold</b> and spicy';
 
@@ -765,7 +771,7 @@ test("helpers can add destroyables", assert => {
 
   env.registerInternalHelper('destroy-me', (vm: VM, args: EvaluatedArgs) => {
     vm.newDestroyable(destroyable);
-    return new ValueReference<Opaque>('destroy me!');
+    return PrimitiveReference.create('destroy me!');
   });
 
   let template = compile('<div>{{destroy-me}}</div>');

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -45,7 +45,7 @@ import {
   InElementSyntax,
 
   // References
-  ValueReference,
+  PrimitiveReference,
   ConditionalReference,
 
   // Misc
@@ -777,7 +777,7 @@ export class TestEnvironment extends Environment {
 
   toConditionalReference(reference: Reference<any>): Reference<boolean> {
     if (isConst(reference)) {
-      return new ValueReference(emberToBool(reference.value()));
+      return PrimitiveReference.create(emberToBool(reference.value()));
     }
 
     return new EmberishConditionalReference(reference);
@@ -1065,14 +1065,14 @@ class StaticTaglessComponentLayoutCompiler extends GenericComponentLayoutCompile
 
 function EmberTagName(vm: VM): PathReference<string> {
   let self = vm.getSelf().value();
-  let tagName = self['tagName'];
+  let tagName: string = self['tagName'];
   tagName = tagName === '' ? null : self['tagName'] || 'div';
-  return new ValueReference(tagName);
+  return PrimitiveReference.create(tagName);
 }
 
 function EmberID(vm: VM): PathReference<string> {
   let self = vm.getSelf().value() as { _guid: string };
-  return new ValueReference(`ember${self._guid}`);
+  return PrimitiveReference.create(`ember${self._guid}`);
 }
 
 class EmberishCurlyComponentLayoutCompiler extends GenericComponentLayoutCompiler {


### PR DESCRIPTION
The previous `ValueReference` implementation does not handle edge cases in its `get` method very well. For example, `new ValueReference(5).get("foo").get("bar")` errors, causing bugs like https://github.com/emberjs/ember.js/issues/14326.

Instead of trying to fix the general case, we made `PrimitiveReference` public instead. This should cover the majority of the `ValueReference` use cases, and the host could implement its own reference type for the rest.