### PR TITLE
Work around for rollup+babel symbol sadness

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
@@ -32,7 +32,7 @@ import {
   ConstantBlock
 } from '../../opcodes';
 
-function opcode(name: Op, op1?: number, op2?: number, op3?: number): AppendOpcode {
+function appendOpcode(name: Op, op1?: number, op2?: number, op3?: number): AppendOpcode {
   return APPEND_OPCODES.construct(name, null, op1, op2, op3);
 }
 
@@ -106,7 +106,7 @@ export abstract class BasicOpcodeBuilder implements SymbolLookup {
   }
 
   protected opcode(name: Op, op1?: number, op2?: number, op3?: number) {
-    this.push(opcode(name, op1, op2, op3));
+    this.push(appendOpcode(name, op1, op2, op3));
   }
 
   push(op: Option<AppendOpcode>) {


### PR DESCRIPTION
In the Ember build we want to do rollup -> babel. This works for vast majority of the code however there appears to be an issue with symbol mangling/detection. When we rollup the runtime, we have a `opcode` function and then an `opcode` argument. For some reason Babel does not correctly follow the symbol and instead mangles the argument but does not propagate it through the constructor. This leads to sadness. 

<img width="518" alt="screen shot 2017-01-15 at 3 09 07 pm" src="https://cloud.githubusercontent.com/assets/183799/21996703/5dde9c14-dbe0-11e6-943e-dfcb14e5a2b7.png">

I linked locally and confirmed that Ember's tests are green with this workaround.