### PR TITLE
Prop removal bugfix

### DIFF
--- a/packages/glimmer-runtime/lib/dom/attribute-managers.ts
+++ b/packages/glimmer-runtime/lib/dom/attribute-managers.ts
@@ -18,6 +18,10 @@ export function defaultManagers(element: Simple.Element, attr: string, isTrustin
     return defaultAttributeManagers(tagName, attr);
   }
 
+  if (attr === 'href' || attr === 'src') {
+    return defaultAttributeManagers(tagName, attr);
+  }
+
   let { type, normalized } = normalizeProperty(element, attr);
 
   if (type === 'attr') {
@@ -110,10 +114,19 @@ export class PropertyManager extends AttributeManager {
   }
 
   updateAttribute(env: Environment, element: Element, value: Opaque, namespace?: DOMNamespace) {
+    let attr = this.attr;
+    if (value === undefined) {
+      value = null;
+    }
+
+    if (value === null && (attr === 'value' || attr === 'type')) {
+      value = '';
+    }
+
+    element[attr] = value;
+
     if (isAttrRemovalValue(value)) {
       this.removeAttribute(env, element, namespace);
-    } else {
-      this.setAttribute(env, element, value, namespace);
     }
   }
 };

--- a/packages/glimmer-runtime/lib/dom/attribute-managers.ts
+++ b/packages/glimmer-runtime/lib/dom/attribute-managers.ts
@@ -18,10 +18,6 @@ export function defaultManagers(element: Simple.Element, attr: string, isTrustin
     return defaultAttributeManagers(tagName, attr);
   }
 
-  if (attr === 'href' || attr === 'src') {
-    return defaultAttributeManagers(tagName, attr);
-  }
-
   let { type, normalized } = normalizeProperty(element, attr);
 
   if (type === 'attr') {
@@ -114,16 +110,8 @@ export class PropertyManager extends AttributeManager {
   }
 
   updateAttribute(env: Environment, element: Element, value: Opaque, namespace?: DOMNamespace) {
-    let attr = this.attr;
-    if (value === undefined) {
-      value = null;
-    }
-
-    if (value === null && (attr === 'value' || attr === 'type')) {
-      value = '';
-    }
-
-    element[attr] = value;
+    // ensure the property is always updated
+    element[this.attr] = value;
 
     if (isAttrRemovalValue(value)) {
       this.removeAttribute(env, element, namespace);

--- a/packages/glimmer-runtime/tests/attributes-test.ts
+++ b/packages/glimmer-runtime/tests/attributes-test.ts
@@ -433,7 +433,7 @@ test('handles undefined `toString` input values', assert => {
   assert.equal(readDOMAttr(root.firstChild as Element, 'value'), '');
 });
 
-test('props update when used with helpers', assert => {
+test('input[checked] prop updates when set to undefined', assert => {
   let template = compile('<input checked={{if foo true undefined}} />');
 
   env.registerHelper('if', (params) => {
@@ -455,6 +455,40 @@ test('props update when used with helpers', assert => {
   rerender({ foo: true });
 
   assert.equal(readDOMAttr(root.firstChild as Element, 'checked'), true);
+});
+
+test('input[checked] prop updates when set to null', assert => {
+  let template = compile('<input checked={{foo}} />');
+
+  render(template, { foo: true });
+
+  assert.equal(readDOMAttr(root.firstChild as Element, 'checked'), true);
+
+  rerender({ foo: null });
+
+  assert.equal(readDOMAttr(root.firstChild as Element, 'checked'), false);
+
+  rerender({ foo: true });
+
+  assert.equal(readDOMAttr(root.firstChild as Element, 'checked'), true);
+});
+
+test('select[value] prop updates when set to undefined', assert => {
+  let template = compile('<select value={{foo}}><option></option><option value="us" selected>us</option></select>');
+
+  // setting `select[value]` only works after initial render, just use `undefined` here but it doesn't really matter
+  render(template, { foo: undefined });
+
+  assert.equal(readDOMAttr(root.firstChild as Element, 'value'), 'us');
+
+  // now setting the `value` property will have an effect
+  rerender({ foo: null });
+
+  assert.equal(readDOMAttr(root.firstChild as Element, 'value'), '');
+
+  rerender({ foo: 'us' });
+
+  assert.equal(readDOMAttr(root.firstChild as Element, 'value'), 'us');
 });
 
 test('handles empty string textarea values', assert => {

--- a/packages/glimmer-runtime/tests/attributes-test.ts
+++ b/packages/glimmer-runtime/tests/attributes-test.ts
@@ -433,6 +433,30 @@ test('handles undefined `toString` input values', assert => {
   assert.equal(readDOMAttr(root.firstChild as Element, 'value'), '');
 });
 
+test('props update when used with helpers', assert => {
+  let template = compile('<input checked={{if foo true undefined}} />');
+
+  env.registerHelper('if', (params) => {
+    if (params[0]) {
+      return params[1];
+    } else {
+      return params[2];
+    }
+  });
+
+  render(template, { foo: true });
+
+  assert.equal(readDOMAttr(root.firstChild as Element, 'checked'), true);
+
+  rerender({ foo: false });
+
+  assert.equal(readDOMAttr(root.firstChild as Element, 'checked'), false);
+
+  rerender({ foo: true });
+
+  assert.equal(readDOMAttr(root.firstChild as Element, 'checked'), true);
+});
+
 test('handles empty string textarea values', assert => {
   let template = compile('<textarea value={{name}} />');
 


### PR DESCRIPTION
According to the semantics today we stringify `null` and covert `undefined` to `null`. In some cases we coerce `null` into an empty string. Here is [repro on 2.9.0](https://ember-twiddle.com/8293ea339131a709a3b36ca4ac09876a?openFiles=templates.application.hbs%2C) that confirms this, also illustrates this is broken in the beta if you switch the Ember versions.

I still need to link this to Ember and fix any failing tests as well. /cc @krisselden 

