### PR TITLE
[BUGFIX] Only freeze empty array/dict with weakmap

### DIFF
--- a/packages/glimmer-runtime/lib/utils.ts
+++ b/packages/glimmer-runtime/lib/utils.ts
@@ -1,7 +1,18 @@
 import { Dict, dict } from 'glimmer-util';
 
-export const EMPTY_ARRAY = Object.freeze([]);
-export const EMPTY_DICT: Dict<any> = Object.freeze(dict<any>());
+const HAS_NATIVE_WEAKMAP = (function() {
+  // detect if `WeakMap` is even present
+  let hasWeakMap = typeof WeakMap === 'function';
+  if (!hasWeakMap) { return false; }
+
+  let instance = new WeakMap();
+  // use `Object`'s `.toString` directly to prevent us from detecting
+  // polyfills as native weakmaps
+  return Object.prototype.toString.call(instance) === '[object WeakMap]';
+})();
+
+export const EMPTY_ARRAY = HAS_NATIVE_WEAKMAP ? Object.freeze([]) : [];
+export const EMPTY_DICT: Dict<any> = HAS_NATIVE_WEAKMAP ? Object.freeze(dict<any>()) : dict<any>();
 
 export interface EnumerableCallback<T> {
   (item: T): void;


### PR DESCRIPTION
When arrays and objects are frozen in JavaScript, it is impossible to attach meta-data (like Ember's own `meta`) to them without using a WeakMap. Ember does adopt the WeakMap strategy in browsers that support it, however there are still supported environments (IE9, IE10) where `Object.freeze` is supported but WeakMap is not. But not freezing these empty arrays and object if WeakMap is missing, legacy meta-data strategies are permitted on those instances.

The change here is untested, however I will add upstream tests in Ember for the relevant cases.

See:

* https://github.com/emberjs/ember.js/issues/14264
* https://github.com/emberjs/ember.js/pull/14244

The approach here is pretty naive. Some other more complex approaches I considered were:

* Attach WeakMap support status to the `env`. This, however, would mean the empty evaluated and compiles positional and named arguments instances could not be eagerly created.
* Export the `HAS_NATIVE_WEAKMAP` value from Glimmer's `glimmer-runtime` package and use that instead of [Ember's implementation](https://github.com/emberjs/ember.js/pull/14649/files#diff-e8a6258f04592c4708f56818ff9f60a3R1). This would remove some small duplication, but it feels a bit weird to have `HAS_NATIVE_WEAKMAP` as a glimmer export.

Happy to make edits in one of those directions.