### PR TITLE
Disallow dotted helpers (again)

### DIFF
--- a/packages/@glimmer/runtime/lib/compiled/expressions/helper.ts
+++ b/packages/@glimmer/runtime/lib/compiled/expressions/helper.ts
@@ -4,12 +4,12 @@ import VM from '../../vm/append';
 import { Helper } from '../../environment';
 import { SymbolTable } from '@glimmer/interfaces';
 import { PathReference } from '@glimmer/reference';
-import { Opaque, Option } from '@glimmer/util';
+import { Opaque } from '@glimmer/util';
 
 export default class CompiledHelper extends CompiledExpression<Opaque> {
   public type = "helper";
 
-  constructor(public name: Option<string>[], public helper: Helper, public args: CompiledArgs, public symbolTable: SymbolTable) {
+  constructor(public name: string, public helper: Helper, public args: CompiledArgs, public symbolTable: SymbolTable) {
     super();
   }
 
@@ -19,6 +19,6 @@ export default class CompiledHelper extends CompiledExpression<Opaque> {
   }
 
   toJSON(): string {
-    return `\`${this.name.join('.')}($ARGS)\``;
+    return `\`${this.name}($ARGS)\``;
   }
 }

--- a/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
+++ b/packages/@glimmer/runtime/lib/compiled/opcodes/builder.ts
@@ -246,7 +246,7 @@ export abstract class BasicOpcodeBuilder implements SymbolLookup {
 
   modifier(_name: string, _args: Represents<CompiledArgs>) {
     let args = this.constants.expression(this.compile(_args));
-    let _modifierManager = this.env.lookupModifier([_name], this.symbolTable);
+    let _modifierManager = this.env.lookupModifier(_name, this.symbolTable);
     let modifierManager = this.constants.other(_modifierManager);
     let name = this.constants.string(_name);
     this.opcode(Op.Modifier, name, modifierManager, args);

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -333,14 +333,14 @@ export abstract class Environment {
     return macros;
   }
 
-  abstract hasHelper(helperName: Option<string>[], blockMeta: TemplateMeta): boolean;
-  abstract lookupHelper(helperName: Option<string>[], blockMeta: TemplateMeta): Helper;
+  abstract hasHelper(helperName: string, blockMeta: TemplateMeta): boolean;
+  abstract lookupHelper(helperName: string, blockMeta: TemplateMeta): Helper;
 
-  abstract hasModifier(modifierName: string[], blockMeta: TemplateMeta): boolean;
-  abstract lookupModifier(modifierName: string[], blockMeta: TemplateMeta): ModifierManager<Opaque>;
+  abstract hasModifier(modifierName: string, blockMeta: TemplateMeta): boolean;
+  abstract lookupModifier(modifierName: string, blockMeta: TemplateMeta): ModifierManager<Opaque>;
 
-  abstract hasComponentDefinition(tagName: string[], symbolTable: SymbolTable): boolean;
-  abstract getComponentDefinition(tagName: string[], symbolTable: SymbolTable): ComponentDefinition<Opaque>;
+  abstract hasComponentDefinition(tagName: string, symbolTable: SymbolTable): boolean;
+  abstract getComponentDefinition(tagName: string, symbolTable: SymbolTable): ComponentDefinition<Opaque>;
 
   abstract hasPartial(partialName: string, symbolTable: SymbolTable): boolean;
   abstract lookupPartial(PartialName: string, symbolTable: SymbolTable): PartialDefinition<TemplateMeta>;

--- a/packages/@glimmer/runtime/lib/scanner.ts
+++ b/packages/@glimmer/runtime/lib/scanner.ts
@@ -266,7 +266,7 @@ export class RawInlineBlock {
   private specializeComponent(sexp: WireFormat.Statements.Component): BaselineSyntax.AnyStatement[] {
     let [, tag, component] = sexp;
 
-    if (this.env.hasComponentDefinition([tag], this.table)) {
+    if (this.env.hasComponentDefinition(tag, this.table)) {
       let child = this.child(component);
       let attrs = new RawInlineBlock(this.env, this.table, component.attrs);
       return [[Ops.ScannedComponent, tag, attrs, component.args, child]];

--- a/packages/@glimmer/runtime/lib/syntax/functions.ts
+++ b/packages/@glimmer/runtime/lib/syntax/functions.ts
@@ -120,7 +120,7 @@ STATEMENTS.add(Ops.Modifier, (sexp: S.Modifier, builder: OpcodeBuilder) => {
 
   let args = compileArgs(params, hash, builder);
 
-  if (builder.env.hasModifier(path, builder.symbolTable)) {
+  if (builder.env.hasModifier(path[0], builder.symbolTable)) {
     builder.modifier(path[0], args);
   } else {
     throw new Error(`Compile Error ${path.join('.')} is not a modifier: Helpers may not be used in the element form.`);
@@ -201,7 +201,7 @@ STATEMENTS.add(Ops.ScannedComponent, (sexp: BaselineSyntax.ScannedComponent, bui
 
   let args = compileBlockArgs(null, rawArgs, { default: block, inverse: null }, builder);
 
-  let definition = builder.env.getComponentDefinition([tag], builder.symbolTable);
+  let definition = builder.env.getComponentDefinition(tag, builder.symbolTable);
 
   builder.putComponentDefinition(definition);
   builder.openComponent(args, attrs.scan());
@@ -274,9 +274,10 @@ export function expr(expression: BaselineSyntax.AnyExpression, builder: OpcodeBu
 
 EXPRESSIONS.add(Ops.Unknown, (sexp: E.Unknown, builder: OpcodeBuilder) => {
   let path = sexp[1];
+  let name = path[0];
 
-  if (builder.env.hasHelper(path, builder.symbolTable)) {
-    return new CompiledHelper(path, builder.env.lookupHelper(path, builder.symbolTable), CompiledArgs.empty(), builder.symbolTable);
+  if (builder.env.hasHelper(name, builder.symbolTable)) {
+    return new CompiledHelper(name, builder.env.lookupHelper(name, builder.symbolTable), CompiledArgs.empty(), builder.symbolTable);
   } else {
     return compileRef(path, builder);
   }
@@ -293,13 +294,13 @@ EXPRESSIONS.add(Ops.Function, (sexp: BaselineSyntax.FunctionExpression, builder:
 
 EXPRESSIONS.add(Ops.Helper, (sexp: E.Helper, builder: OpcodeBuilder) => {
   let { env, symbolTable } = builder;
-  let [, path, params, hash] = sexp;
+  let [, [name], params, hash] = sexp;
 
-  if (env.hasHelper(path, symbolTable)) {
+  if (env.hasHelper(name, symbolTable)) {
     let args = compileArgs(params, hash, builder);
-    return new CompiledHelper(path, env.lookupHelper(path, symbolTable), args, symbolTable);
+    return new CompiledHelper(name, env.lookupHelper(name, symbolTable), args, symbolTable);
   } else {
-    throw new Error(`Compile Error: ${path.join('.')} is not a helper`);
+    throw new Error(`Compile Error: ${name} is not a helper`);
   }
 });
 

--- a/packages/@glimmer/runtime/lib/syntax/specialize.ts
+++ b/packages/@glimmer/runtime/lib/syntax/specialize.ts
@@ -36,11 +36,12 @@ import E = WireFormat.Expressions;
 const { Ops } = WireFormat;
 
 SPECIALIZE.add(Ops.Append, (sexp: S.Append, _symbolTable) => {
-  let path = sexp[1];
+  let expression = sexp[1];
 
-  if (Array.isArray(path) && (E.isUnknown(path) || E.isGet(path))) {
-    if (path[1].length !== 1) {
+  if (Array.isArray(expression) && E.isGet(expression)) {
+    let path = expression[1];
 
+    if (path.length !== 1) {
       return [Ops.UnoptimizedAppend, sexp[1], sexp[2]];
     }
   }

--- a/packages/@glimmer/runtime/tests/compile-errors-test.ts
+++ b/packages/@glimmer/runtime/tests/compile-errors-test.ts
@@ -25,3 +25,21 @@ QUnit.test('explicit self ref with ./ is not allowed', assert => {
     env.compile('<div><p>{{./value}}</p></div>');
   }, new Error("Using \"./\" is not supported in Glimmer and unnecessary: \"./value\" on line 1."), "should throw error");
 });
+
+QUnit.test('helper invocation with dot-paths are not allowed', assert => {
+  assert.throws(() => {
+    env.compile('{{foo.bar some="args"}}');
+  }, new Error("`foo.bar` is not a valid name for a helper on line 1."), "should throw error");
+});
+
+QUnit.test('sub-expression helper invocation with dot-paths are not allowed', assert => {
+  assert.throws(() => {
+    env.compile('{{log (foo.bar some="args")}}');
+  }, new Error("`foo.bar` is not a valid name for a helper on line 1."), "should throw error");
+});
+
+QUnit.test('sub-expression modifier invocation with dot-paths are not allowed', assert => {
+  assert.throws(() => {
+    env.compile('<div {{foo.bar some="args"}} />');
+  }, new Error("`foo.bar` is not a valid name for a modifier on line 1."), "should throw error");
+});

--- a/packages/@glimmer/runtime/tests/ember-component-test.ts
+++ b/packages/@glimmer/runtime/tests/ember-component-test.ts
@@ -1697,78 +1697,6 @@ QUnit.test('{{component}} helper works with positional params', function() {
   assertEmberishElement('div', 'Quint4');
 });
 
-module('Emberish closure components');
-
-QUnit.test('can handle aliased block components', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
-  env.registerEmberishCurlyComponent('foo-bar', null, 'Hello {{arg1}} {{yield}}');
-  appendViewFor(
-    stripTight`
-      {{#with (hash comp=(component 'foo-bar')) as |my|}}
-        {{#my.comp arg1="World!"}}Test1{{/my.comp}} Test2
-      {{/with}}
-    `
-  );
-
-  assertText('Hello World! Test1 Test2');
-});
-
-QUnit.test('can handle aliased inline components', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
-  env.registerEmberishCurlyComponent('foo-bar', null, 'Hello {{arg1}}');
-  appendViewFor(
-    stripTight`
-      {{#with (hash comp=(component 'foo-bar')) as |my|}}
-        {{my.comp arg1="World!"}} Test
-      {{/with}}
-    `
-  );
-
-  assertText('Hello World! Test');
-});
-
-QUnit.test('can handle higher order inline components', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
-
-  env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
-  env.registerEmberishCurlyComponent('baz-bar', null, 'Hello {{arg1}}');
-
-  appendViewFor(
-    stripTight`
-      {{#foo-bar as |my|}}
-        {{my.comp arg1="World!"}} Test
-      {{/foo-bar}}
-    `
-  );
-
-  assertText('Hello World! Test');
-});
-
-QUnit.test('can handle higher order block components', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
-
-  env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
-  env.registerEmberishCurlyComponent('baz-bar', null, 'Hello {{arg1}} {{yield}}');
-
-  appendViewFor(
-    stripTight`
-      {{#foo-bar as |my|}}
-        {{#my.comp arg1="World!"}}Test1{{/my.comp}} Test2
-      {{/foo-bar}}
-    `
-  );
-
-  assertText('Hello World! Test1 Test2');
-});
-
 module("Emberish Components - parentView");
 
 QUnit.skip('components in template of a yielding component should have the proper parentView', function() {
@@ -1850,10 +1778,8 @@ QUnit.skip('newly-added sub-components get correct parentView', function() {
 module('Emberish closure components');
 
 QUnit.test('can handle aliased block components with args', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
   env.registerEmberishCurlyComponent('foo-bar', null, 'Hello {{arg1}} {{yield}}');
+
   appendViewFor(
     stripTight`
       {{#with (hash comp=(component 'foo-bar')) as |my|}}
@@ -1866,10 +1792,8 @@ QUnit.test('can handle aliased block components with args', assert => {
 });
 
 QUnit.test('can handle aliased block components without args', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
   env.registerEmberishCurlyComponent('foo-bar', null, 'Hello {{yield}}');
+
   appendViewFor(
     stripTight`
       {{#with (hash comp=(component 'foo-bar')) as |my|}}
@@ -1882,10 +1806,8 @@ QUnit.test('can handle aliased block components without args', assert => {
 });
 
 QUnit.test('can handle aliased inline components with args', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
   env.registerEmberishCurlyComponent('foo-bar', null, 'Hello {{arg1}}');
+
   appendViewFor(
     stripTight`
       {{#with (hash comp=(component 'foo-bar')) as |my|}}
@@ -1898,10 +1820,8 @@ QUnit.test('can handle aliased inline components with args', assert => {
 });
 
 QUnit.test('can handle aliased inline components without args', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
   env.registerEmberishCurlyComponent('foo-bar', null, 'Hello');
+
   appendViewFor(
     stripTight`
       {{#with (hash comp=(component 'foo-bar')) as |my|}}
@@ -1913,49 +1833,7 @@ QUnit.test('can handle aliased inline components without args', assert => {
   assertText('Hello World!');
 });
 
-QUnit.test('can handle higher order block components with args', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
-
-  env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
-  env.registerEmberishCurlyComponent('baz-bar', null, 'Hello {{arg1}} {{yield}}');
-
-  appendViewFor(
-    stripTight`
-      {{#foo-bar as |my|}}
-        {{#my.comp arg1="World!"}}Test1{{/my.comp}} Test2
-      {{/foo-bar}}
-    `
-  );
-
-  assertText('Hello World! Test1 Test2');
-});
-
-QUnit.test('can handle higher order block components without args', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
-
-  env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
-  env.registerEmberishCurlyComponent('baz-bar', null, 'Hello {{arg1}} {{yield}}');
-
-  appendViewFor(
-    stripTight`
-      {{#foo-bar as |my|}}
-        {{#my.comp}}World!{{/my.comp}} Test
-      {{/foo-bar}}
-    `
-  );
-
-  assertText('Hello World! Test');
-});
-
 QUnit.test('can handle higher order inline components with args', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
-
   env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
   env.registerEmberishCurlyComponent('baz-bar', null, 'Hello {{arg1}}');
 
@@ -1971,10 +1849,6 @@ QUnit.test('can handle higher order inline components with args', assert => {
 });
 
 QUnit.test('can handle higher order inline components without args', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
-
   env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
   env.registerEmberishCurlyComponent('baz-bar', null, 'Hello');
 
@@ -1989,30 +1863,7 @@ QUnit.test('can handle higher order inline components without args', assert => {
   assertText('Hello World!');
 });
 
-QUnit.test('can handle higher order inline components without args', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
-
-  env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
-  env.registerEmberishCurlyComponent('baz-bar', null, 'Hello');
-
-  appendViewFor(
-    stripTight`
-      {{#foo-bar as |my|}}
-        {{my.comp}} World!
-      {{/foo-bar}}
-    `
-  );
-
-  assertText('Hello World!');
-});
-
-QUnit.test('can handle higher order block components', assert => {
-  env.registerHelper('hash', function(params, hash) {
-    return hash;
-  });
-
+QUnit.test('can handle higher order block components with args', assert => {
   env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
   env.registerEmberishCurlyComponent('baz-bar', null, 'Hello {{arg1}} {{yield}}');
 
@@ -2025,6 +1876,21 @@ QUnit.test('can handle higher order block components', assert => {
   );
 
   assertText('Hello World! Test1 Test2');
+});
+
+QUnit.test('can handle higher order block components without args', assert => {
+  env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
+  env.registerEmberishCurlyComponent('baz-bar', null, 'Hello {{arg1}} {{yield}}');
+
+  appendViewFor(
+    stripTight`
+      {{#foo-bar as |my|}}
+        {{#my.comp}}World!{{/my.comp}} Test
+      {{/foo-bar}}
+    `
+  );
+
+  assertText('Hello World! Test');
 });
 
 module("Emberish Component - ids");

--- a/packages/@glimmer/runtime/tests/ember-component-test.ts
+++ b/packages/@glimmer/runtime/tests/ember-component-test.ts
@@ -1777,13 +1777,13 @@ QUnit.skip('newly-added sub-components get correct parentView', function() {
 
 module('Emberish closure components');
 
-QUnit.test('can handle aliased block components with args', assert => {
+QUnit.test('component helper can handle aliased block components with args', assert => {
   env.registerEmberishCurlyComponent('foo-bar', null, 'Hello {{arg1}} {{yield}}');
 
   appendViewFor(
     stripTight`
       {{#with (hash comp=(component 'foo-bar')) as |my|}}
-        {{#my.comp arg1="World!"}}Test1{{/my.comp}} Test2
+        {{#component my.comp arg1="World!"}}Test1{{/component}} Test2
       {{/with}}
     `
   );
@@ -1791,13 +1791,13 @@ QUnit.test('can handle aliased block components with args', assert => {
   assertText('Hello World! Test1 Test2');
 });
 
-QUnit.test('can handle aliased block components without args', assert => {
+QUnit.test('component helper can handle aliased block components without args', assert => {
   env.registerEmberishCurlyComponent('foo-bar', null, 'Hello {{yield}}');
 
   appendViewFor(
     stripTight`
       {{#with (hash comp=(component 'foo-bar')) as |my|}}
-        {{#my.comp}}World!{{/my.comp}} Test
+        {{#component my.comp}}World!{{/component}} Test
       {{/with}}
     `
   );
@@ -1805,13 +1805,13 @@ QUnit.test('can handle aliased block components without args', assert => {
   assertText('Hello World! Test');
 });
 
-QUnit.test('can handle aliased inline components with args', assert => {
+QUnit.test('component helper can handle aliased inline components with args', assert => {
   env.registerEmberishCurlyComponent('foo-bar', null, 'Hello {{arg1}}');
 
   appendViewFor(
     stripTight`
       {{#with (hash comp=(component 'foo-bar')) as |my|}}
-        {{my.comp arg1="World!"}} Test
+        {{component my.comp arg1="World!"}} Test
       {{/with}}
     `
   );
@@ -1819,7 +1819,81 @@ QUnit.test('can handle aliased inline components with args', assert => {
   assertText('Hello World! Test');
 });
 
-QUnit.test('can handle aliased inline components without args', assert => {
+QUnit.test('component helper can handle aliased inline components without args', assert => {
+  env.registerEmberishCurlyComponent('foo-bar', null, 'Hello');
+
+  appendViewFor(
+    stripTight`
+      {{#with (hash comp=(component 'foo-bar')) as |my|}}
+        {{component my.comp}} World!
+      {{/with}}
+    `
+  );
+
+  assertText('Hello World!');
+});
+
+QUnit.test('component helper can handle higher order inline components with args', assert => {
+  env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
+  env.registerEmberishCurlyComponent('baz-bar', null, 'Hello {{arg1}}');
+
+  appendViewFor(
+    stripTight`
+      {{#foo-bar as |my|}}
+        {{component my.comp arg1="World!"}} Test
+      {{/foo-bar}}
+    `
+  );
+
+  assertText('Hello World! Test');
+});
+
+QUnit.test('component helper can handle higher order inline components without args', assert => {
+  env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
+  env.registerEmberishCurlyComponent('baz-bar', null, 'Hello');
+
+  appendViewFor(
+    stripTight`
+      {{#foo-bar as |my|}}
+        {{component my.comp}} World!
+      {{/foo-bar}}
+    `
+  );
+
+  assertText('Hello World!');
+});
+
+QUnit.test('component helper can handle higher order block components with args', assert => {
+  env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
+  env.registerEmberishCurlyComponent('baz-bar', null, 'Hello {{arg1}} {{yield}}');
+
+  appendViewFor(
+    stripTight`
+      {{#foo-bar as |my|}}
+        {{#component my.comp arg1="World!"}}Test1{{/component}} Test2
+      {{/foo-bar}}
+    `
+  );
+
+  assertText('Hello World! Test1 Test2');
+});
+
+QUnit.test('component helper can handle higher order block components without args', assert => {
+  env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
+  env.registerEmberishCurlyComponent('baz-bar', null, 'Hello {{arg1}} {{yield}}');
+
+  appendViewFor(
+    stripTight`
+      {{#foo-bar as |my|}}
+        {{#component my.comp}}World!{{/component}} Test
+      {{/foo-bar}}
+    `
+  );
+
+  assertText('Hello World! Test');
+});
+
+QUnit.test('component deopt can handle aliased inline components without args', assert => {
   env.registerEmberishCurlyComponent('foo-bar', null, 'Hello');
 
   appendViewFor(
@@ -1833,22 +1907,7 @@ QUnit.test('can handle aliased inline components without args', assert => {
   assertText('Hello World!');
 });
 
-QUnit.test('can handle higher order inline components with args', assert => {
-  env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
-  env.registerEmberishCurlyComponent('baz-bar', null, 'Hello {{arg1}}');
-
-  appendViewFor(
-    stripTight`
-      {{#foo-bar as |my|}}
-        {{my.comp arg1="World!"}} Test
-      {{/foo-bar}}
-    `
-  );
-
-  assertText('Hello World! Test');
-});
-
-QUnit.test('can handle higher order inline components without args', assert => {
+QUnit.test('component deopt can handle higher order inline components without args', assert => {
   env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
   env.registerEmberishCurlyComponent('baz-bar', null, 'Hello');
 
@@ -1861,36 +1920,6 @@ QUnit.test('can handle higher order inline components without args', assert => {
   );
 
   assertText('Hello World!');
-});
-
-QUnit.test('can handle higher order block components with args', assert => {
-  env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
-  env.registerEmberishCurlyComponent('baz-bar', null, 'Hello {{arg1}} {{yield}}');
-
-  appendViewFor(
-    stripTight`
-      {{#foo-bar as |my|}}
-        {{#my.comp arg1="World!"}}Test1{{/my.comp}} Test2
-      {{/foo-bar}}
-    `
-  );
-
-  assertText('Hello World! Test1 Test2');
-});
-
-QUnit.test('can handle higher order block components without args', assert => {
-  env.registerEmberishCurlyComponent('foo-bar', null, '{{yield (hash comp=(component "baz-bar"))}}');
-  env.registerEmberishCurlyComponent('baz-bar', null, 'Hello {{arg1}} {{yield}}');
-
-  appendViewFor(
-    stripTight`
-      {{#foo-bar as |my|}}
-        {{#my.comp}}World!{{/my.comp}} Test
-      {{/foo-bar}}
-    `
-  );
-
-  assertText('Hello World! Test');
 });
 
 module("Emberish Component - ids");

--- a/packages/@glimmer/test-helpers/lib/environment.ts
+++ b/packages/@glimmer/test-helpers/lib/environment.ts
@@ -788,16 +788,14 @@ export class TestEnvironment extends Environment {
     return macros;
   }
 
-  hasHelper(helperName: string[]) {
-    return helperName.length === 1 && (<string>helperName[0] in this.helpers);
+  hasHelper(helperName: string) {
+    return helperName in this.helpers;
   }
 
-  lookupHelper(helperParts: string[]) {
-    let helperName = helperParts[0];
-
+  lookupHelper(helperName: string) {
     let helper = this.helpers[helperName];
 
-    if (!helper) throw new Error(`Helper for ${helperParts.join('.')} not found.`);
+    if (!helper) throw new Error(`Helper for ${helperName} not found.`);
 
     return helper;
   }
@@ -812,24 +810,23 @@ export class TestEnvironment extends Environment {
     return partial;
   }
 
-  hasComponentDefinition(name: string[]): boolean {
-    return !!this.components[name[0]];
+  hasComponentDefinition(name: string): boolean {
+    return !!this.components[name];
   }
 
-  getComponentDefinition(name: string[], blockMeta?: TemplateMeta): ComponentDefinition<any> {
-    return this.components[name[0]];
+  getComponentDefinition(name: string, blockMeta?: TemplateMeta): ComponentDefinition<any> {
+    return this.components[name];
   }
 
-  hasModifier(modifierName: string[]): boolean {
-    return modifierName.length === 1 && (<string>modifierName[0] in this.modifiers);
+  hasModifier(modifierName: string): boolean {
+    return modifierName in this.modifiers;
   }
 
-  lookupModifier(modifierName: string[]): ModifierManager<Opaque> {
-    let [name] = modifierName;
+  lookupModifier(modifierName: string): ModifierManager<Opaque> {
+    let modifier = this.modifiers[modifierName];
 
-    let modifier = this.modifiers[name];
+    if(!modifier) throw new Error(`Modifier for ${modifierName} not found.`);
 
-    if(!modifier) throw new Error(`Modifier for ${modifierName.join('.')} not found.`);
     return modifier;
   }
 
@@ -902,7 +899,7 @@ class DynamicComponentReference implements PathReference<ComponentDefinition<Opa
     let nameOrDef = nameRef.value();
 
     if (typeof nameOrDef === 'string') {
-      return env.getComponentDefinition([nameOrDef], this.symbolTable);
+      return env.getComponentDefinition(nameOrDef, this.symbolTable);
     } else if (isComponentDefinition(nameOrDef)) {
       return nameOrDef;
     }
@@ -1137,7 +1134,7 @@ function populateBlocks(blocks: BlockMacros, inlines: InlineMacros): { blocks: B
       return true;
     }
 
-    let definition = builder.env.getComponentDefinition(path, builder.symbolTable);
+    let definition = builder.env.getComponentDefinition(path[0], builder.symbolTable);
 
     if (definition) {
       builder.component.static(definition, [params, hash, _default, inverse], table);
@@ -1157,7 +1154,7 @@ function populateBlocks(blocks: BlockMacros, inlines: InlineMacros): { blocks: B
   inlines.addMissing((path, params, hash, builder) => {
     let table = builder.symbolTable;
 
-    let definition = builder.env.getComponentDefinition(path, builder.symbolTable);
+    let definition = builder.env.getComponentDefinition(path[0], builder.symbolTable);
 
     if (path.length > 1) {
       let definitionArgs: BaselineSyntax.Args = [[[Ops.Get, path]], hash, null, null];

--- a/packages/glimmer-demos/lib/visualizer.ts
+++ b/packages/glimmer-demos/lib/visualizer.ts
@@ -399,7 +399,7 @@ function renderContent() {
   let app = env.compile($template.value);
 
   function compileLayout(component) {
-    let definition = env.getComponentDefinition([component]);
+    let definition = env.getComponentDefinition(component);
 
     let manager = definition.manager;
     let instance = manager.create(env, definition, EvaluatedArgs.empty(), new TestDynamicScope(), null, false);


### PR DESCRIPTION
We don't actually use this "feature" in Ember and it is making a lot of the lookups more complicated than they need to be.

With this change, `{{foo.bar}}` is statically known to be a `get`, as opposed to an `unknown` before, saving us a `hasHelper` lookup at runtime.

The other caveat is that the Ember "closure component" syntax doesn't work anymore (besides the inline with no args form), but that could be statically transformed into using the component helper, as seen in the tests.

Closes emberjs/ember.js#13404.

Same as #386, but on master.