### PR TITLE
workaround default type issue

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -300,9 +300,9 @@ module.exports = function(_options) {
   ];
 
   if (hasBower) {
-    var loader = find(__dirname + '/node_modules', {
-      srcDir: '/loader.js/lib/loader',
-      files: [ 'loader.js' ],
+    var loaderPath = path.parse(require.resolve('loader.js'));
+    var loader = find(loaderPath.dir, {
+      files: [ loaderPath.base ],
       destDir: '/assets'
     });
 

--- a/packages/@glimmer/compiler/lib/template-visitor.ts
+++ b/packages/@glimmer/compiler/lib/template-visitor.ts
@@ -5,8 +5,8 @@ class Frame {
   public children: Object = null;
   public childIndex: number = null;
   public childCount: number = null;
-  public childTemplateCount: number = 0;
-  public mustacheCount: number = 0;
+  public childTemplateCount = 0;
+  public mustacheCount = 0;
   public actions: any[] = [];
   public blankChildTextNodes: number[] = null;
   public symbols: SymbolTable = null;

--- a/packages/@glimmer/reference/lib/iterable.ts
+++ b/packages/@glimmer/reference/lib/iterable.ts
@@ -35,8 +35,8 @@ export type OpaquePathReferenceIterationItem = IterationItem<OpaquePathReference
 export class ListItem extends ListNode<OpaquePathReference> implements OpaqueIterationItem {
   public key: string;
   public memo: OpaquePathReference;
-  public retained: boolean = false;
-  public seen: boolean = false;
+  public retained = false;
+  public seen = false;
   private iterable: OpaqueIterable;
 
   constructor(iterable: OpaqueIterable, result: OpaqueIterationItem) {

--- a/packages/@glimmer/reference/lib/validators.ts
+++ b/packages/@glimmer/reference/lib/validators.ts
@@ -278,7 +278,7 @@ export class ReferenceCache<T> implements Tagged<Revision> {
   private reference: VersionedReference<T>;
   private lastValue: Option<T> = null;
   private lastRevision: Option<Revision> = null;
-  private initialized: boolean = false;
+  private initialized = false;
 
   constructor(reference: VersionedReference<T>) {
     this.tag = reference.tag;

--- a/packages/@glimmer/runtime/lib/vm/frame.ts
+++ b/packages/@glimmer/runtime/lib/vm/frame.ts
@@ -27,7 +27,7 @@ class Frame {
   constructor(
     public start: number,
     public end: number,
-    public component: Component = null,
+    public component = <Component>null,
     public manager: Option<ComponentManager<Component>> = null,
     public shadow: Option<InlineBlock> = null
   ) {
@@ -58,7 +58,7 @@ export class FrameStack {
     return this.frames[this.frame];
   }
 
-  push(start: number, end: number, component: Component = null, manager: Option<ComponentManager<Component>> = null, shadow: Option<InlineBlock> = null) {
+  push(start: number, end: number, component = <Component>null, manager: Option<ComponentManager<Component>> = null, shadow: Option<InlineBlock> = null) {
     let pos = ++this.frame;
     if (pos < this.frames.length) {
       let frame = this.frames[pos];


### PR DESCRIPTION
Specifying a default value seems to be causing issues with explicit parameter type when it is a union type.   This workaround uses the implicit type of the default by moving the type to a cast of the default value.