### PR TITLE
Add @glimmer/util as a dependency of @glimmer/syntax

### DIFF
--- a/packages/@glimmer/syntax/package.json
+++ b/packages/@glimmer/syntax/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "handlebars": "^4.0.6",
     "@glimmer/interfaces": "^0.22.0",
+    "@glimmer/util": "^0.22.0",
     "simple-html-tokenizer": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
@glimmer/syntax depends on @glimmer/util but it is not in the package.json dependencies. I ran into an error because of this trying to build hello-glimmer with https://github.com/tildeio/glimmer/pull/424.

cc @tomdale 