### PR TITLE
Fix yielding values in partials

### DIFF
--- a/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/builder.ts
@@ -342,16 +342,22 @@ export default class OpcodeBuilder extends BasicOpcodeBuilder {
     this.append(vm.BindPositionalArgsOpcode.create(block));
   }
 
-  bindNamedArgsForLayout(layout: Layout) {
-    this.append(vm.BindNamedArgsOpcode.create(layout));
-  }
+  preludeForLayout(layout: Layout) {
+    if (layout.hasNamedParameters) {
+      this.append(vm.BindNamedArgsOpcode.create(layout));
+    }
 
-  bindBlocksForLayout(layout: Layout) {
-    this.append(vm.BindBlocksOpcode.create(layout));
-  }
+    if (layout.hasYields || layout.hasPartials) {
+      this.append(new vm.BindCallerScopeOpcode());
+    }
 
-  bindPartialArgsForLayout(layout: Layout) {
-    this.append(vm.BindPartialArgsOpcode.create(layout));
+    if (layout.hasYields) {
+      this.append(vm.BindBlocksOpcode.create(layout));
+    }
+
+    if (layout.hasPartials) {
+      this.append(vm.BindPartialArgsOpcode.create(layout));
+    }
   }
 
   // TODO

--- a/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
+++ b/packages/glimmer-runtime/lib/compiled/opcodes/vm.ts
@@ -205,6 +205,14 @@ export class BindPartialArgsOpcode extends Opcode {
   }
 }
 
