### PR TITLE
Convert `Parser` to a class

### DIFF
--- a/packages/glimmer-syntax/lib/parser.ts
+++ b/packages/glimmer-syntax/lib/parser.ts
@@ -38,16 +38,59 @@ export function preprocess(html, options?) {
 
 const entityParser = new EntityParser(namedCharRefs);
 
-export function Parser(source, options) {
-  this.options = options || {};
-  this.elementStack = [];
-  this.tokenizer = new EventedTokenizer(this, entityParser);
+export class Parser {
+  constructor(source, options) {
+    this.options = options || {};
+    this.elementStack = [];
+    this.tokenizer = new EventedTokenizer(this, entityParser);
 
-  this.currentNode = null;
-  this.currentAttribute = null;
+    this.currentNode = null;
+    this.currentAttribute = null;
 
-  if (typeof source === 'string') {
-    this.source = source.split(/(?:\r\n?|\n)/g);
+    if (typeof source === 'string') {
+      this.source = source.split(/(?:\r\n?|\n)/g);
+    }
+  }
+
+  acceptNode(node) {
+    return this[node.type](node);
+  }
+
+  currentElement() {
+    return this.elementStack[this.elementStack.length - 1];
+  }
+
+  sourceForMustache(mustache) {
+    let firstLine = mustache.loc.start.line - 1;
+    let lastLine = mustache.loc.end.line - 1;
+    let currentLine = firstLine - 1;
+    let firstColumn = mustache.loc.start.column + 2;
+    let lastColumn = mustache.loc.end.column - 2;
+    let string = [];
+    let line;
+
+    if (!this.source) {
+      return '{{' + mustache.path.id.original + '}}';
+    }
+
+    while (currentLine < lastLine) {
+      currentLine++;
+      line = this.source[currentLine];
+
+      if (currentLine === firstLine) {
+        if (firstLine === lastLine) {
+          string.push(line.slice(firstColumn, lastColumn));
+        } else {
+          string.push(line.slice(firstColumn));
+        }
+      } else if (currentLine === lastLine) {
+        string.push(line.slice(0, lastColumn));
+      } else {
+        string.push(line);
+      }
+    }
+
+    return string.join('\n');
   }
 }
 
@@ -58,44 +101,3 @@ for (let key in handlebarsNodeVisitors) {
 for (let key in tokenizerEventHandlers) {
   Parser.prototype[key] = tokenizerEventHandlers[key];
 }
-
-Parser.prototype.acceptNode = function(node) {
-  return this[node.type](node);
-};
-
-Parser.prototype.currentElement = function() {
-  return this.elementStack[this.elementStack.length - 1];
-};
-
-Parser.prototype.sourceForMustache = function(mustache) {
-  let firstLine = mustache.loc.start.line - 1;
-  let lastLine = mustache.loc.end.line - 1;
-  let currentLine = firstLine - 1;
-  let firstColumn = mustache.loc.start.column + 2;
-  let lastColumn = mustache.loc.end.column - 2;
-  let string = [];
-  let line;
-
-  if (!this.source) {
-    return '{{' + mustache.path.id.original + '}}';
-  }
-
-  while (currentLine < lastLine) {
-    currentLine++;
-    line = this.source[currentLine];
-
-    if (currentLine === firstLine) {
-      if (firstLine === lastLine) {
-        string.push(line.slice(firstColumn, lastColumn));
-      } else {
-        string.push(line.slice(firstColumn));
-      }
-    } else if (currentLine === lastLine) {
-      string.push(line.slice(0, lastColumn));
-    } else {
-      string.push(line);
-    }
-  }
-
-  return string.join('\n');
-};


### PR DESCRIPTION
Addresses #368.

I considered defining the dynamic methods in the `constructor` method but decided against it because that is not a concern of instantiating the class. Going the prototype route also allows us to add the dynamic methods once instead of every time we instantiate.

cc @locks 