### PR TITLE
Represent opcodes as integers in wire-format

### DIFF
--- a/packages/@glimmer/compiler/lib/javascript-compiler.ts
+++ b/packages/@glimmer/compiler/lib/javascript-compiler.ts
@@ -11,7 +11,8 @@ import {
   Statement,
   Statements,
   Expression,
-  Expressions
+  Expressions,
+  Ops
 } from '@glimmer/wire-format';
 
 export type str = string;
@@ -155,22 +156,22 @@ export default class JavaScriptCompiler<T extends TemplateMeta> {
   /// Statements
 
   text(content: string) {
-    this.push(['text', content]);
+    this.push([Ops.Text, content]);
   }
 
   append(trusted: boolean) {
-    this.push(['append', this.popValue<Expression>(), trusted]);
+    this.push([Ops.Append, this.popValue<Expression>(), trusted]);
   }
 
   comment(value: string) {
-    this.push(['comment', value]);
+    this.push([Ops.Comment, value]);
   }
 
   modifier(path: Path) {
     let params = this.popValue<Params>();
     let hash = this.popValue<Hash>();
 
-    this.push(['modifier', path, params, hash]);
+    this.push([Ops.Modifier, path, params, hash]);
   }
 
   block(path: Path, template: number, inverse: number) {
@@ -181,78 +182,78 @@ export default class JavaScriptCompiler<T extends TemplateMeta> {
     assert(typeof template !== 'number' || blocks[template] !== null, 'missing block in the compiler');
     assert(typeof inverse !== 'number' || blocks[inverse] !== null, 'missing block in the compiler');
 
-    this.push(['block', path, params, hash, blocks[template], blocks[inverse]]);
+    this.push([Ops.Block, path, params, hash, blocks[template], blocks[inverse]]);
   }
 
   openElement(tag: str, blockParams: string[]) {
     if (tag.indexOf('-') !== -1) {
       this.startComponent(blockParams);
     } else {
-      this.push(['open-element', tag, blockParams]);
+      this.push([Ops.OpenElement, tag, blockParams]);
     }
   }
 
   flushElement() {
-    this.push(['flush-element']);
+    this.push([Ops.FlushElement]);
   }
 
   closeElement(tag: str) {
     if (tag.indexOf('-') !== -1) {
       let component = this.endComponent();
-      this.push(['component', tag, component]);
+      this.push([Ops.Component, tag, component]);
     } else {
-      this.push(['close-element']);
+      this.push([Ops.CloseElement]);
     }
   }
 
   staticAttr(name: str, namespace: str) {
     let value = this.popValue<Expression>();
-    this.push(['static-attr', name, value, namespace]);
+    this.push([Ops.StaticAttr, name, value, namespace]);
   }
 
   dynamicAttr(name: str, namespace: str) {
     let value = this.popValue<Expression>();
-    this.push(['dynamic-attr', name, value, namespace]);
+    this.push([Ops.DynamicAttr, name, value, namespace]);
   }
 
   trustingAttr(name: str, namespace: str) {
     let value = this.popValue<Expression>();
-    this.push(['trusting-attr', name, value, namespace]);
+    this.push([Ops.TrustingAttr, name, value, namespace]);
   }
 
   staticArg(name: str) {
     let value = this.popValue<Expression>();
-    this.push(['static-arg', name.slice(1), value]);
+    this.push([Ops.StaticArg, name.slice(1), value]);
   }
 
   dynamicArg(name: str) {
     let value = this.popValue<Expression>();
-    this.push(['dynamic-arg', name.slice(1), value]);
+    this.push([Ops.DynamicArg, name.slice(1), value]);
   }
 
   yield(to: string) {
     let params = this.popValue<Params>();
-    this.push(['yield', to, params]);
+    this.push([Ops.Yield, to, params]);
     this.template.block.yields.add(to);
   }
 
   debugger() {
-    this.push(['debugger', null, null]);
+    this.push([Ops.Debugger, null, null]);
   }
 
   hasBlock(name: string) {
-    this.pushValue<Expressions.HasBlock>(['has-block', name]);
+    this.pushValue<Expressions.HasBlock>([Ops.HasBlock, name]);
     this.template.block.yields.add(name);
   }
 
   hasBlockParams(name: string) {
-    this.pushValue<Expressions.HasBlockParams>(['has-block-params', name]);
+    this.pushValue<Expressions.HasBlockParams>([Ops.HasBlockParams, name]);
     this.template.block.yields.add(name);
   }
 
   partial() {
     let params = this.popValue<Params>();
-    this.push(['partial', params[0]]);
+    this.push([Ops.Partial, params[0]]);
     this.template.block.hasPartials = true;
   }
 
@@ -260,34 +261,34 @@ export default class JavaScriptCompiler<T extends TemplateMeta> {
 
   literal(value: Expressions.Value | undefined) {
     if (value === undefined) {
-      this.pushValue<Expressions.Undefined>(['undefined']);
+      this.pushValue<Expressions.Undefined>([Ops.Undefined]);
     } else {
       this.pushValue<Expressions.Value>(value);
     }
   }
 
   unknown(path: string[]) {
-    this.pushValue<Expressions.Unknown>(['unknown', path]);
+    this.pushValue<Expressions.Unknown>([Ops.Unknown, path]);
   }
 
   arg(path: string[]) {
     this.template.block.named.add(path[0]);
-    this.pushValue<Expressions.Arg>(['arg', path]);
+    this.pushValue<Expressions.Arg>([Ops.Arg, path]);
   }
 
   get(path: string[]) {
-    this.pushValue<Expressions.Get>(['get', path]);
+    this.pushValue<Expressions.Get>([Ops.Get, path]);
   }
 
   concat() {
-    this.pushValue<Expressions.Concat>(['concat', this.popValue<Params>()]);
+    this.pushValue<Expressions.Concat>([Ops.Concat, this.popValue<Params>()]);
   }
 
   helper(path: string[]) {
     let params = this.popValue<Params>();
     let hash = this.popValue<Hash>();
 
-    this.pushValue<Expressions.Helper>(['helper', path, params, hash]);
+    this.pushValue<Expressions.Helper>([Ops.Helper, path, params, hash]);
   }
 
   /// Stack Management Opcodes

--- a/packages/@glimmer/node/tests/node-test.ts
+++ b/packages/@glimmer/node/tests/node-test.ts
@@ -274,8 +274,8 @@ module('default template id');
 QUnit.test('generates id in node', function (assert) {
   let template = precompile('hello');
   let obj = JSON.parse(template);
-  assert.equal(obj.id, 'ZDHnvwb1', 'short sha of template source');
+  assert.equal(obj.id, '3TlrituF', 'short sha of template source');
   template = precompile('hello', { meta: {moduleName: 'template/hello'} });
   obj = JSON.parse(template);
-  assert.equal(obj.id, 'mQsxG3uR', 'short sha of template source and meta');
+  assert.equal(obj.id, 'CiDxizBQ', 'short sha of template source and meta');
 });

--- a/packages/@glimmer/runtime/lib/compiler.ts
+++ b/packages/@glimmer/runtime/lib/compiler.ts
@@ -2,6 +2,7 @@ import { Environment } from './environment';
 import { SymbolTable } from '@glimmer/interfaces';
 import { CompiledProgram } from './compiled/blocks';
 import { Maybe, Option } from '@glimmer/util';
+import { Ops } from '@glimmer/wire-format';
 
 import {
   BaselineSyntax,
@@ -153,7 +154,7 @@ class WrappedBuilder {
 
 function isOpenElement(value: BaselineSyntax.AnyStatement): value is (BaselineSyntax.OpenPrimitiveElement | WireFormat.Statements.OpenElement) {
   let type = value[0];
-  return type === 'open-element' || type === 'open-primitive-element';
+  return type === Ops.OpenElement || type === Ops.OpenPrimitiveElement;
 }
 
 class UnwrappedBuilder {
@@ -222,7 +223,7 @@ class ComponentTagBuilder implements Component.ComponentTagBuilder {
 
   dynamic(tagName: FunctionExpression<string>) {
     this.isDynamic = true;
-    this.dynamicTagName = ['function', tagName];
+    this.dynamicTagName = [Ops.Function, tagName];
   }
 }
 
@@ -230,11 +231,11 @@ class ComponentAttrsBuilder implements Component.ComponentAttrsBuilder {
   private buffer: WireFormat.Statements.Attribute[] = [];
 
   static(name: string, value: string) {
-    this.buffer.push(['static-attr', name, value, null]);
+    this.buffer.push([Ops.StaticAttr, name, value, null]);
   }
 
   dynamic(name: string, value: FunctionExpression<string>) {
-    this.buffer.push(['dynamic-attr', name, ['function', value], null]);
+    this.buffer.push([Ops.DynamicAttr, name, [Ops.Function, value], null]);
   }
 }
 
@@ -256,7 +257,7 @@ export class ComponentBuilder implements IComponentBuilder {
   dynamic(definitionArgs: BaselineSyntax.Args, definition: DynamicDefinition, args: BaselineSyntax.Args, _symbolTable: SymbolTable, shadow: InlineBlock) {
     this.builder.unit(b => {
       b.putArgs(compileArgs(definitionArgs[0], definitionArgs[1], b));
-      b.putValue(['function', definition]);
+      b.putValue([Ops.Function, definition]);
       b.test('simple');
       b.enter('BEGIN', 'END');
       b.label('BEGIN');

--- a/packages/@glimmer/runtime/lib/scanner.ts
+++ b/packages/@glimmer/runtime/lib/scanner.ts
@@ -139,43 +139,45 @@ import { PathReference } from '@glimmer/reference';
 export namespace BaselineSyntax {
   import Core = WireFormat.Core;
 
+  const { Ops } = WireFormat;
+
   // TODO: use symbols for sexp[0]?
-  export type ScannedComponent = ['scanned-component', string, RawInlineBlock, WireFormat.Core.Hash, Option<RawInlineBlock>];
-  export const isScannedComponent = WireFormat.is<ScannedComponent>('scanned-component');
+  export type ScannedComponent = [number, string, RawInlineBlock, WireFormat.Core.Hash, Option<RawInlineBlock>];
+  export const isScannedComponent = WireFormat.is<ScannedComponent>(Ops.ScannedComponent);
 
   import Params = WireFormat.Core.Params;
   import Hash = WireFormat.Core.Hash;
   export type Block = InlineBlock;
 
-  export type OpenPrimitiveElement = ['open-primitive-element', string, string[]];
-  export const isPrimitiveElement = WireFormat.is<OpenPrimitiveElement>('open-primitive-element');
+  export type OpenPrimitiveElement = [number, string, string[]];
+  export const isPrimitiveElement = WireFormat.is<OpenPrimitiveElement>(Ops.OpenPrimitiveElement);
 
-  export type OptimizedAppend = ['optimized-append', WireFormat.Expression, boolean];
-  export const isOptimizedAppend = WireFormat.is<OptimizedAppend>('optimized-append');
+  export type OptimizedAppend = [number, WireFormat.Expression, boolean];
+  export const isOptimizedAppend = WireFormat.is<OptimizedAppend>(Ops.OptimizedAppend);
 
-  export type UnoptimizedAppend = ['unoptimized-append', WireFormat.Expression, boolean];
-  export const isUnoptimizedAppend = WireFormat.is<UnoptimizedAppend>('unoptimized-append');
+  export type UnoptimizedAppend = [number, WireFormat.Expression, boolean];
+  export const isUnoptimizedAppend = WireFormat.is<UnoptimizedAppend>(Ops.UnoptimizedAppend);
 
-  export type AnyDynamicAttr = ['any-dynamic-attr', string, WireFormat.Expression, Option<string>, boolean];
-  export const isAnyAttr = WireFormat.is<AnyDynamicAttr>('any-dynamic-attr');
+  export type AnyDynamicAttr = [number, string, WireFormat.Expression, Option<string>, boolean];
+  export const isAnyAttr = WireFormat.is<AnyDynamicAttr>(Ops.AnyDynamicAttr);
 
-  export type StaticPartial = ['static-partial', string];
-  export const isStaticPartial = WireFormat.is<StaticPartial>('static-partial');
-  export type DynamicPartial = ['dynamic-partial', WireFormat.Expression];
-  export const isDynamicPartial = WireFormat.is<DynamicPartial>('dynamic-partial');
+  export type StaticPartial = [number, string];
+  export const isStaticPartial = WireFormat.is<StaticPartial>(Ops.StaticPartial);
+  export type DynamicPartial = [number, WireFormat.Expression];
+  export const isDynamicPartial = WireFormat.is<DynamicPartial>(Ops.DynamicPartial);
 
   export type FunctionExpressionCallback<T> = (VM: PublicVM, symbolTable: SymbolTable) => PathReference<T>;
-  export type FunctionExpression = ['function', FunctionExpressionCallback<Opaque>];
-  export const isFunctionExpression = WireFormat.is<FunctionExpression>('function');
+  export type FunctionExpression = [number, FunctionExpressionCallback<Opaque>];
+  export const isFunctionExpression = WireFormat.is<FunctionExpression>(Ops.Function);
 
-  export type NestedBlock = ['nested-block', WireFormat.Core.Path, WireFormat.Core.Params, WireFormat.Core.Hash, Option<Block>, Option<Block>];
-  export const isNestedBlock = WireFormat.is<NestedBlock>('nested-block');
+  export type NestedBlock = [number, WireFormat.Core.Path, WireFormat.Core.Params, WireFormat.Core.Hash, Option<Block>, Option<Block>];
+  export const isNestedBlock = WireFormat.is<NestedBlock>(Ops.NestedBlock);
 
-  export type ScannedBlock = ['scanned-block', Core.Path, Core.Params, Core.Hash, Option<RawInlineBlock>, Option<RawInlineBlock>];
-  export const isScannedBlock = WireFormat.is<ScannedBlock>('scanned-block');
+  export type ScannedBlock = [number, Core.Path, Core.Params, Core.Hash, Option<RawInlineBlock>, Option<RawInlineBlock>];
+  export const isScannedBlock = WireFormat.is<ScannedBlock>(Ops.ScannedBlock);
 
-  export type Debugger = ['debugger'];
-  export const isDebugger = WireFormat.is<Debugger>('debugger');
+  export type Debugger = [number];
+  export const isDebugger = WireFormat.is<Debugger>(Ops.Debugger);
 
   export type Args = [Params, Hash, Option<Block>, Option<Block>];
 
@@ -216,6 +218,8 @@ export namespace BaselineSyntax {
   export type Program = AnyStatement[];
 }
 
+const { Ops } = WireFormat;
+
 export class RawInlineBlock {
   constructor(private env: Environment, private table: SymbolTable, private statements: SerializedStatement[]) {}
 
@@ -238,7 +242,7 @@ export class RawInlineBlock {
 
   private specializeBlock(block: WireFormat.Statements.Block): BaselineSyntax.ScannedBlock {
     let [, path, params, hash, template, inverse] = block;
-    return ['scanned-block', path, params, hash, this.child(template), this.child(inverse)];
+    return [Ops.ScannedBlock, path, params, hash, this.child(template), this.child(inverse)];
   }
 
   private specializeComponent(sexp: WireFormat.Statements.Component): BaselineSyntax.AnyStatement[] {
@@ -247,14 +251,14 @@ export class RawInlineBlock {
     if (this.env.hasComponentDefinition([tag], this.table)) {
       let child = this.child(component);
       let attrs = new RawInlineBlock(this.env, this.table, component.attrs);
-      return [['scanned-component', tag, attrs, component.args, child]];
+      return [[Ops.ScannedComponent, tag, attrs, component.args, child]];
     } else {
       let buf: BaselineSyntax.AnyStatement[] = [];
-      buf.push(['open-element', tag, []]);
+      buf.push([Ops.OpenElement, tag, []]);
       buf.push(...component.attrs);
-      buf.push(['flush-element']);
+      buf.push([Ops.FlushElement]);
       buf.push(...component.statements);
-      buf.push(['close-element']);
+      buf.push([Ops.CloseElement]);
       return buf;
     }
   }

--- a/packages/@glimmer/runtime/lib/syntax/specialize.ts
+++ b/packages/@glimmer/runtime/lib/syntax/specialize.ts
@@ -33,33 +33,35 @@ export const SPECIALIZE = new Specialize();
 import S = WireFormat.Statements;
 import E = WireFormat.Expressions;
 
-SPECIALIZE.add('append', (sexp: S.Append, _symbolTable) => {
+const { Ops } = WireFormat;
+
+SPECIALIZE.add(Ops.Append, (sexp: S.Append, _symbolTable) => {
   let path = sexp[1];
 
   if (Array.isArray(path) && (E.isUnknown(path) || E.isGet(path))) {
     if (path[1].length !== 1) {
 
-      return ['unoptimized-append', sexp[1], sexp[2]];
+      return [Ops.UnoptimizedAppend, sexp[1], sexp[2]];
     }
   }
 
-  return ['optimized-append', sexp[1], sexp[2]];
+  return [Ops.OptimizedAppend, sexp[1], sexp[2]];
 });
 
-SPECIALIZE.add('dynamic-attr', (sexp: S.DynamicAttr, _symbolTable) => {
-  return ['any-dynamic-attr', sexp[1], sexp[2], sexp[3], false];
+SPECIALIZE.add(Ops.DynamicAttr, (sexp: S.DynamicAttr, _symbolTable) => {
+  return [Ops.AnyDynamicAttr, sexp[1], sexp[2], sexp[3], false];
 });
 
-SPECIALIZE.add('trusting-attr', (sexp: S.TrustingAttr, _symbolTable) => {
-  return ['any-dynamic-attr', sexp[1], sexp[2], sexp[3], true];
+SPECIALIZE.add(Ops.TrustingAttr, (sexp: S.TrustingAttr, _symbolTable) => {
+  return [Ops.AnyDynamicAttr, sexp[1], sexp[2], sexp[3], true];
 });
 
-SPECIALIZE.add('partial', (sexp: S.Partial, _table) => {
+SPECIALIZE.add(Ops.Partial, (sexp: S.Partial, _table) => {
   let expression = sexp[1];
 
   if (typeof expression === 'string') {
-    return ['static-partial', expression];
+    return [Ops.StaticPartial, expression];
   } else {
-    return ['dynamic-partial', expression];
+    return [Ops.DynamicPartial, expression];
   }
 });

--- a/packages/@glimmer/test-helpers/lib/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment.ts
@@ -93,6 +93,7 @@ import {
 
 import {
   TemplateMeta,
+  Ops
 } from "@glimmer/wire-format";
 
 type KeyFor<T> = (item: Opaque, index: T) => string;
@@ -1130,7 +1131,7 @@ function populateBlocks(blocks: BlockMacros, inlines: InlineMacros): { blocks: B
     }
 
     if (path.length > 1) {
-      let definitionArgs: BaselineSyntax.Args = [[['get', path]], hash, _default, inverse];
+      let definitionArgs: BaselineSyntax.Args = [[[Ops.Get, path]], hash, _default, inverse];
       let args: BaselineSyntax.Args = [params, hash, _default, inverse];
       builder.component.dynamic(definitionArgs, dynamicComponentFor, args, table);
       return true;
@@ -1159,7 +1160,7 @@ function populateBlocks(blocks: BlockMacros, inlines: InlineMacros): { blocks: B
     let definition = builder.env.getComponentDefinition(path, builder.symbolTable);
 
     if (path.length > 1) {
-      let definitionArgs: BaselineSyntax.Args = [[['get', path]], hash, null, null];
+      let definitionArgs: BaselineSyntax.Args = [[[Ops.Get, path]], hash, null, null];
       let args: BaselineSyntax.Args = [params, hash, null, null];
       builder.component.dynamic(definitionArgs, dynamicComponentFor, args, table);
       return true;

--- a/packages/@glimmer/wire-format/index.ts
+++ b/packages/@glimmer/wire-format/index.ts
@@ -1,4 +1,7 @@
 import { Dict, Option } from '@glimmer/util';
+import { Opcodes } from './lib/opcodes';
+
+export { Opcodes as Ops } from './lib/opcodes';
 
 type JsonValue =
     string
@@ -17,7 +20,7 @@ export type str = string;
 export type TemplateReference = Option<SerializedBlock>;
 export type YieldTo = str;
 
-export function is<T extends any[]>(variant: string): (value: any[]) => value is T {
+export function is<T extends any[]>(variant: number): (value: any[]) => value is T {
   return function(value: any[]): value is T {
     return value[0] === variant;
   };
@@ -37,14 +40,14 @@ export namespace Expressions {
   export type Params = Core.Params;
   export type Hash = Core.Hash;
 
-  export type Unknown        = ['unknown', Path];
-  export type Arg            = ['arg', Path];
-  export type Get            = ['get', Path];
+  export type Unknown        = [Opcodes.Unknown, Path];
+  export type Arg            = [Opcodes.Arg, Path];
+  export type Get            = [Opcodes.Get, Path];
   export type Value          = str | number | boolean | null; // tslint:disable-line
-  export type HasBlock       = ['has-block', str];
-  export type HasBlockParams = ['has-block-params', str];
-  export type Undefined      = ['undefined'];
-  export type ClientSide     = ['function', Function];
+  export type HasBlock       = [Opcodes.HasBlock, str];
+  export type HasBlockParams = [Opcodes.HasBlockParams, str];
+  export type Undefined      = [Opcodes.Undefined];
+  export type ClientSide     = [Opcodes.Function, Function];
 
   export type Expression =
       Unknown
@@ -60,25 +63,25 @@ export namespace Expressions {
     ;
 
   export interface Concat extends Array<any> {
-    [0]: 'concat';
+    [0]: Opcodes.Concat;
     [1]: Params;
   }
 
   export interface Helper extends Array<any> {
-    [0]: 'helper';
+    [0]: Opcodes.Helper;
     [1]: Path;
     [2]: Params;
     [3]: Hash;
   }
 
-  export const isUnknown        = is<Unknown>('unknown');
-  export const isArg            = is<Arg>('arg');
-  export const isGet            = is<Get>('get');
-  export const isConcat         = is<Concat>('concat');
-  export const isHelper         = is<Helper>('helper');
-  export const isHasBlock       = is<HasBlock>('has-block');
-  export const isHasBlockParams = is<HasBlockParams>('has-block-params');
-  export const isUndefined      = is<Undefined>('undefined');
+  export const isUnknown        = is<Unknown>(Opcodes.Unknown);
+  export const isArg            = is<Arg>(Opcodes.Arg);
+  export const isGet            = is<Get>(Opcodes.Get);
+  export const isConcat         = is<Concat>(Opcodes.Concat);
+  export const isHelper         = is<Helper>(Opcodes.Helper);
+  export const isHasBlock       = is<HasBlock>(Opcodes.HasBlock);
+  export const isHasBlockParams = is<HasBlockParams>(Opcodes.HasBlockParams);
+  export const isUndefined      = is<Undefined>(Opcodes.Undefined);
 
   export function isPrimitiveValue(value: any): value is Value {
     if (value === null) {
@@ -96,41 +99,41 @@ export namespace Statements {
   export type Hash = Core.Hash;
   export type Path = Core.Path;
 
-  export type Text          = ['text', str];
-  export type Append        = ['append', Expression, boolean];
-  export type Comment       = ['comment', str];
-  export type Modifier      = ['modifier', Path, Params, Hash];
-  export type Block         = ['block', Path, Params, Hash, Option<SerializedBlock>, Option<SerializedBlock>];
-  export type Component     = ['component', str, SerializedComponent];
-  export type OpenElement   = ['open-element', str, str[]];
-  export type FlushElement  = ['flush-element'];
-  export type CloseElement  = ['close-element'];
-  export type StaticAttr    = ['static-attr', str, Expression, Option<str>];
-  export type DynamicAttr   = ['dynamic-attr', str, Expression, Option<str>];
-  export type Yield         = ['yield', YieldTo, Params];
-  export type Partial       = ['partial', Expression];
-  export type DynamicArg    = ['dynamic-arg', str, Expression];
-  export type StaticArg     = ['static-arg', str, Expression];
-  export type TrustingAttr  = ['trusting-attr', str, Expression, str];
-  export type Debugger      = ['debugger'];
+  export type Text          = [Opcodes.Text, str];
+  export type Append        = [Opcodes.Append, Expression, boolean];
+  export type Comment       = [Opcodes.Comment, str];
+  export type Modifier      = [Opcodes.Modifier, Path, Params, Hash];
+  export type Block         = [Opcodes.Block, Path, Params, Hash, Option<SerializedBlock>, Option<SerializedBlock>];
+  export type Component     = [Opcodes.Component, str, SerializedComponent];
+  export type OpenElement   = [Opcodes.OpenElement, str, str[]];
+  export type FlushElement  = [Opcodes.FlushElement];
+  export type CloseElement  = [Opcodes.CloseElement];
+  export type StaticAttr    = [Opcodes.StaticAttr, str, Expression, Option<str>];
+  export type DynamicAttr   = [Opcodes.DynamicAttr, str, Expression, Option<str>];
+  export type Yield         = [Opcodes.Yield, YieldTo, Params];
+  export type Partial       = [Opcodes.Partial, Expression];
+  export type DynamicArg    = [Opcodes.DynamicArg, str, Expression];
+  export type StaticArg     = [Opcodes.StaticArg, str, Expression];
+  export type TrustingAttr  = [Opcodes.TrustingAttr, str, Expression, str];
+  export type Debugger      = [Opcodes.Debugger];
 
-  export const isText         = is<Text>('text');
-  export const isAppend       = is<Append>('append');
-  export const isComment      = is<Comment>('comment');
-  export const isModifier     = is<Modifier>('modifier');
-  export const isBlock        = is<Block>('block');
-  export const isComponent    = is<Component>('component');
-  export const isOpenElement  = is<OpenElement>('open-element');
-  export const isFlushElement = is<FlushElement>('flush-element');
-  export const isCloseElement = is<CloseElement>('close-element');
-  export const isStaticAttr   = is<StaticAttr>('static-attr');
-  export const isDynamicAttr  = is<DynamicAttr>('dynamic-attr');
-  export const isYield        = is<Yield>('yield');
-  export const isPartial      = is<Partial>('partial');
-  export const isDynamicArg   = is<DynamicArg>('dynamic-arg');
-  export const isStaticArg    = is<StaticArg>('static-arg');
-  export const isTrustingAttr = is<TrustingAttr>('trusting-attr');
-  export const isDebugger     = is<Debugger>('debugger');
+  export const isText         = is<Text>(Opcodes.Text);
+  export const isAppend       = is<Append>(Opcodes.Append);
+  export const isComment      = is<Comment>(Opcodes.Comment);
+  export const isModifier     = is<Modifier>(Opcodes.Modifier);
+  export const isBlock        = is<Block>(Opcodes.Block);
+  export const isComponent    = is<Component>(Opcodes.Component);
+  export const isOpenElement  = is<OpenElement>(Opcodes.OpenElement);
+  export const isFlushElement = is<FlushElement>(Opcodes.FlushElement);
+  export const isCloseElement = is<CloseElement>(Opcodes.CloseElement);
+  export const isStaticAttr   = is<StaticAttr>(Opcodes.StaticAttr);
+  export const isDynamicAttr  = is<DynamicAttr>(Opcodes.DynamicAttr);
+  export const isYield        = is<Yield>(Opcodes.Yield);
+  export const isPartial      = is<Partial>(Opcodes.Partial);
+  export const isDynamicArg   = is<DynamicArg>(Opcodes.DynamicArg);
+  export const isStaticArg    = is<StaticArg>(Opcodes.StaticArg);
+  export const isTrustingAttr = is<TrustingAttr>(Opcodes.TrustingAttr);
+  export const isDebugger     = is<Debugger>(Opcodes.Debugger);
 
   export type Statement =
       Text
@@ -158,7 +161,7 @@ export namespace Statements {
     ;
 
   export function isAttribute(val: Statement): val is Attribute {
-    return val[0] === 'static-attr' || val[0] === 'dynamic-attr';
+    return val[0] === Opcodes.StaticAttr || val[0] === Opcodes.DynamicAttr;
   }
 
   export type Argument =
@@ -167,7 +170,7 @@ export namespace Statements {
     ;
 
   export function isArgument(val: Statement): val is Argument {
-    return val[0] === 'static-arg' || val[0] === 'dynamic-arg';
+    return val[0] === Opcodes.StaticArg || val[0] === Opcodes.DynamicArg;
   }
 
   export type Parameter = Attribute | Argument;

--- a/packages/@glimmer/wire-format/lib/opcodes.ts
+++ b/packages/@glimmer/wire-format/lib/opcodes.ts
@@ -1,0 +1,42 @@
+export enum Opcodes {
+  // Statements
+  Text,
+  Append,
+  UnoptimizedAppend,
+  OptimizedAppend,
+  Comment,
+  Modifier,
+  Block,
+  ScannedBlock,
+  NestedBlock,
+  Component,
+  ScannedComponent,
+  OpenElement,
+  OpenPrimitiveElement,
+  FlushElement,
+  CloseElement,
+  StaticAttr,
+  DynamicAttr,
+  AnyDynamicAttr,
+  Yield,
+  Partial,
+  StaticPartial,
+  DynamicPartial,
+
+  DynamicArg,
+  StaticArg,
+  TrustingAttr,
+  Debugger,
+
+  // Expressions
+
+  Unknown,
+  Arg,
+  Get,
+  HasBlock,
+  HasBlockParams,
+  Undefined,
+  Function,
+  Helper,
+  Concat
+}


### PR DESCRIPTION
This introduces the idea of representing the wire-format opcodes as an integer instead of a string. Consider the following:

```handlebars
<div>Hello World</div>
```
__Today pre-compiles to:__

```
[
  ['open-element, 'div', []],
  ['flush-element'],
  ['text', 'Hello World'],
  ['close-element']
]
```
__After this PR__

```
[
  [11, 'div', []],
  [13],
  [0, 'Hello World'],
  [14]
]
```

In my experiments this will have a slight decrease in gzip size in a large application, however does has a decent size win post-unzipping and residing in memory. 

__Update__

The second commit introduces an enum for the most common html tags. This would produce the following:

```
[
  [11, 0, []],
  [13],
  [0, 'Hello World'],
  [14]
]
```