### PR TITLE
Nested angle bracket components test

### DIFF
--- a/packages/@glimmer/runtime/tests/component-test.ts
+++ b/packages/@glimmer/runtime/tests/component-test.ts
@@ -61,6 +61,8 @@ class MyComponent extends BasicComponent {
   }
 }
 
+class MyOtherComponent extends BasicComponent {}
+
 QUnit.test('creating a new component', assert => {
   let template = compile("<my-component color='{{color}}'>hello!</my-component>");
   render(template, { color: 'red' });
@@ -88,6 +90,16 @@ QUnit.test('attrs are available in the layout', assert => {
   equalTokens(root, "<div color='red'><p>red</p>hello!</div>");
   rerender({ color: 'green' });
   equalTokens(root, "<div color='green'><p>green</p>hello!</div>");
+});
+
+QUnit.test('nested components', assert => {
+  env.registerBasicComponent('my-other-component', MyOtherComponent, '<p>{{yield}}</p>');
+  let template = compile('<my-component><my-other-component>{{color}}</my-other-component></my-component>');
+  render(template, { color: 'red' });
+
+  equalTokens(root, '<div><p>red</p></div>');
+  rerender({ color: 'green' });
+  equalTokens(root, '<div><p>green</p></div>');
 });
 
 function testError(layout: string, expected: RegExp) {


### PR DESCRIPTION
Addresses #359. Note that this is not in the context of Ember but rather [standalone Glimmer](https://github.com/robbiepitts/sparkles).

This works:

```hbs
{{#my-component}}
  {{#my-other-component}}
    Hello!
  {{/my-other-component}}
{{/my-component}}
```

This results in an error:

```xml
<my-component>
  <my-other-component>
    Hello!
  </my-other-component>
</my-component>
```

```
TypeError: Cannot read property 'scan' of null
    at BlockScanner.addStatement (http://localhost:7357/amd/glimmer-runtime.amd.js:6937:54)
    at OpenElement.tagContents (http://localhost:7357/amd/glimmer-runtime.amd.js:8200:25)
    at OpenElement.scan (http://localhost:7357/amd/glimmer-runtime.amd.js:8145:22)
    at BlockScanner.addStatement (http://localhost:7357/amd/glimmer-runtime.amd.js:6937:55)
    at BlockScanner.scan (http://localhost:7357/amd/glimmer-runtime.amd.js:6904:22)
    at buildStatements (http://localhost:7357/amd/glimmer-runtime.amd.js:6885:71)
    at Scanner.scanEntryPoint (http://localhost:7357/amd/glimmer-runtime.amd.js:6850:27)
    at asEntryPoint (http://localhost:7357/amd/glimmer-runtime.amd.js:9104:51)
    at Object.render (http://localhost:7357/amd/glimmer-runtime.amd.js:9117:28)
    at render (http://localhost:7357/amd/glimmer-tests.amd.js:3991:27)
```

My understanding of the problem:

1. `<my-component>` kicks off a scan of its children in `OpenElement#tagContents`.
2. First child is `<my-other-component>`, which also kicks off a scan of its children.
3. The `<my-other-component>` scan completes with `</my-other-component>`.
4. At this point the `<my-component>` scan's `nesting` variable (in `OpenElement#tagContents`) is at a value of 2. It started at one and was incremented when it hit `<my-other-component>`, so 2.
5. We now hit `</my-component>`, but because `nesting` is at 2 and not 1 we cannot decrement to 0 and break the loop; thus we continue…
6. The `BlockScanner` instance is out of statements, so now a call to `#next` results in `null`.
7. `scanner.addStatement(null)`
8. 💥 