### PR TITLE
Fix allocing for arg compilation

### DIFF
--- a/packages/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/glimmer-runtime/lib/syntax/core.ts
@@ -1144,7 +1144,13 @@ export class NamedArgs {
 
   compile(compiler: SymbolLookup, env: Environment, symbolTable: SymbolTable): CompiledNamedArgs {
     let { keys, values } = this;
-    return new CompiledNamedArgs(keys, values.map(value => value.compile(compiler, env, symbolTable)));
+    let compiledValues = new Array(values.length);
+
+    for (let i = 0; i < compiledValues.length; i++) {
+      compiledValues[i] = values[i].compile(compiler, env, symbolTable);
+    }
+
+    return new CompiledNamedArgs(keys, compiledValues);
   }
 }
 


### PR DESCRIPTION
This is a very hot path and we need to make sure we are not allocing
context objects each time we compile the args. Still need to alloc
the array but that is far less of an issue than each context created by
`map`.