### PR TITLE
[glimmer-syntax][bugfix] fix and test syntax generation bug with block params

### DIFF
--- a/packages/glimmer-syntax/lib/generation/print.ts
+++ b/packages/glimmer-syntax/lib/generation/print.ts
@@ -170,7 +170,7 @@ function compactJoin(array, delimiter?) {
 function blockParams(block) {
   const params = block.program.blockParams;
   if(params.length) {
-    return ` as |${params.join(',')}|`;
+    return ` as |${params.join(' ')}|`;
   }
 }
 

--- a/packages/glimmer-syntax/tests/generation/print-test.ts
+++ b/packages/glimmer-syntax/tests/generation/print-test.ts
@@ -64,7 +64,7 @@ test('SubExpression', function() {
 });
 
 test('BlockStatement: multiline', function() {
-  printEqual('<ul>{{#each foos as |foo|}}\n  {{foo}}\n{{/each}}</ul>');
+  printEqual('<ul>{{#each foos as |foo index|}}\n  <li>{{foo}}: {{index}}</li>\n{{/each}}</ul>');
 });
 
 test('BlockStatement: inline', function() {


### PR DESCRIPTION
Noticed this bug just browsing through the code. I'm also thinking of using this code generation for an experimental project I'm working on, so would be great to get this in!