### PR TITLE
Bump QUnit

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "exists-sync": "0.0.3",
     "git-repo-version": "^0.1.2",
     "handlebars": "^3.0.2",
-    "qunit": "^0.7.2",
+    "qunit": "^0.9.1",
     "simple-dom": "^0.3.0",
     "simple-html-tokenizer": "^0.2.5",
     "typescript": "^2.0.0"


### PR DESCRIPTION
There is a transitive dependency using a branch of esprima in an older
version of Qunit, making hard for us to use this internally. This
version appears to not have this issue.