+export class BindCallerScopeOpcode extends Opcode {
+  public type = "bind-caller-scope";
+
+  evaluate(vm: VM) {
+    vm.bindCallerScope();
+  }
+}
+
 export class BindDynamicScopeOpcode extends Opcode {
   public type = "bind-dynamic-scope";
 

--- a/packages/glimmer-runtime/lib/compiler.ts
+++ b/packages/glimmer-runtime/lib/compiler.ts
@@ -265,17 +265,7 @@ class WrappedBuilder {
       dsl.flushElement();
     }
 
-    if (layout.hasNamedParameters) {
-      dsl.bindNamedArgsForLayout(layout);
-    }
-
-    if (layout.hasYields) {
-      dsl.bindBlocksForLayout(layout);
-    }
-
-    if (layout.hasPartials) {
-      dsl.bindPartialArgsForLayout(layout);
-    }
+    dsl.preludeForLayout(layout);
 
     layout.program.forEachNode(statement => compileStatement(env, statement, dsl, layout));
 
@@ -313,17 +303,7 @@ class UnwrappedBuilder {
 
     dsl.startLabels();
 
-    if (layout.hasNamedParameters) {
-      dsl.bindNamedArgsForLayout(layout);
-    }
-
-    if (layout.hasYields) {
-      dsl.bindBlocksForLayout(layout);
-    }
-
-    if (layout.hasPartials) {
-      dsl.bindPartialArgsForLayout(layout);
-    }
+    dsl.preludeForLayout(layout);
 
     let attrs = this.attrs['buffer'];
     let attrsInserted = false;

--- a/packages/glimmer-runtime/lib/vm/append.ts
+++ b/packages/glimmer-runtime/lib/vm/append.ts
@@ -334,12 +334,11 @@ export default class VM implements PublicVM {
 
   bindNamedArgs(names: string[], symbols: number[]) {
     let args = this.frame.getArgs();
+    let scope = this.scope();
 
     assert(args, "Cannot bind named args");
 
     let { named } = args;
-
-    let scope = this.scope();
 
     for(let i=0; i < names.length; i++) {
       scope.bindSymbol(symbols[i], named.get(names[i]));
@@ -348,11 +347,7 @@ export default class VM implements PublicVM {
 
   bindBlocks(names: string[], symbols: number[]) {
     let blocks = this.frame.getBlocks();
-    let callerScope = this.frame.getCallerScope();
-
     let scope = this.scope();
-
-    scope.bindCallerScope(callerScope);
 
     for(let i=0; i < names.length; i++) {
       scope.bindBlock(symbols[i], (blocks && blocks[names[i]]) || null);
@@ -361,18 +356,27 @@ export default class VM implements PublicVM {
 
   bindPartialArgs(symbol: number) {
     let args = this.frame.getArgs();
+    let scope = this.scope();
 
     assert(args, "Cannot bind named args");
 
-    this.scope().bindPartialArgs(symbol, args);
+    scope.bindPartialArgs(symbol, args);
+  }
+
+  bindCallerScope() {
+    let callerScope = this.frame.getCallerScope();
+    let scope = this.scope();
+
+    assert(callerScope, "Cannot bind caller scope");
+
+    scope.bindCallerScope(callerScope);
   }
 
   bindDynamicScope(names: string[]) {
     let args = this.frame.getArgs();
+    let scope = this.dynamicScope();
 
     assert(args, "Cannot bind dynamic scope");
-
-    let scope = this.dynamicScope();
 
     for(let i=0; i < names.length; i++) {
       scope.set(names[i], args.named.get(names[i]));

--- a/packages/glimmer-runtime/tests/partial-test.ts
+++ b/packages/glimmer-runtime/tests/partial-test.ts
@@ -232,20 +232,20 @@ QUnit.test('static partial with has-block-params in curly component', assert => 
 
 QUnit.test('static partial with yield in basic component', assert => {
   env.registerBasicComponent('foo-bar', BasicComponent, `<p>{{partial 'test'}}</p>`);
-  env.registerBasicComponent('foo-bar-baz', BasicComponent, `<p>{{partial 'test'}}-{{yield}}-{{yield to='inverse'}}</p>`);
-  env.registerPartial('test', `{{yield}}-{{yield to='inverse'}}`);
+  env.registerBasicComponent('foo-bar-baz', BasicComponent, `<p>{{partial 'test'}}-{{yield "layout"}}-{{yield to='inverse'}}</p>`);
+  env.registerPartial('test', `{{yield "partial"}}-{{yield to='inverse'}}`);
 
   render(compile(strip`
-    <foo-bar>a block</foo-bar>
+    <foo-bar as |source|>from {{source}}</foo-bar>
     <foo-bar />
-    <foo-bar-baz>a block</foo-bar-baz>
+    <foo-bar-baz as |source|>from {{source}}</foo-bar-baz>
     <foo-bar-baz />
   `));
 
   equalTokens(root, strip`
-    <p>a block-</p>
+    <p>from partial-</p>
     <p>-</p>
-    <p>a block--a block-</p>
+    <p>from partial--from layout-</p>
     <p>---</p>
   `);
 
@@ -258,24 +258,24 @@ QUnit.test('static partial with yield in curly component', assert => {
   }
 
   env.registerEmberishCurlyComponent('foo-bar', TaglessComponent as any, `<p>{{partial 'test'}}</p>`);
-  env.registerEmberishCurlyComponent('foo-bar-baz', TaglessComponent as any, `<p>{{partial 'test'}}-{{yield}}-{{yield to='inverse'}}</p>`);
-  env.registerPartial('test', `{{yield}}-{{yield to='inverse'}}`);
+  env.registerEmberishCurlyComponent('foo-bar-baz', TaglessComponent as any, `<p>{{partial 'test'}}-{{yield "layout"}}-{{yield to='inverse'}}</p>`);
+  env.registerPartial('test', `{{yield "partial"}}-{{yield to='inverse'}}`);
 
   render(compile(strip`
-    {{#foo-bar}}a block{{/foo-bar}}
-    {{#foo-bar}}a block{{else}}inverse{{/foo-bar}}
+    {{#foo-bar as |source|}}from {{source}}{{/foo-bar}}
+    {{#foo-bar as |source|}}from {{source}}{{else}}inverse{{/foo-bar}}
     {{foo-bar}}
-    {{#foo-bar-baz}}a block{{/foo-bar-baz}}
-    {{#foo-bar-baz}}a block{{else}}inverse{{/foo-bar-baz}}
+    {{#foo-bar-baz as |source|}}from {{source}}{{/foo-bar-baz}}
+    {{#foo-bar-baz as |source|}}from {{source}}{{else}}inverse{{/foo-bar-baz}}
     {{foo-bar-baz}}
   `));
 
   equalTokens(root, strip`
-    <p>a block-</p>
-    <p>a block-inverse</p>
+    <p>from partial-</p>
+    <p>from partial-inverse</p>
     <p>-</p>
-    <p>a block--a block-</p>
-    <p>a block-inverse-a block-inverse</p>
+    <p>from partial--from layout-</p>
+    <p>from partial-inverse-from layout-inverse</p>
     <p>---</p>
   `);
 


### PR DESCRIPTION
- Move the "prelude" compilation into the DSL
- Ensure component layouts using partials always get the caller scope

Fixes emberjs/ember.js#14642