### PR TITLE
Test nested 'else if' body location with whitespace eaten

### DIFF
--- a/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
@@ -221,15 +221,13 @@ function updateTokenizerLocation(tokenizer, content) {
   let line = content.loc.start.line;
   let column = content.loc.start.column;
 
-  if (content.rightStripped) {
-    let offsets = calculateRightStrippedOffsets(content.original, content.value);
+  let offsets = calculateRightStrippedOffsets(content.original, content.value);
 
-    line = line + offsets.lines;
-    if (offsets.lines) {
-      column = offsets.columns;
-    } else {
-      column = column + offsets.columns;
-    }
+  line = line + offsets.lines;
+  if (offsets.lines) {
+    column = offsets.columns;
+  } else {
+    column = column + offsets.columns;
   }
 
   tokenizer.line = line;

--- a/packages/@glimmer/syntax/tests/loc-node-test.ts
+++ b/packages/@glimmer/syntax/tests/loc-node-test.ts
@@ -278,6 +278,22 @@ test("whitespace control - trailing", function() {
   locEqual(div, 3, 4, 3, 15, 'div inside truthy if block');
 });
 
+test("whitespace control - 'else if' trailing", function() {
+  let ast = parse(`
+  {{#if foo}}
+    {{bar}}
+  {{else if baz~}}
+    <div></div>
+  {{/if}}`);
+
+  let [,ifBlock] = ast.body;
+  let [nestedIfBlock] = ifBlock.inverse.body;
+  let [div] = nestedIfBlock.program.body;
+
+  locEqual(ifBlock, 2, 2, 6, 9, 'if block');
+  locEqual(div, 5, 4, 5, 15, 'div inside truthy else if block');
+});
+
 test("whitespace control - leading", function() {
   let ast = parse(`
   {{~#if foo}}


### PR DESCRIPTION
This PR introduces a test that should pass but does not with current glimmer code.

Problem:
```
{{#if foo}}
  {{bar}}
{{else if baz~}}
  <div></div>
{{/if}}
```
the snippet above reports the ```div``` tag starting on the same line as ```else if``` (as if it was appended to the line) which is obviously not correct.

Here's a snippet to investigate this structure parsed with glimmer: https://astexplorer.net/#/9zr8ioRZ4u
