### PR TITLE
Better error for stray quotes

### DIFF
--- a/packages/glimmer-compiler/lib/template-compiler.ts
+++ b/packages/glimmer-compiler/lib/template-compiler.ts
@@ -86,13 +86,16 @@ export default class TemplateCompiler<T extends TemplateMeta> {
   }
 
   attribute([action]) {
-    let { name, value } = action;
+    let { name, value, loc } = action;
 
     let namespace = getAttrNamespace(name);
 
     let isStatic = this.prepareAttributeValue(value);
-
-    if (name.charAt(0) === '@') {
+    let firstChar = name.charAt(0);
+    if (firstChar === '"' || firstChar === "'") {
+      throw new Error(`attribute cannot start with ${firstChar} (line ${loc.start.line}, column ${loc.start.column})`);
+    }
+    if (firstChar === '@') {
       // Arguments
       if (isStatic) {
         this.opcode('staticArg', action, name);

--- a/packages/glimmer-runtime/tests/attributes-test.ts
+++ b/packages/glimmer-runtime/tests/attributes-test.ts
@@ -668,3 +668,9 @@ test("input list attribute updates properly", () => {
 
   equalTokens(root, '<input list="bar" />');
 });
+
+test("rejects attribute names that begin with quotes", assert => {
+  assert.throws(() => {
+    compile('<div " />');
+  }, /attribute cannot start with " \(line 1, column 5\)/);
+});


### PR DESCRIPTION
Currently, a template like

    <div " ></div>

parses as having an attribute whose name is a double quote character. Similarly

    <div foo="bar""></div>

Parses as having two attributes. The correct `foo`, and an additional `"` attribute.

Since these are not caught at compile time, they result in confusing runtime errors when the DOM rejects our `setAttribute` with these invalid names.

This change produces a compile-time error instead, with proper line and column attribution.