### PR TITLE
Avoid default initializer in hot paths.

### DIFF
--- a/packages/@glimmer/runtime/lib/builder.ts
+++ b/packages/@glimmer/runtime/lib/builder.ts
@@ -114,16 +114,16 @@ export class ElementStack implements Cursor {
     this.nextSiblingStack.push(this.nextSibling);
   }
 
-  expectConstructing(method: string): Simple.Element {
-    return this.constructing;
+  expectConstructing(_: string): Simple.Element {
+    return this.constructing!;
   }
 
-  expectOperations(method: string): ElementOperations {
-    return this.operations;
+  expectOperations(_: string): ElementOperations {
+    return this.operations!;
   }
 
   block(): Tracker {
-    return this.blockStack.current;
+    return this.blockStack.current!;
   }
 
   popElement() {
@@ -133,7 +133,7 @@ export class ElementStack implements Cursor {
     nextSiblingStack.pop();
     // LOGGER.debug(`-> element stack ${this.elementStack.toArray().map(e => e.tagName).join(', ')}`);
 
-    this.element = elementStack.current;
+    this.element = elementStack.current!;
     this.nextSibling = nextSiblingStack.current;
 
     return topElement;
@@ -182,10 +182,12 @@ export class ElementStack implements Cursor {
   popBlock(): Tracker {
     this.block().finalize(this);
 
-    return this.blockStack.pop();
+    return this.blockStack.pop()!;
   }
 
-  openElement(tag: string, operations = this.defaultOperations): Simple.Element {
+  openElement(tag: string, _operations?: ElementOperations): Simple.Element {
+    // workaround argument.length transpile of arg initializer
+    let operations = _operations === undefined ? this.defaultOperations : _operations;
     let element = this.dom.createElement(tag, this.element);
 
     this.constructing = element;
@@ -196,14 +198,14 @@ export class ElementStack implements Cursor {
 
   flushElement() {
     let parent  = this.element;
-    let element = this.constructing;
+    let element = this.constructing!;
 
     this.dom.insertBefore(parent, element, this.nextSibling);
 
     this.constructing = null;
     this.operations = null;
 
-    this.pushElement(element);
+    this.pushElement(element, null);
     this.block().openElement(element);
   }
 
@@ -219,7 +221,7 @@ export class ElementStack implements Cursor {
     this.popElement();
   }
 
-  private pushElement(element: Simple.Element, nextSibling: Option<Simple.Node> = null) {
+  private pushElement(element: Simple.Element, nextSibling: Option<Simple.Node>) {
     this.element = element;
     this.elementStack.push(element);
     // LOGGER.debug(`-> element stack ${this.elementStack.toArray().map(e => e.tagName).join(', ')}`);

--- a/packages/@glimmer/runtime/lib/environment.ts
+++ b/packages/@glimmer/runtime/lib/environment.ts
@@ -61,7 +61,7 @@ export class Scope {
       refs[i] = UNDEFINED_REFERENCE;
     }
 
-    return new Scope(refs).init({ self });
+    return new Scope(refs, null, null, null).init({ self });
   }
 
   static sized(size = 0) {
@@ -71,17 +71,17 @@ export class Scope {
       refs[i] = UNDEFINED_REFERENCE;
     }
 
-    return new Scope(refs);
+    return new Scope(refs, null, null, null);
   }
 
   constructor(
     // the 0th slot is `self`
     private slots: ScopeSlot[],
-    private callerScope: Option<Scope> = null,
+    private callerScope: Option<Scope>,
     // named arguments and blocks passed to a layout that uses eval
-    private evalScope: Option<Dict<ScopeSlot>> = null,
+    private evalScope: Option<Dict<ScopeSlot>>,
     // locals in scope when the partial was invoked
-    private partialMap: Option<Dict<VersionedPathReference<Opaque>>> = null) {
+    private partialMap: Option<Dict<VersionedPathReference<Opaque>>>) {
   }
 
   init({ self }: { self: VersionedPathReference<Opaque> }): this {
@@ -332,7 +332,7 @@ export abstract class Environment {
   }
 
   private get transaction(): Transaction {
-    return this._transaction;
+    return this._transaction!;
   }
 
   didCreate<T>(component: T, manager: ComponentManager<T>) {

--- a/packages/@glimmer/runtime/lib/vm/append.ts
+++ b/packages/@glimmer/runtime/lib/vm/append.ts
@@ -255,7 +255,7 @@ export default class VM implements PublicVM {
     this.didEnter(tryOpcode);
   }
 
-  iterate(memo: VersionedPathReference<Opaque>, value: VersionedPathReference<Opaque>, updating = new LinkedList<UpdatingOpcode>()): TryOpcode {
+  iterate(memo: VersionedPathReference<Opaque>, value: VersionedPathReference<Opaque>): TryOpcode {
     let stack = this.stack;
     stack.push(value);
     stack.push(memo);
@@ -267,7 +267,7 @@ export default class VM implements PublicVM {
     // this.ip = end + 4;
     // this.frames.push(ip);
 
-    return new TryOpcode(this.pc, state, tracker, updating);
+    return new TryOpcode(this.pc, state, tracker, new LinkedList<UpdatingOpcode>());
   }
 
   enterItem(key: string, opcode: TryOpcode) {


### PR DESCRIPTION
The arguments.length check that TypeScript emits for default initializers causes "bad arguments for context" issues in V8.