### PR TITLE
Report tokenization error states

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -85,9 +85,10 @@ module.exports = function(_options) {
   /*
    * ES6 Build
    */
-  var tokenizerPath = path.join(require.resolve('simple-html-tokenizer'), '..', '..', 'lib');
+  var tokenizerPath = path.join(require.resolve('simple-html-tokenizer'), '..', '..', 'src');
   // TODO: WAT, why does { } change the output so much....
-  var HTMLTokenizer = find(tokenizerPath, { });
+  var tokenizerTree = find(tokenizerPath, { });
+  var HTMLTokenizer = mv(tokenizerTree, "simple-html-tokenizer");
 
   var tsTree = find(packages, {
     include: ['**/*.ts'],

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "handlebars": "^3.0.2",
     "qunit": "^0.9.1",
     "simple-dom": "^0.3.0",
-    "simple-html-tokenizer": "^0.2.5"
+    "simple-html-tokenizer": "^0.3.0"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",

--- a/packages/@glimmer/compiler/package.json
+++ b/packages/@glimmer/compiler/package.json
@@ -17,7 +17,7 @@
     "@glimmer/syntax": "^0.5.3",
     "@glimmer/util": "^0.5.3",
     "@glimmer/wire-format": "^0.5.3",
-    "simple-html-tokenizer": "^0.2.5"
+    "simple-html-tokenizer": "^0.3.0"
   },
   "devDependencies": {
     "typescript": "^2.1.4"

--- a/packages/@glimmer/runtime/tests/initial-render-test.ts
+++ b/packages/@glimmer/runtime/tests/initial-render-test.ts
@@ -898,7 +898,7 @@ test("Block params in HTML syntax - Throws an error on invalid identifiers for p
   }, /Invalid identifier for block parameters: 'foo\.bar' in 'as \|x foo\.bar|'/);
   QUnit.throws(function() {
     compile('<x-bar as |x "foo"|></x-bar>');
-  }, /Invalid identifier for block parameters: '"foo"' in 'as \|x "foo"|'/);
+  }, /Syntax error at line 1 col 17: " is not a valid character within attribute names/);
   QUnit.throws(function() {
     compile('<x-bar as |foo[bar]|></x-bar>');
   }, /Invalid identifier for block parameters: 'foo\[bar\]' in 'as \|foo\[bar\]\|'/);

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -196,6 +196,10 @@ export default {
     let attribute = b.attr(name, value, loc);
 
     this.currentNode.attributes.push(attribute);
+  },
+
+  reportSyntaxError: function(message) {
+    throw new Error(`Syntax error at line ${this.tokenizer.line} col ${this.tokenizer.column}: ${message}`);
   }
 };
 

--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "handlebars": "^3.0.3",
-    "simple-html-tokenizer": "^0.2.5"
+    "simple-html-tokenizer": "^0.3.0"
   },
   "devDependencies": {
     "@types/handlebars": "^4.0.31",

--- a/packages/@glimmer/syntax/tests/parser-node-test.ts
+++ b/packages/@glimmer/syntax/tests/parser-node-test.ts
@@ -48,6 +48,20 @@ test("elements can have empty attributes", function() {
   ]));
 });
 
+test("disallowed quote in element space is rejected", function(assert) {
+  let t = '<img foo="bar"" >';
+  assert.throws(() => {
+    parse(t);
+  }, /Syntax error at line 1 col 14: " is not a valid character within attribute names/);
+});
+
+test("disallowed equals sign in element space is rejected", function(assert) {
+  let t = '<img =foo >';
+  assert.throws(() => {
+    parse(t);
+  }, /Syntax error at line 1 col 5: attribute name cannot start with equals sign/);
+});
+
 test("svg content", function() {
   let t = "<svg></svg>";
   astEqual(t, b.program([


### PR DESCRIPTION
This depends on https://github.com/tildeio/simple-html-tokenizer/pull/37, which adds the new `reportSyntaxError` events.

This supersedes https://github.com/tildeio/glimmer/pull/362