### PR TITLE
Disallow dotted helpers/modifiers

### DIFF
--- a/packages/glimmer-demos/lib/visualizer.ts
+++ b/packages/glimmer-demos/lib/visualizer.ts
@@ -374,7 +374,7 @@ function renderContent() {
   let app = env.compile($template.value);
 
   function compileLayout(component) {
-    let definition = env.getComponentDefinition([component]);
+    let definition = env.getComponentDefinition(component);
 
     let manager = definition.manager;
     let instance = manager.create(env, definition, EvaluatedArgs.empty(), new TestDynamicScope(), null, false);

--- a/packages/glimmer-runtime/lib/environment.ts
+++ b/packages/glimmer-runtime/lib/environment.ts
@@ -261,14 +261,14 @@ export abstract class Environment {
     return defaultManagers(element, attr, isTrusting, namespace);
   }
 
-  abstract hasHelper(helperName: string[], blockMeta: TemplateMeta): boolean;
-  abstract lookupHelper(helperName: string[], blockMeta: TemplateMeta): Helper;
+  abstract hasHelper(helperName: string, blockMeta: TemplateMeta): boolean;
+  abstract lookupHelper(helperName: string, blockMeta: TemplateMeta): Helper;
 
-  abstract hasModifier(modifierName: string[], blockMeta: TemplateMeta): boolean;
-  abstract lookupModifier(modifierName: string[], blockMeta: TemplateMeta): ModifierManager<Opaque>;
+  abstract hasModifier(modifierName: string, blockMeta: TemplateMeta): boolean;
+  abstract lookupModifier(modifierName: string, blockMeta: TemplateMeta): ModifierManager<Opaque>;
 
-  abstract hasComponentDefinition(tagName: string[], symbolTable: SymbolTable): boolean;
-  abstract getComponentDefinition(tagName: string[], symbolTable: SymbolTable): ComponentDefinition<Opaque>;
+  abstract hasComponentDefinition(tagName: string, symbolTable: SymbolTable): boolean;
+  abstract getComponentDefinition(tagName: string, symbolTable: SymbolTable): ComponentDefinition<Opaque>;
 
   abstract hasPartial(partialName: string, symbolTable: SymbolTable): boolean;
   abstract lookupPartial(PartialName: string, symbolTable: SymbolTable): PartialDefinition<TemplateMeta>;

--- a/packages/glimmer-runtime/lib/syntax/core.ts
+++ b/packages/glimmer-runtime/lib/syntax/core.ts
@@ -233,10 +233,10 @@ export class Modifier extends StatementSyntax {
   compile(compiler: CompileInto & SymbolLookup, env: Environment, symbolTable: SymbolTable) {
     let args = this.args.compile(compiler, env, symbolTable);
 
-    if (env.hasModifier(this.path, symbolTable)) {
+    if (env.hasModifier(this.path[0], symbolTable)) {
       compiler.append(new ModifierOpcode(
         this.path[0],
-        env.lookupModifier(this.path, symbolTable),
+        env.lookupModifier(this.path[0], symbolTable),
         args
       ));
     } else {
@@ -496,7 +496,7 @@ export class OpenElement extends StatementSyntax {
   scan(scanner: BlockScanner): StatementSyntax {
     let { tag } = this;
 
-    if (scanner.env.hasComponentDefinition([tag], this.symbolTable)) {
+    if (scanner.env.hasComponentDefinition(tag, this.symbolTable)) {
       let { args, attrs } = this.parameters(scanner);
       scanner.startBlock(this.blockParams);
       this.tagContents(scanner);
@@ -579,7 +579,7 @@ export class Component extends StatementSyntax {
   }
 
   compile(list: CompileInto & SymbolLookup, env: Environment, symbolTable: SymbolTable) {
-    let definition = env.getComponentDefinition([this.tag], symbolTable);
+    let definition = env.getComponentDefinition(this.tag, symbolTable);
     let args = this.args.compile(list as SymbolLookup, env, symbolTable);
     let shadow = this.attrs;
 
@@ -851,8 +851,8 @@ export class Unknown extends ExpressionSyntax<any> {
   compile(compiler: SymbolLookup, env: Environment, symbolTable: SymbolTable): CompiledExpression<Opaque> {
     let { ref } = this;
 
-    if (env.hasHelper(ref.parts, symbolTable)) {
-      return new CompiledHelper(ref.parts, env.lookupHelper(ref.parts, symbolTable), CompiledArgs.empty(), symbolTable);
+    if (env.hasHelper(ref.parts[0], symbolTable)) {
+      return new CompiledHelper(ref.parts, env.lookupHelper(ref.parts[0], symbolTable), CompiledArgs.empty(), symbolTable);
     } else {
       return this.ref.compile(compiler);
     }
@@ -880,9 +880,9 @@ export class Helper extends ExpressionSyntax<Opaque> {
   }
 
   compile(compiler: SymbolLookup, env: Environment, symbolTable: SymbolTable): CompiledExpression<Opaque> {
-    if (env.hasHelper(this.ref.parts, symbolTable)) {
+    if (env.hasHelper(this.ref.parts[0], symbolTable)) {
       let { args, ref } = this;
-      return new CompiledHelper(ref.parts, env.lookupHelper(ref.parts, symbolTable), args.compile(compiler, env, symbolTable), symbolTable);
+      return new CompiledHelper(ref.parts, env.lookupHelper(ref.parts[0], symbolTable), args.compile(compiler, env, symbolTable), symbolTable);
     } else {
       throw new Error(`Compile Error: ${this.ref.parts.join('.')} is not a helper`);
     }

--- a/packages/glimmer-runtime/tests/compile-errors-test.ts
+++ b/packages/glimmer-runtime/tests/compile-errors-test.ts
@@ -25,3 +25,21 @@ QUnit.test('explicit self ref with ./ is not allowed', assert => {
     env.compile('<div><p>{{./value}}</p></div>');
   }, new Error("Using \"./\" is not supported in Glimmer and unnecessary: \"./value\" on line 1."), "should throw error");
 });
+
+QUnit.test('helper invocation with dot-paths are not allowed', assert => {
+  assert.throws(() => {
+    env.compile('{{foo.bar some="args"}}');
+  }, new Error("`foo.bar` is not a valid name for a helper on line 1."), "should throw error");
+});
+
+QUnit.test('sub-expression helper invocation with dot-paths are not allowed', assert => {
+  assert.throws(() => {
+    env.compile('{{log (foo.bar some="args")}}');
+  }, new Error("`foo.bar` is not a valid name for a helper on line 1."), "should throw error");
+});
+
+QUnit.test('sub-expression modifier invocation with dot-paths are not allowed', assert => {
+  assert.throws(() => {
+    env.compile('<div {{foo.bar some="args"}} />');
+  }, new Error("`foo.bar` is not a valid name for a modifier on line 1."), "should throw error");
+});

--- a/packages/glimmer-test-helpers/lib/environment.ts
+++ b/packages/glimmer-test-helpers/lib/environment.ts
@@ -811,7 +811,7 @@ export class TestEnvironment extends Environment {
         return new DynamicComponentSyntax({ args, symbolTable });
       }
 
-      let component = this.getComponentDefinition(path, symbolTable);
+      let component = this.getComponentDefinition(path[0], symbolTable);
 
       if (component) {
         return new CurlyComponentSyntax({ args, definition: component, symbolTable });
@@ -825,16 +825,14 @@ export class TestEnvironment extends Environment {
     return super.refineStatement(statement, symbolTable);
   }
 
-  hasHelper(helperName: string[]) {
-    return helperName.length === 1 && (<string>helperName[0] in this.helpers);
+  hasHelper(helperName: string) {
+    return helperName in this.helpers;
   }
 
-  lookupHelper(helperParts: string[]) {
-    let helperName = helperParts[0];
-
+  lookupHelper(helperName: string) {
     let helper = this.helpers[helperName];
 
-    if (!helper) throw new Error(`Helper for ${helperParts.join('.')} not found.`);
+    if (!helper) throw new Error(`Helper for ${helperName} not found.`);
 
     return helper;
   }
@@ -849,24 +847,22 @@ export class TestEnvironment extends Environment {
     return partial;
   }
 
-  hasComponentDefinition(name: string[]): boolean {
-    return !!this.components[name[0]];
+  hasComponentDefinition(name: string): boolean {
+    return !!this.components[name];
   }
 
-  getComponentDefinition(name: string[], blockMeta?: TemplateMeta): ComponentDefinition<any> {
-    return this.components[name[0]];
+  getComponentDefinition(name: string, blockMeta?: TemplateMeta): ComponentDefinition<any> {
+    return this.components[name];
   }
 
-  hasModifier(modifierName: string[]): boolean {
-    return modifierName.length === 1 && (<string>modifierName[0] in this.modifiers);
+  hasModifier(modifierName: string): boolean {
+    return modifierName in this.modifiers;
   }
 
-  lookupModifier(modifierName: string[]): ModifierManager<Opaque> {
-    let [name] = modifierName;
+  lookupModifier(modifierName: string): ModifierManager<Opaque> {
+    let modifier = this.modifiers[modifierName];
 
-    let modifier = this.modifiers[name];
-
-    if(!modifier) throw new Error(`Modifier for ${modifierName.join('.')} not found.`);
+    if(!modifier) throw new Error(`Modifier for ${modifierName} not found.`);
     return modifier;
   }
 
@@ -958,7 +954,7 @@ class DynamicComponentReference implements PathReference<ComponentDefinition<Opa
     let name = nameRef.value();
 
     if (typeof name === 'string') {
-      return env.getComponentDefinition([name], this.symbolTable);
+      return env.getComponentDefinition(name, this.symbolTable);
     } else {
       return null;
     }


### PR DESCRIPTION
We don't actually use this "feature" in Ember and it is making a lot of the lookups more complicated than they need to be.

With this change, `{{foo.bar}}` is statically known to be a `get`, as opposed to an `unknown` before, saving us a `hasHelper` lookup at runtime.

Closes emberjs/ember.js#13404.