### PR TITLE
Fix failing TSLint issues

### DIFF
--- a/packages/@glimmer/compiler/lib/template-visitor.ts
+++ b/packages/@glimmer/compiler/lib/template-visitor.ts
@@ -5,8 +5,8 @@ class Frame {
   public children: Object = null;
   public childIndex: number = null;
   public childCount: number = null;
-  public childTemplateCount: number = 0;
-  public mustacheCount: number = 0;
+  public childTemplateCount = 0;
+  public mustacheCount = 0;
   public actions: any[] = [];
   public blankChildTextNodes: number[] = null;
   public symbols: SymbolTable = null;

--- a/packages/@glimmer/reference/lib/iterable.ts
+++ b/packages/@glimmer/reference/lib/iterable.ts
@@ -35,8 +35,8 @@ export type OpaquePathReferenceIterationItem = IterationItem<OpaquePathReference
 export class ListItem extends ListNode<OpaquePathReference> implements OpaqueIterationItem {
   public key: string;
   public memo: OpaquePathReference;
-  public retained: boolean = false;
-  public seen: boolean = false;
+  public retained = false;
+  public seen = false;
   private iterable: OpaqueIterable;
 
   constructor(iterable: OpaqueIterable, result: OpaqueIterationItem) {

--- a/packages/@glimmer/reference/lib/validators.ts
+++ b/packages/@glimmer/reference/lib/validators.ts
@@ -278,7 +278,7 @@ export class ReferenceCache<T> implements Tagged<Revision> {
   private reference: VersionedReference<T>;
   private lastValue: Option<T> = null;
   private lastRevision: Option<Revision> = null;
-  private initialized: boolean = false;
+  private initialized = false;
 
   constructor(reference: VersionedReference<T>) {
     this.tag = reference.tag;


### PR DESCRIPTION
🤷‍♂️ 

```
@glimmer/compiler/lib/template-visitor.ts[8, 30]: Type number trivially inferred from a number literal, remove type annotation
@glimmer/compiler/lib/template-visitor.ts[9, 25]: Type number trivially inferred from a number literal, remove type annotation


@glimmer/reference/lib/iterable.ts[38, 20]: Type boolean trivially inferred from a boolean literal, remove type annotation
@glimmer/reference/lib/iterable.ts[39, 16]: Type boolean trivially inferred from a boolean literal, remove type annotation


@glimmer/reference/lib/validators.ts[281, 24]: Type boolean trivially inferred from a boolean literal, remove type annotation
```