### PR TITLE
[glimmer-syntax][bugfix] codegen fixes

### DIFF
--- a/packages/@glimmer/syntax/lib/generation/print.ts
+++ b/packages/@glimmer/syntax/lib/generation/print.ts
@@ -170,7 +170,7 @@ function compactJoin(array, delimiter?) {
 function blockParams(block) {
   const params = block.program.blockParams;
   if(params.length) {
-    return ` as |${params.join(',')}|`;
+    return ` as |${params.join(' ')}|`;
   }
 }
 

--- a/packages/@glimmer/syntax/lib/generation/print.ts
+++ b/packages/@glimmer/syntax/lib/generation/print.ts
@@ -57,7 +57,7 @@ export default function build(ast) {
     }
     break;
     case 'MustacheCommentStatement': {
-      output.push(compactJoin(['{{!', ast.value, '}}']));
+      output.push(compactJoin(['{{!--', ast.value, '--}}']));
     }
     break;
     case 'ElementModifierStatement': {

--- a/packages/@glimmer/syntax/tests/generation/print-test.ts
+++ b/packages/@glimmer/syntax/tests/generation/print-test.ts
@@ -64,7 +64,7 @@ test('SubExpression', function() {
 });
 
 test('BlockStatement: multiline', function() {
-  printEqual('<ul>{{#each foos as |foo|}}\n  {{foo}}\n{{/each}}</ul>');
+  printEqual('<ul>{{#each foos as |foo index|}}\n  <li>{{foo}}: {{index}}</li>\n{{/each}}</ul>');
 });
 
 test('BlockStatement: inline', function() {

--- a/packages/@glimmer/syntax/tests/generation/print-test.ts
+++ b/packages/@glimmer/syntax/tests/generation/print-test.ts
@@ -1,5 +1,9 @@
 import { preprocess as parse, print, builders as b } from "@glimmer/syntax";
 
+function printTransform(template) {
+  return print(parse(template));
+}
+
 function printEqual(template) {
   const ast = parse(template);
   equal(print(ast), template);
@@ -99,13 +103,17 @@ test('HTML comment', function() {
 });
 
 test('Handlebars comment', function() {
-  printEqual('{{! foo }}');
+  equal(printTransform('{{! foo }}'), '{{!-- foo --}}');
 });
 
 test('Handlebars comment: in ElementNode', function() {
-  printEqual('<div {{! foo }}></div>');
+  printEqual('<div {{!-- foo --}}></div>');
 });
 
 test('Handlebars comment: in ElementNode children', function() {
-  printEqual('<div>{{! foo bar}}<b></b></div>');
+  printEqual('<div>{{!-- foo bar --}}<b></b></div>');
+});
+
+test('Handlebars in handlebar comment', function() {
+  printEqual('{{!-- {{foo-bar}} --}}');
 });

--- a/packages/@glimmer/syntax/tests/generation/print-test.ts
+++ b/packages/@glimmer/syntax/tests/generation/print-test.ts
@@ -5,8 +5,7 @@ function printTransform(template) {
 }
 
 function printEqual(template) {
-  const ast = parse(template);
-  equal(print(ast), template);
+  equal(printTransform(template), template);
 }
 
 QUnit.module('[glimmer-syntax] Code generation');


### PR DESCRIPTION
This PR adds tests and fixes two bugs in the current codegen printer:

1. block params should be separated by spaces
2. comments should alway be generated as multi-line comments